### PR TITLE
Implement fg builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `source`, and `help`
+- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `source`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
@@ -73,6 +73,7 @@ $HOME
 - `exit` - terminate the shell.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
+- `fg ID` - wait for background job `ID`.
 - `export NAME=value` - set an environment variable for the shell.
 - `history` - show previously entered commands.
   Entries are read from and written to `~/.vush_history`.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -26,6 +26,9 @@ Print the current working directory.
 .B jobs
 List running background jobs.
 .TP
+.B fg ID
+Wait for job ID in the foreground.
+.TP
 .B export NAME=value
 Set an environment variable for the shell.
 .TP

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -46,6 +46,16 @@ static int builtin_jobs(char **args) {
     return 1;
 }
 
+static int builtin_fg(char **args) {
+    if (!args[1]) {
+        fprintf(stderr, "usage: fg ID\n");
+        return 1;
+    }
+    int id = atoi(args[1]);
+    wait_job(id);
+    return 1;
+}
+
 static int builtin_history(char **args) {
     (void)args;
     print_history();
@@ -184,6 +194,7 @@ static int builtin_help(char **args) {
     printf("  exit       Exit the shell\n");
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
+    printf("  fg ID      Wait for job ID in foreground\n");
     printf("  export NAME=value   Set an environment variable\n");
     printf("  history    Show command history\n");
     printf("  source FILE (. FILE)   Execute commands from FILE\n");
@@ -201,6 +212,7 @@ static struct builtin builtins[] = {
     {"exit", builtin_exit},
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
+    {"fg", builtin_fg},
     {"export", builtin_export},
     {"history", builtin_history},
     {"source", builtin_source},

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -61,3 +61,20 @@ void print_jobs(void) {
     }
 }
 
+int wait_job(int id) {
+    Job **curr = &jobs;
+    while (*curr) {
+        if ((*curr)->id == id) {
+            int status;
+            waitpid((*curr)->pid, &status, 0);
+            Job *tmp = *curr;
+            *curr = (*curr)->next;
+            free(tmp);
+            return 0;
+        }
+        curr = &((*curr)->next);
+    }
+    fprintf(stderr, "fg: job %d not found\n", id);
+    return -1;
+}
+

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -12,5 +12,6 @@ void add_job(pid_t pid, const char *cmd);
 void remove_job(pid_t pid);
 void check_jobs(void);
 void print_jobs(void);
+int wait_job(int id);
 
 #endif /* JOBS_H */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect"
+tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_fg.expect
+++ b/tests/test_fg.expect
@@ -1,0 +1,10 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "sleep 1 &\r"
+expect "vush> "
+send "fg 1\r"
+expect "vush> "
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add `wait_job` helper to wait for a background job
- implement `fg` builtin using `wait_job`
- list `fg` in help output and builtin table
- document `fg` in README and manual
- add expect test for foregrounding a job

## Testing
- `make`
- `cd tests && ./run_tests.sh` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fc1140f3c832481735529f0962436