### PR TITLE
Add PS1 customizable prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and a few built-in commands.
 - Command chaining with `;`, `&&`, and `||`
 - Input and output redirection with `<`, `>` and `>>`
 - Persistent command history saved to `~/.vush_history`
+- Prompt string configurable via the `PS1` environment variable
 
 ## Building
 

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,9 @@ int main(int argc, char **argv) {
     while (1) {
         check_jobs();
         if (interactive) {
-            printf("vush> ");
+            const char *prompt = getenv("PS1");
+            if (!prompt) prompt = "vush> ";
+            printf("%s", prompt);
             fflush(stdout);
         }
         if (!fgets(line, sizeof(line), input)) break;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
+tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_ps1.expect
+++ b/tests/test_ps1.expect
@@ -1,0 +1,8 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "export PS1='custom> '\r"
+expect "custom> "
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- allow overriding the shell prompt with the `PS1` environment variable
- document the new variable in README
- add expect test for changing the prompt

## Testing
- `make test` *(fails: ./run_tests.sh: 7: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fce47ba448324ae2efd040de43406