### PR TITLE
Handle comments starting with #

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Words beginning with `$` expand to environment variables. A leading `~` is
 replaced with the value of `$HOME`.
 
 Single quotes disable all expansion. Double quotes preserve spaces while still
-expanding variables. Use a backslash to escape the next character.
+expanding variables. Use a backslash to escape the next character. A `#` that
+appears outside of quotes starts a comment and everything after it on the line
+is ignored.
 
 ```
 vush> echo '$HOME is not expanded'

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -8,7 +8,8 @@ vush \- simple UNIX shell
 vush is a lightweight UNIX shell supporting command execution,
 environment variable expansion and background jobs.  When a
 \fIscriptfile\fP is supplied, commands are read from that file
-instead of standard input.
+instead of standard input.  A `#` outside of quotes begins a comment
+and causes the rest of the line to be ignored.
 .SH OPTIONS
 None.
 .SH BUILTINS

--- a/src/parser.c
+++ b/src/parser.c
@@ -34,7 +34,7 @@ int parse_line(char *line, char **args, int *background) {
     char *p = line;
     while (*p && argc < MAX_TOKENS - 1) {
         while (*p == ' ' || *p == '\t') p++;
-        if (*p == '\0') break;
+        if (*p == '\0' || *p == '#') break; /* comment */
 
         char buf[MAX_LINE];
         int len = 0;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_comments.expect
+++ b/tests/test_comments.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "# foo\r"
+expect "vush> "
+send "echo bar # comment\r"
+expect {
+    -re "[\r\n]+bar[\r\n]+vush> " {}
+    timeout { send_user "comment parsing failed\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- treat `#` as the start of a comment in `parse_line`
- document comment handling in README and `vush.1`
- add expect test for comments
- run the new test from `run_tests.sh`

## Testing
- `make test` *(fails: ./run_tests.sh: 7: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb8d6818c8324a2b517b85c02152f