### PR TITLE
Implement simple pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and a few built-in commands.
 - Built-in commands: `cd`, `exit`, `pwd`, `jobs`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - Background job management using `&`
+- Simple pipelines using `|` to connect commands
 
 ## Building
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,6 @@
 
 int main(int argc, char **argv) {
     char line[MAX_LINE];
-    char *args[MAX_TOKENS];
 
     FILE *input = stdin;
     if (argc > 1) {
@@ -44,31 +43,68 @@ int main(int argc, char **argv) {
         size_t len = strlen(line);
         if (len && line[len-1] == '\n') line[len-1] = '\0';
         int background = 0;
-        int ac = parse_line(line, args, &background);
-        if (ac == 0) continue;
-        add_history(line);
-        if (run_builtin(args)) {
-            for (int i = 0; i < ac; i++) free(args[i]);
+        PipelineSegment *pipeline = parse_line(line, &background);
+        if (!pipeline || !pipeline->argv[0]) {
+            free_pipeline(pipeline);
             continue;
         }
-        pid_t pid = fork();
-        if (pid == 0) {
-            /* Restore default SIGINT handling for the child */
-            signal(SIGINT, SIG_DFL);
-            execvp(args[0], args);
-            perror("exec");
-            exit(1);
-        } else if (pid > 0) {
-            if (background) {
-                add_job(pid, line);
-            } else {
-                int status;
-                waitpid(pid, &status, 0);
-            }
-        } else {
-            perror("fork");
+        add_history(line);
+
+        if (!pipeline->next && run_builtin(pipeline->argv)) {
+            free_pipeline(pipeline);
+            continue;
         }
-        for (int i = 0; i < ac; i++) free(args[i]);
+
+        int seg_count = 0;
+        for (PipelineSegment *tmp = pipeline; tmp; tmp = tmp->next) seg_count++;
+        pid_t *pids = calloc(seg_count, sizeof(pid_t));
+        int i = 0;
+        int in_fd = -1;
+        PipelineSegment *seg = pipeline;
+        int pipefd[2];
+        while (seg) {
+            if (seg->next && pipe(pipefd) < 0) {
+                perror("pipe");
+                break;
+            }
+            pid_t pid = fork();
+            if (pid == 0) {
+                signal(SIGINT, SIG_DFL);
+                if (in_fd != -1) {
+                    dup2(in_fd, STDIN_FILENO);
+                    close(in_fd);
+                }
+                if (seg->next) {
+                    close(pipefd[0]);
+                    dup2(pipefd[1], STDOUT_FILENO);
+                    close(pipefd[1]);
+                }
+                execvp(seg->argv[0], seg->argv);
+                perror("exec");
+                exit(1);
+            } else if (pid < 0) {
+                perror("fork");
+            } else {
+                pids[i++] = pid;
+                if (in_fd != -1) close(in_fd);
+                if (seg->next) {
+                    close(pipefd[1]);
+                    in_fd = pipefd[0];
+                }
+            }
+            seg = seg->next;
+        }
+        if (in_fd != -1) close(in_fd);
+
+        if (background) {
+            if (i > 0) add_job(pids[i-1], line);
+        } else {
+            int status;
+            for (int j = 0; j < i; j++)
+                waitpid(pids[j], &status, 0);
+        }
+        free(pids);
+        free_pipeline(pipeline);
     }
     if (input != stdin)
         fclose(input);

--- a/src/parser.h
+++ b/src/parser.h
@@ -11,7 +11,13 @@
 #define MAX_TOKENS 64
 #define MAX_LINE 1024
 
+typedef struct PipelineSegment {
+    char *argv[MAX_TOKENS];
+    struct PipelineSegment *next;
+} PipelineSegment;
+
 char *expand_var(const char *token);
-int parse_line(char *line, char **args, int *background);
+PipelineSegment *parse_line(char *line, int *background);
+void free_pipeline(PipelineSegment *p);
 
 #endif /* PARSER_H */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_pipe.expect
+++ b/tests/test_pipe.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "echo foo | grep foo\r"
+expect {
+    -re "[\r\n]+foo[\r\n]+vush> " {}
+    timeout { send_user "pipeline output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- support pipelines in parsing and execution
- document pipeline support
- test echo/grep pipeline

## Testing
- `make`
- `make test` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fbcf4ed748324a9338bbe2147c22f