### PR TITLE
Add `source` builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, and `help`
+- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `source`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
@@ -76,6 +76,7 @@ $HOME
 - `export NAME=value` - set an environment variable for the shell.
 - `history` - show previously entered commands.
   Entries are read from and written to `~/.vush_history`.
+- `source file` or `. file` - execute commands from a file.
 - `help` - display information about built-in commands.
 
 ## Redirection Examples

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -32,6 +32,12 @@ Set an environment variable for the shell.
 .B history
 Show command history.
 .TP
+.B source \fIfile\fP
+Read commands from \fIfile\fP.
+.TP
+.B . \fIfile\fP
+Alias for \fBsource\fP.
+.TP
 .B help
 Display information about built-in commands.
 .SH SEE ALSO

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -7,10 +7,14 @@
 #include "builtins.h"
 #include "jobs.h"
 #include "history.h"
+#include "parser.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <fcntl.h>
 
 static int builtin_cd(char **args) {
     const char *dir = args[1] ? args[1] : getenv("HOME");
@@ -64,6 +68,115 @@ static int builtin_export(char **args) {
     return 1;
 }
 
+static int builtin_source(char **args) {
+    if (!args[1]) {
+        fprintf(stderr, "usage: source file\n");
+        return 1;
+    }
+
+    FILE *input = fopen(args[1], "r");
+    if (!input) {
+        perror(args[1]);
+        return 1;
+    }
+
+    char line[MAX_LINE];
+    while (fgets(line, sizeof(line), input)) {
+        size_t len = strlen(line);
+        if (len && line[len-1] == '\n') line[len-1] = '\0';
+
+        int background = 0;
+        PipelineSegment *pipeline = parse_line(line, &background);
+        if (!pipeline || !pipeline->argv[0]) {
+            free_pipeline(pipeline);
+            continue;
+        }
+
+        add_history(line);
+
+        if (!pipeline->next && run_builtin(pipeline->argv)) {
+            free_pipeline(pipeline);
+            continue;
+        }
+
+        int seg_count = 0;
+        for (PipelineSegment *tmp = pipeline; tmp; tmp = tmp->next) seg_count++;
+        pid_t *pids = calloc(seg_count, sizeof(pid_t));
+        int i = 0;
+        int in_fd = -1;
+        PipelineSegment *seg = pipeline;
+        int pipefd[2];
+        while (seg) {
+            if (seg->next && pipe(pipefd) < 0) {
+                perror("pipe");
+                break;
+            }
+            pid_t pid = fork();
+            if (pid == 0) {
+                signal(SIGINT, SIG_DFL);
+                if (in_fd != -1) {
+                    dup2(in_fd, STDIN_FILENO);
+                    close(in_fd);
+                }
+                if (seg->next) {
+                    close(pipefd[0]);
+                    dup2(pipefd[1], STDOUT_FILENO);
+                    close(pipefd[1]);
+                }
+                if (seg->in_file) {
+                    int fd = open(seg->in_file, O_RDONLY);
+                    if (fd < 0) {
+                        perror(seg->in_file);
+                        exit(1);
+                    }
+                    dup2(fd, STDIN_FILENO);
+                    close(fd);
+                }
+                if (seg->out_file) {
+                    int flags = O_WRONLY | O_CREAT;
+                    if (seg->append)
+                        flags |= O_APPEND;
+                    else
+                        flags |= O_TRUNC;
+                    int fd = open(seg->out_file, flags, 0644);
+                    if (fd < 0) {
+                        perror(seg->out_file);
+                        exit(1);
+                    }
+                    dup2(fd, STDOUT_FILENO);
+                    close(fd);
+                }
+                execvp(seg->argv[0], seg->argv);
+                perror("exec");
+                exit(1);
+            } else if (pid < 0) {
+                perror("fork");
+            } else {
+                pids[i++] = pid;
+                if (in_fd != -1) close(in_fd);
+                if (seg->next) {
+                    close(pipefd[1]);
+                    in_fd = pipefd[0];
+                }
+            }
+            seg = seg->next;
+        }
+        if (in_fd != -1) close(in_fd);
+
+        if (background) {
+            if (i > 0) add_job(pids[i-1], line);
+        } else {
+            int status;
+            for (int j = 0; j < i; j++)
+                waitpid(pids[j], &status, 0);
+        }
+        free(pids);
+        free_pipeline(pipeline);
+    }
+    fclose(input);
+    return 1;
+}
+
 static int builtin_help(char **args) {
     (void)args;
     printf("Built-in commands:\n");
@@ -73,6 +186,7 @@ static int builtin_help(char **args) {
     printf("  jobs       List running background jobs\n");
     printf("  export NAME=value   Set an environment variable\n");
     printf("  history    Show command history\n");
+    printf("  source FILE (. FILE)   Execute commands from FILE\n");
     printf("  help       Display this help message\n");
     return 1;
 }
@@ -89,6 +203,8 @@ static struct builtin builtins[] = {
     {"jobs", builtin_jobs},
     {"export", builtin_export},
     {"history", builtin_history},
+    {"source", builtin_source},
+    {".", builtin_source},
     {"help", builtin_help},
     {NULL, NULL}
 };

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_source.expect
+++ b/tests/test_source.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+set timeout 5
+set script [exec mktemp]
+set f [open $script "w"]
+puts $f "echo sourced"
+close $f
+spawn ../vush
+expect "vush> "
+send "source $script\r"
+expect {
+    -re "[\r\n]+sourced[\r\n]+vush> " {}
+    timeout { send_user "source builtin failed\n"; exec rm $script; exit 1 }
+}
+send ". $script\r"
+expect {
+    -re "[\r\n]+sourced[\r\n]+vush> " {}
+    timeout { send_user "dot alias failed\n"; exec rm $script; exit 1 }
+}
+send "exit\r"
+expect eof
+exec rm $script


### PR DESCRIPTION
## Summary
- implement `source` builtin with `.` alias
- list `source` in help output and builtin table
- document `source` usage in README and man page
- add expect test for sourcing files

## Testing
- `make`
- `make test` *(fails: ./run_tests.sh: 7: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc00c90848324aeefdd1f9d85a583