### PR TITLE
Add help builtin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `exit`, `pwd`, and `jobs`
+- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - Background job management using `&`
 
@@ -60,6 +60,7 @@ $HOME
 - `exit` - terminate the shell.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
+- `help` - display information about built-in commands.
 
 ## Background Jobs Example
 

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -21,5 +21,8 @@ Print the current working directory.
 .TP
 .B jobs
 List running background jobs.
+.TP
+.B help
+Display information about built-in commands.
 .SH SEE ALSO
 README.md

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -35,6 +35,17 @@ static int builtin_jobs(char **args) {
     return 1;
 }
 
+static int builtin_help(char **args) {
+    (void)args;
+    printf("Built-in commands:\n");
+    printf("  cd [dir]   Change the current directory\n");
+    printf("  exit       Exit the shell\n");
+    printf("  pwd        Print the current working directory\n");
+    printf("  jobs       List running background jobs\n");
+    printf("  help       Display this help message\n");
+    return 1;
+}
+
 struct builtin {
     const char *name;
     int (*func)(char **);
@@ -45,6 +56,7 @@ static struct builtin builtins[] = {
     {"exit", builtin_exit},
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
+    {"help", builtin_help},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
## Summary
- support `help` builtin command
- show help for builtins
- document `help` in README and manual

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_683fab027c148324891080345a7bd3b7