### PR TITLE
Implement tilde expansion

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,19 @@ static void print_jobs(void) {
 }
 
 static char *expand_var(const char *token) {
+    if (token[0] == '~') {
+        const char *home = getenv("HOME");
+        if (!home) home = "";
+        size_t home_len = strlen(home);
+        size_t token_len = strlen(token);
+        char *tmp = malloc(home_len + token_len);
+        if (!tmp) return NULL;
+        strcpy(tmp, home);
+        strcat(tmp, token + 1);
+        char *ret = strdup(tmp);
+        free(tmp);
+        return ret;
+    }
     if (token[0] != '$') return strdup(token);
     const char *val = getenv(token + 1);
     return strdup(val ? val : "");


### PR DESCRIPTION
## Summary
- expand '~' using `$HOME` environment variable in `expand_var`

## Testing
- `cc -o vush src/main.c`
- `printf 'echo ~\nexit\n' | ./vush`
- `printf 'echo $PATH\nexit\n' | ./vush | head -n 2`


------
https://chatgpt.com/codex/tasks/task_e_683f9bf701f08324a54d6d517f09e4a6