### PR TITLE
Add cd and jobs expect tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Ensure `expect` is installed and run:
 make test
 ```
 
-The test scripts under `tests/` will launch `./vush` with predefined commands and verify the output.
+The test scripts under `tests/` will launch `./vush` with predefined commands and verify the output.  
+Current tests cover environment variables, `pwd`, `export`, running scripts, comment handling, and now the `cd` and `jobs` built-ins.
 
 ## License
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_cd.expect test_jobs.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_cd.expect
+++ b/tests/test_cd.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "cd /\r"
+expect "vush> "
+send "pwd\r"
+expect {
+    -re "[\r\n]+/[\r\n]+vush> " {}
+    timeout { send_user "cd output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof

--- a/tests/test_jobs.expect
+++ b/tests/test_jobs.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "sleep 1 &\r"
+expect "vush> "
+send "jobs\r"
+expect {
+    -re "\[1\] [0-9]+ sleep 1 &\r?\nvush> " {}
+    timeout { send_user "jobs output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add expect test for `cd`
- add expect test for `jobs`
- run new tests from `run_tests.sh`
- mention new coverage in README

## Testing
- `make test` *(fails: `./test_env.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fba2f8cd083248b87e0a1b52b27a6