### PR TITLE
Implement 'cd -' directory toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Example interactive session:
 ```
 vush> ls -l
 vush> cd /tmp
+vush> cd -
+/home/user
 vush> echo $HOME
 vush> sleep 5 &
 ```
@@ -69,7 +71,7 @@ $HOME
 
 ## Built-in Commands
 
-- `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`.
+- `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`. Use `cd -` to toggle back to the previous directory.
 - `exit` - terminate the shell.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect"
+tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_cd_dash.expect
+++ b/tests/test_cd_dash.expect
@@ -1,0 +1,28 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "cd /tmp\r"
+expect "vush> "
+send "cd -\r"
+expect {
+    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    timeout { send_user "cd - output mismatch\n"; exit 1 }
+}
+send "pwd\r"
+expect {
+    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    timeout { send_user "cd - didn't switch\n"; exit 1 }
+}
+send "cd -\r"
+expect {
+    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    timeout { send_user "cd - toggle mismatch\n"; exit 1 }
+}
+send "pwd\r"
+expect {
+    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    timeout { send_user "cd - didn't toggle back\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- track last visited directory in builtin_cd
- show previous directory when running `cd -`
- clarify help text and README usage
- add regression test for `cd -`

## Testing
- `make test` *(fails: ./run_tests.sh: 7: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3d95d7483249233bc7ccbe91bbd