### PR TITLE
Add command sequences with &&, || and ;

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and a few built-in commands.
 - Environment variable expansion for tokens beginning with `$`
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
+- Command chaining with `;`, `&&`, and `||`
 - Input and output redirection with `<`, `>` and `>>`
 - Persistent command history saved to `~/.vush_history`
 

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -6,6 +6,7 @@ vush \- simple UNIX shell
 .RI [ scriptfile ]
 .SH DESCRIPTION
 vush is a lightweight UNIX shell supporting command execution,
+pipelines, command chaining with ';', '&&' and '||',
 environment variable expansion and background jobs.  When a
 \fIscriptfile\fP is supplied, commands are read from that file
 instead of standard input.  A `#` outside of quotes begins a comment

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -8,6 +8,7 @@
 #include "jobs.h"
 #include "history.h"
 #include "parser.h"
+#include "execute.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -123,93 +124,29 @@ static int builtin_source(char **args) {
         size_t len = strlen(line);
         if (len && line[len-1] == '\n') line[len-1] = '\0';
 
-        int background = 0;
-        PipelineSegment *pipeline = parse_line(line, &background);
-        if (!pipeline || !pipeline->argv[0]) {
-            free_pipeline(pipeline);
+        Command *cmds = parse_line(line);
+        if (!cmds || !cmds->pipeline || !cmds->pipeline->argv[0]) {
+            free_commands(cmds);
             continue;
         }
 
         add_history(line);
 
-        if (!pipeline->next && run_builtin(pipeline->argv)) {
-            free_pipeline(pipeline);
-            continue;
-        }
-
-        int seg_count = 0;
-        for (PipelineSegment *tmp = pipeline; tmp; tmp = tmp->next) seg_count++;
-        pid_t *pids = calloc(seg_count, sizeof(pid_t));
-        int i = 0;
-        int in_fd = -1;
-        PipelineSegment *seg = pipeline;
-        int pipefd[2];
-        while (seg) {
-            if (seg->next && pipe(pipefd) < 0) {
-                perror("pipe");
-                break;
+        int last_status = 0;
+        CmdOp prev = OP_SEMI;
+        for (Command *c = cmds; c; c = c->next) {
+            int run = 1;
+            if (c != cmds) {
+                if (prev == OP_AND)
+                    run = (last_status == 0);
+                else if (prev == OP_OR)
+                    run = (last_status != 0);
             }
-            pid_t pid = fork();
-            if (pid == 0) {
-                signal(SIGINT, SIG_DFL);
-                if (in_fd != -1) {
-                    dup2(in_fd, STDIN_FILENO);
-                    close(in_fd);
-                }
-                if (seg->next) {
-                    close(pipefd[0]);
-                    dup2(pipefd[1], STDOUT_FILENO);
-                    close(pipefd[1]);
-                }
-                if (seg->in_file) {
-                    int fd = open(seg->in_file, O_RDONLY);
-                    if (fd < 0) {
-                        perror(seg->in_file);
-                        exit(1);
-                    }
-                    dup2(fd, STDIN_FILENO);
-                    close(fd);
-                }
-                if (seg->out_file) {
-                    int flags = O_WRONLY | O_CREAT;
-                    if (seg->append)
-                        flags |= O_APPEND;
-                    else
-                        flags |= O_TRUNC;
-                    int fd = open(seg->out_file, flags, 0644);
-                    if (fd < 0) {
-                        perror(seg->out_file);
-                        exit(1);
-                    }
-                    dup2(fd, STDOUT_FILENO);
-                    close(fd);
-                }
-                execvp(seg->argv[0], seg->argv);
-                perror("exec");
-                exit(1);
-            } else if (pid < 0) {
-                perror("fork");
-            } else {
-                pids[i++] = pid;
-                if (in_fd != -1) close(in_fd);
-                if (seg->next) {
-                    close(pipefd[1]);
-                    in_fd = pipefd[0];
-                }
-            }
-            seg = seg->next;
+            if (run)
+                last_status = run_pipeline(c->pipeline, c->background, line);
+            prev = c->op;
         }
-        if (in_fd != -1) close(in_fd);
-
-        if (background) {
-            if (i > 0) add_job(pids[i-1], line);
-        } else {
-            int status;
-            for (int j = 0; j < i; j++)
-                waitpid(pids[j], &status, 0);
-        }
-        free(pids);
-        free_pipeline(pipeline);
+        free_commands(cmds);
     }
     fclose(input);
     return 1;

--- a/src/execute.c
+++ b/src/execute.c
@@ -1,0 +1,94 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <fcntl.h>
+
+#include "execute.h"
+#include "jobs.h"
+#include "builtins.h"
+
+int run_pipeline(PipelineSegment *pipeline, int background, const char *line) {
+    if (!pipeline)
+        return 0;
+
+    if (!pipeline->next && run_builtin(pipeline->argv))
+        return 0;
+
+    int seg_count = 0;
+    for (PipelineSegment *tmp = pipeline; tmp; tmp = tmp->next) seg_count++;
+    pid_t *pids = calloc(seg_count, sizeof(pid_t));
+    int i = 0;
+    int in_fd = -1;
+    PipelineSegment *seg = pipeline;
+    int pipefd[2];
+    while (seg) {
+        if (seg->next && pipe(pipefd) < 0) {
+            perror("pipe");
+            free(pids);
+            return 1;
+        }
+        pid_t pid = fork();
+        if (pid == 0) {
+            signal(SIGINT, SIG_DFL);
+            if (in_fd != -1) {
+                dup2(in_fd, STDIN_FILENO);
+                close(in_fd);
+            }
+            if (seg->next) {
+                close(pipefd[0]);
+                dup2(pipefd[1], STDOUT_FILENO);
+                close(pipefd[1]);
+            }
+            if (seg->in_file) {
+                int fd = open(seg->in_file, O_RDONLY);
+                if (fd < 0) {
+                    perror(seg->in_file);
+                    exit(1);
+                }
+                dup2(fd, STDIN_FILENO);
+                close(fd);
+            }
+            if (seg->out_file) {
+                int flags = O_WRONLY | O_CREAT;
+                if (seg->append)
+                    flags |= O_APPEND;
+                else
+                    flags |= O_TRUNC;
+                int fd = open(seg->out_file, flags, 0644);
+                if (fd < 0) {
+                    perror(seg->out_file);
+                    exit(1);
+                }
+                dup2(fd, STDOUT_FILENO);
+                close(fd);
+            }
+            execvp(seg->argv[0], seg->argv);
+            perror("exec");
+            exit(1);
+        } else if (pid < 0) {
+            perror("fork");
+        } else {
+            pids[i++] = pid;
+            if (in_fd != -1) close(in_fd);
+            if (seg->next) {
+                close(pipefd[1]);
+                in_fd = pipefd[0];
+            }
+        }
+        seg = seg->next;
+    }
+    if (in_fd != -1) close(in_fd);
+
+    int status = 0;
+    if (background) {
+        if (i > 0)
+            add_job(pids[i-1], line);
+    } else {
+        for (int j = 0; j < i; j++)
+            waitpid(pids[j], &status, 0);
+    }
+    free(pids);
+    return WEXITSTATUS(status);
+}

--- a/src/execute.h
+++ b/src/execute.h
@@ -1,0 +1,8 @@
+#ifndef EXECUTE_H
+#define EXECUTE_H
+
+#include "parser.h"
+
+int run_pipeline(PipelineSegment *pipeline, int background, const char *line);
+
+#endif /* EXECUTE_H */

--- a/src/parser.h
+++ b/src/parser.h
@@ -19,8 +19,23 @@ typedef struct PipelineSegment {
     struct PipelineSegment *next;
 } PipelineSegment;
 
+typedef enum {
+    OP_NONE,
+    OP_SEMI,
+    OP_AND,
+    OP_OR
+} CmdOp;
+
+typedef struct Command {
+    PipelineSegment *pipeline;
+    int background;
+    CmdOp op; /* operator connecting to next command */
+    struct Command *next;
+} Command;
+
 char *expand_var(const char *token);
-PipelineSegment *parse_line(char *line, int *background);
+Command *parse_line(char *line);
 void free_pipeline(PipelineSegment *p);
+void free_commands(Command *c);
 
 #endif /* PARSER_H */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect"
+tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_andor.expect
+++ b/tests/test_andor.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "false && echo nope\r"
+expect {
+    -re "nope" { send_user "AND execution failed\n"; exit 1 }
+    -re "vush> " {}
+    timeout { send_user "command timeout\n"; exit 1 }
+}
+send "exit\r"
+expect eof

--- a/tests/test_sequence.expect
+++ b/tests/test_sequence.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "echo first; echo second\r"
+expect {
+    -re "[\r\n]+first[\r\n]+second[\r\n]+vush> " {}
+    timeout { send_user "sequence output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add new Command struct in parser and support for `;`, `&&`, `||`
- implement command execution helper in new execute.c
- update main loop and `source` builtin to evaluate command chains
- document chaining syntax in README and man page
- add expect tests for sequencing and conditional execution

## Testing
- `make test` *(fails: ./run_tests.sh: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc4f3b5248324a3c82ccea4ce3ed7