### PR TITLE
Fix parse_line buffer clamp

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,9 @@ static int parse_line(char *line, char **args, int *background) {
             while (*p && *p != ' ' && *p != '\t') p++;
         }
         int len = p - start;
+        /* clamp length to avoid overflowing the temporary buffer */
+        if (len >= MAX_LINE)
+            len = MAX_LINE - 1;
         char buf[MAX_LINE];
         strncpy(buf, start, len);
         buf[len] = '\0';


### PR DESCRIPTION
## Summary
- handle overly long tokens in `parse_line`
- avoid potential overflow when copying tokens

## Testing
- `cc -o vush src/main.c`

------
https://chatgpt.com/codex/tasks/task_e_683f9b4d156c8324be1125450f88794f