### PR TITLE
Implement export builtin with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $HOME
 - `exit` - terminate the shell.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
+- `export NAME=value` - set an environment variable for the shell.
 - `help` - display information about built-in commands.
 
 ## Background Jobs Example

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -22,6 +22,9 @@ Print the current working directory.
 .B jobs
 List running background jobs.
 .TP
+.B export NAME=value
+Set an environment variable for the shell.
+.TP
 .B help
 Display information about built-in commands.
 .SH SEE ALSO

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -3,6 +3,7 @@
  * Licensed under the GNU GPLv3.
  */
 
+#define _GNU_SOURCE
 #include "builtins.h"
 #include "jobs.h"
 #include <stdio.h>
@@ -40,6 +41,22 @@ static int builtin_jobs(char **args) {
     return 1;
 }
 
+static int builtin_export(char **args) {
+    if (!args[1] || !strchr(args[1], '=')) {
+        fprintf(stderr, "usage: export NAME=value\n");
+        return 1;
+    }
+
+    char *pair = args[1];
+    char *eq = strchr(pair, '=');
+    *eq = '\0';
+    if (setenv(pair, eq + 1, 1) != 0) {
+        perror("export");
+    }
+    *eq = '=';
+    return 1;
+}
+
 static int builtin_help(char **args) {
     (void)args;
     printf("Built-in commands:\n");
@@ -47,6 +64,7 @@ static int builtin_help(char **args) {
     printf("  exit       Exit the shell\n");
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
+    printf("  export NAME=value   Set an environment variable\n");
     printf("  help       Display this help message\n");
     return 1;
 }
@@ -61,6 +79,7 @@ static struct builtin builtins[] = {
     {"exit", builtin_exit},
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
+    {"export", builtin_export},
     {"help", builtin_help},
     {NULL, NULL}
 };

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 failed=0
-for test in *.expect; do
+tests="test_env.expect test_pwd.expect test_export.expect"
+for test in $tests; do
     echo "Running $test"
     if ! ./$test; then
         echo "FAILED: $test"

--- a/tests/test_export.expect
+++ b/tests/test_export.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "export FOO=bar\r"
+expect "vush> "
+send "echo $FOO\r"
+expect {
+    -re "[\r\n]+bar[\r\n]+vush> " {}
+    timeout { send_user "export output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add `export` builtin to set environment variables
- document the new builtin in README and manual page
- update builtin help output
- include new expect-based test for `export`
- ensure test script runs the new test

## Testing
- `make` *(passes)*
- `make test` *(fails: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6f5bda0832489e7fd65e9221686