### PR TITLE
Add basic expect tests and test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,7 @@ vush: $(SRCS)
 
 clean:
 	rm -f vush *.o
+
+
+test: vush
+	cd tests && ./run_tests.sh

--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ vush> # continue using the shell
 
 See [docs/vush.1](docs/vush.1) for the manual page and
 [docs/CHANGELOG.md](docs/CHANGELOG.md) for the change history.
+
+## Tests
+
+Ensure `expect` is installed and run:
+
+```sh
+make test
+```
+
+The test scripts under `tests/` will launch `./vush` with predefined commands and verify the output.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+failed=0
+for test in *.expect; do
+    echo "Running $test"
+    if ! ./$test; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/test_env.expect
+++ b/tests/test_env.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "echo $HOME\r"
+expect {
+    -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
+    timeout { send_user "HOME output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof

--- a/tests/test_pwd.expect
+++ b/tests/test_pwd.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "pwd\r"
+expect {
+    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    timeout { send_user "pwd output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add automated integration tests for `vush`
- add `test` target to `Makefile`
- document test usage in `README`

## Testing
- `make clean`
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab934184832496e660746a66a8e3