### PR TITLE
Add kill builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `source`, and `help`
+- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `kill`, `source`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - `$?` expands to the exit status of the last foreground command
 - Wildcard expansion for unquoted `*` and `?` patterns
@@ -89,6 +89,7 @@ vush> echo $?
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
 - `fg ID` - wait for background job `ID`.
+- `kill [-SIGNAL] ID` - send a signal to the background job `ID`.
 - `export NAME=value` - set an environment variable for the shell.
 - `history` - show previously entered commands.
   Entries are read from and written to `~/.vush_history`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to **vush** will be documented in this file.
 
+## 0.3.0 - Added kill builtin
+- New `kill` command allows sending signals to background jobs
+
 ## 0.2.0 - Added globbing support
 - Unquoted `*` and `?` patterns now expand to matching files
 

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -33,6 +33,9 @@ List running background jobs.
 .B fg ID
 Wait for job ID in the foreground.
 .TP
+.B kill [-SIGNAL] ID
+Send a signal to job ID.
+.TP
 .B export NAME=value
 Set an environment variable for the shell.
 .TP

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -92,6 +92,26 @@ static int builtin_fg(char **args) {
     return 1;
 }
 
+static int builtin_kill(char **args) {
+    if (!args[1]) {
+        fprintf(stderr, "usage: kill [-SIGNAL] ID\n");
+        return 1;
+    }
+    int sig = SIGTERM;
+    int idx = 1;
+    if (args[1][0] == '-') {
+        sig = atoi(args[1] + 1);
+        idx++;
+    }
+    if (!args[idx]) {
+        fprintf(stderr, "usage: kill [-SIGNAL] ID\n");
+        return 1;
+    }
+    int id = atoi(args[idx]);
+    kill_job(id, sig);
+    return 1;
+}
+
 static int builtin_history(char **args) {
     (void)args;
     print_history();
@@ -166,6 +186,7 @@ static int builtin_help(char **args) {
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
     printf("  fg ID      Wait for job ID in foreground\n");
+    printf("  kill [-SIGNAL] ID   Send a signal to job ID\n");
     printf("  export NAME=value   Set an environment variable\n");
     printf("  history    Show command history\n");
     printf("  source FILE (. FILE)   Execute commands from FILE\n");
@@ -184,6 +205,7 @@ static struct builtin builtins[] = {
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
     {"fg", builtin_fg},
+    {"kill", builtin_kill},
     {"export", builtin_export},
     {"history", builtin_history},
     {"source", builtin_source},

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -3,12 +3,15 @@
  * Licensed under the GNU GPLv3.
  */
 
+#define _GNU_SOURCE
 #include "jobs.h"
 #include "parser.h"  /* for MAX_LINE */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
 
 typedef struct Job {
     int id;
@@ -75,6 +78,22 @@ int wait_job(int id) {
         curr = &((*curr)->next);
     }
     fprintf(stderr, "fg: job %d not found\n", id);
+    return -1;
+}
+
+int kill_job(int id, int sig) {
+    Job *curr = jobs;
+    while (curr) {
+        if (curr->id == id) {
+            if (kill(curr->pid, sig) != 0) {
+                perror("kill");
+                return -1;
+            }
+            return 0;
+        }
+        curr = curr->next;
+    }
+    fprintf(stderr, "kill: job %d not found\n", id);
     return -1;
 }
 

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -13,5 +13,6 @@ void remove_job(pid_t pid);
 void check_jobs(void);
 void print_jobs(void);
 int wait_job(int id);
+int kill_job(int id, int sig);
 
 #endif /* JOBS_H */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
+tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_kill.expect
+++ b/tests/test_kill.expect
@@ -1,0 +1,19 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "sleep 5 &\r"
+expect "vush> "
+send "kill 1\r"
+expect {
+    -re "\[vush\] job [0-9]+ finished[\r\n]+vush> " {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "jobs\r"
+expect {
+    -re "vush> " {}
+    -re "\[1\]" { send_user "job not terminated\n"; exit 1 }
+    timeout { send_user "jobs timeout\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- send signals to jobs via `kill_job`
- implement `kill` builtin
- document `kill` command in README and man page
- add `kill` regression test
- mention the new builtin in changelog

## Testing
- `make clean && make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcfd95f9c8324ad64b0b991c2c505