### PR TITLE
Improve quoting and escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,13 @@ vush> cd /tmp
 vush> echo $HOME
 vush> sleep 5 &
 ```
+
+Single quotes prevent expansion and take text verbatim. A backslash escapes the next character:
+
+```
+vush> echo '$HOME is not expanded'
+$HOME is not expanded
+vush> echo \$HOME
+$HOME
 ```
 


### PR DESCRIPTION
## Summary
- handle single quotes and backslashes in `parse_line`
- prevent expansion when characters are escaped
- document single quotes and escaping in README
- define `_GNU_SOURCE` so `strdup` prototype is visible

## Testing
- `make clean`
- `make`
- `./vush <<'EOF'
echo hi
EOF`
- `./vush <<'EOF'
echo '$HOME'
echo \$HOME
echo a\ b
EOF`
- `./vush <<'EOF'
echo 'foo bar'
echo "foo\"bar"
EOF`
- `./vush <<'EOF'
echo "$HOME"
EOF`
- `./vush <<'EOF'
echo \~
EOF`


------
https://chatgpt.com/codex/tasks/task_e_683fa475fe00832485bff395ec2bcdb7