### PR TITLE
Add basic command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ $HOME
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
 - `export NAME=value` - set an environment variable for the shell.
+- `history` - show previously entered commands.
 - `help` - display information about built-in commands.
 
 ## Background Jobs Example

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -29,6 +29,9 @@ List running background jobs.
 .B export NAME=value
 Set an environment variable for the shell.
 .TP
+.B history
+Show command history.
+.TP
 .B help
 Display information about built-in commands.
 .SH SEE ALSO

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -6,6 +6,7 @@
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "jobs.h"
+#include "history.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,6 +42,12 @@ static int builtin_jobs(char **args) {
     return 1;
 }
 
+static int builtin_history(char **args) {
+    (void)args;
+    print_history();
+    return 1;
+}
+
 static int builtin_export(char **args) {
     if (!args[1] || !strchr(args[1], '=')) {
         fprintf(stderr, "usage: export NAME=value\n");
@@ -65,6 +72,7 @@ static int builtin_help(char **args) {
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
     printf("  export NAME=value   Set an environment variable\n");
+    printf("  history    Show command history\n");
     printf("  help       Display this help message\n");
     return 1;
 }
@@ -80,6 +88,7 @@ static struct builtin builtins[] = {
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
     {"export", builtin_export},
+    {"history", builtin_history},
     {"help", builtin_help},
     {NULL, NULL}
 };

--- a/src/history.c
+++ b/src/history.c
@@ -1,0 +1,37 @@
+#include "history.h"
+#include "parser.h" /* for MAX_LINE */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct HistEntry {
+    int id;
+    char cmd[MAX_LINE];
+    struct HistEntry *next;
+} HistEntry;
+
+static HistEntry *head = NULL;
+static HistEntry *tail = NULL;
+static int next_id = 1;
+
+void add_history(const char *cmd) {
+    HistEntry *e = malloc(sizeof(HistEntry));
+    if (!e) return;
+    e->id = next_id++;
+    strncpy(e->cmd, cmd, MAX_LINE - 1);
+    e->cmd[MAX_LINE - 1] = '\0';
+    e->next = NULL;
+    if (!head) {
+        head = tail = e;
+    } else {
+        tail->next = e;
+        tail = e;
+    }
+}
+
+void print_history(void) {
+    for (HistEntry *e = head; e; e = e->next) {
+        printf("%d %s\n", e->id, e->cmd);
+    }
+}
+

--- a/src/history.h
+++ b/src/history.h
@@ -1,0 +1,7 @@
+#ifndef HISTORY_H
+#define HISTORY_H
+
+void add_history(const char *cmd);
+void print_history(void);
+
+#endif /* HISTORY_H */

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "parser.h"
 #include "jobs.h"
 #include "builtins.h"
+#include "history.h"
 
 int main(int argc, char **argv) {
     char line[MAX_LINE];
@@ -45,6 +46,7 @@ int main(int argc, char **argv) {
         int background = 0;
         int ac = parse_line(line, args, &background);
         if (ac == 0) continue;
+        add_history(line);
         if (run_builtin(args)) {
             for (int i = 0; i < ac; i++) free(args[i]);
             continue;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_history.expect
+++ b/tests/test_history.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "echo first\r"
+expect {
+    -re "[\r\n]+first[\r\n]+vush> " {}
+    timeout { send_user "echo output mismatch\n"; exit 1 }
+}
+send "echo second\r"
+expect {
+    -re "[\r\n]+second[\r\n]+vush> " {}
+    timeout { send_user "second output mismatch\n"; exit 1 }
+}
+send "history\r"
+expect {
+    -re "1 echo first[\r\n]+2 echo second[\r\n]+3 history[\r\n]+vush> " {}
+    timeout { send_user "history output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add a simple linked-list history implementation
- record each command in history from main loop
- provide new `history` builtin and register it
- document the command in README and manpage
- add expect test for `history` and run from test suite

## Testing
- `make`
- `make test` *(fails: `expect` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fba6e35d08324bda950a24ff1ea8f