### PR TITLE
Implement $? variable for last status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ and a few built-in commands.
 - Execution of external commands via `fork` and `exec`
 - Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `source`, and `help`
 - Environment variable expansion for tokens beginning with `$`
+- `$?` expands to the exit status of the last foreground command
 - Wildcard expansion for unquoted `*` and `?` patterns
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
@@ -72,6 +73,12 @@ vush> echo "$HOME"
 /home/user
 vush> echo \$HOME
 $HOME
+vush> false
+vush> echo $?
+1
+vush> true
+vush> echo $?
+0
 ```
 
 ## Built-in Commands

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -7,8 +7,8 @@ vush \- simple UNIX shell
 .SH DESCRIPTION
 vush is a lightweight UNIX shell supporting command execution,
 pipelines, command chaining with ';', '&&' and '||',
-environment variable expansion, wildcard matching for '*' and '?', and
-background jobs.  When a
+environment variable expansion (with "$?" storing the last exit status),
+wildcard matching for '*' and '?', and background jobs.  When a
 \fIscriptfile\fP is supplied, commands are read from that file
 instead of standard input.  A `#` outside of quotes begins a comment
 and causes the rest of the line to be ignored.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+extern int last_status;
 #include <limits.h>
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -132,7 +134,6 @@ static int builtin_source(char **args) {
 
         add_history(line);
 
-        int last_status = 0;
         CmdOp prev = OP_SEMI;
         for (Command *c = cmds; c; c = c->next) {
             int run = 1;
@@ -143,7 +144,7 @@ static int builtin_source(char **args) {
                     run = (last_status != 0);
             }
             if (run)
-                last_status = run_pipeline(c->pipeline, c->background, line);
+                run_pipeline(c->pipeline, c->background, line);
             prev = c->op;
         }
         free_commands(cmds);

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,8 @@
 #include "execute.h"
 #include "history.h"
 
+int last_status = 0;
+
 int main(int argc, char **argv) {
     char line[MAX_LINE];
 
@@ -53,7 +55,6 @@ int main(int argc, char **argv) {
         }
         add_history(line);
 
-        int last_status = 0;
         CmdOp prev = OP_SEMI;
         for (Command *c = cmds; c; c = c->next) {
             int run = 1;
@@ -63,9 +64,8 @@ int main(int argc, char **argv) {
                 else if (prev == OP_OR)
                     run = (last_status != 0);
             }
-            if (run) {
-                last_status = run_pipeline(c->pipeline, c->background, line);
-            }
+            if (run)
+                run_pipeline(c->pipeline, c->background, line);
             prev = c->op;
         }
         free_commands(cmds);

--- a/src/parser.c
+++ b/src/parser.c
@@ -10,7 +10,14 @@
 #include <stdio.h>
 #include <glob.h>
 
+extern int last_status;
+
 char *expand_var(const char *token) {
+    if (strcmp(token, "$?") == 0) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%d", last_status);
+        return strdup(buf);
+    }
     if (token[0] == '~') {
         const char *home = getenv("HOME");
         if (!home) home = "";

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect test_glob.expect"
+tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_status.expect
+++ b/tests/test_status.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "false\r"
+expect "vush> "
+send "echo $?\r"
+expect {
+    -re "[\r\n]+1[\r\n]+vush> " {}
+    timeout { send_user "false status mismatch\n"; exit 1 }
+}
+send "true\r"
+expect "vush> "
+send "echo $?\r"
+expect {
+    -re "[\r\n]+0[\r\n]+vush> " {}
+    timeout { send_user "true status mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- keep last command status globally in `main.c`
- expose `$?` in `expand_var`
- update background job status handling
- document `$?` usage in README and man page
- add expect test for `$?`

## Testing
- `make clean && make`
- `make test` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fcc10f02c8324b3b7ff46a821e509