### PR TITLE
Add persistent history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and a few built-in commands.
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
 - Input and output redirection with `<`, `>` and `>>`
+- Persistent command history saved to `~/.vush_history`
 
 ## Building
 
@@ -74,6 +75,7 @@ $HOME
 - `jobs` - list background jobs started with `&`.
 - `export NAME=value` - set an environment variable for the shell.
 - `history` - show previously entered commands.
+  Entries are read from and written to `~/.vush_history`.
 - `help` - display information about built-in commands.
 
 ## Redirection Examples

--- a/src/history.c
+++ b/src/history.c
@@ -3,6 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 typedef struct HistEntry {
     int id;
@@ -14,7 +19,7 @@ static HistEntry *head = NULL;
 static HistEntry *tail = NULL;
 static int next_id = 1;
 
-void add_history(const char *cmd) {
+static void add_history_entry(const char *cmd, int save_file) {
     HistEntry *e = malloc(sizeof(HistEntry));
     if (!e) return;
     e->id = next_id++;
@@ -27,11 +32,47 @@ void add_history(const char *cmd) {
         tail->next = e;
         tail = e;
     }
+
+    if (save_file) {
+        const char *home = getenv("HOME");
+        if (home) {
+            char path[PATH_MAX];
+            snprintf(path, sizeof(path), "%s/.vush_history", home);
+            FILE *f = fopen(path, "a");
+            if (f) {
+                fprintf(f, "%s\n", cmd);
+                fclose(f);
+            }
+        }
+    }
+}
+
+void add_history(const char *cmd) {
+    add_history_entry(cmd, 1);
 }
 
 void print_history(void) {
     for (HistEntry *e = head; e; e = e->next) {
         printf("%d %s\n", e->id, e->cmd);
     }
+}
+
+void load_history(void) {
+    const char *home = getenv("HOME");
+    if (!home)
+        return;
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "%s/.vush_history", home);
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return;
+    char line[MAX_LINE];
+    while (fgets(line, sizeof(line), f)) {
+        size_t len = strlen(line);
+        if (len && line[len - 1] == '\n')
+            line[len - 1] = '\0';
+        add_history_entry(line, 0);
+    }
+    fclose(f);
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -3,5 +3,6 @@
 
 void add_history(const char *cmd);
 void print_history(void);
+void load_history(void);
 
 #endif /* HISTORY_H */

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,8 @@ int main(int argc, char **argv) {
     /* Ignore Ctrl-C in the shell itself */
     signal(SIGINT, SIG_IGN);
 
+    load_history();
+
     while (1) {
         check_jobs();
         if (interactive) {


### PR DESCRIPTION
## Summary
- persist command history to `~/.vush_history`
- load history from the history file at startup
- mention the history file location in README

## Testing
- `make`
- `make test` *(fails: `expect` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf37cf188324acb86557fafd2b55