### PR TITLE
Add alias builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `kill`, `source`, and `help`
+- Built-in commands: `cd`, `exit`, `pwd`, `jobs`, `fg`, `kill`, `alias`, `unalias`, `source`, and `help`
 - Environment variable expansion for tokens beginning with `$`
 - `$?` expands to the exit status of the last foreground command
 - Wildcard expansion for unquoted `*` and `?` patterns
@@ -93,6 +93,8 @@ vush> echo $?
 - `export NAME=value` - set an environment variable for the shell.
 - `history` - show previously entered commands.
   Entries are read from and written to `~/.vush_history`.
+- `alias NAME=value` - define an alias or list all aliases when used without arguments.
+- `unalias NAME` - remove an alias.
 - `source file` or `. file` - execute commands from a file.
 - `help` - display information about built-in commands.
 

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -42,6 +42,12 @@ Set an environment variable for the shell.
 .B history
 Show command history.
 .TP
+.B alias \fIname\fP=\fIvalue\fP
+Set an alias or list aliases when used without arguments.
+.TP
+.B unalias \fIname\fP
+Remove an alias.
+.TP
 .B source \fIfile\fP
 Read commands from \fIfile\fP.
 .TP

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -7,5 +7,6 @@
 #define BUILTINS_H
 
 int run_builtin(char **args);
+const char *get_alias(const char *name);
 
 #endif /* BUILTINS_H */

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,7 @@
 
 #define _GNU_SOURCE
 #include "parser.h"
+#include "builtins.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -128,6 +129,22 @@ Command *parse_line(char *line) {
 
             int quoted = 0;
             char *tok = read_token(&p, &quoted);
+
+            if (!quoted && argc == 0) {
+                const char *alias = get_alias(tok);
+                if (alias) {
+                    free(tok);
+                    char *dup = strdup(alias);
+                    char *sp = NULL;
+                    char *word = strtok_r(dup, " \t", &sp);
+                    while (word && argc < MAX_TOKENS - 1) {
+                        seg->argv[argc++] = strdup(word);
+                        word = strtok_r(NULL, " \t", &sp);
+                    }
+                    free(dup);
+                    continue;
+                }
+            }
 
             if (!quoted && strcmp(tok, "<") == 0) {
                 while (*p == ' ' || *p == '\t') p++;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_status.expect"
+tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_status.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "alias ll='echo hi'\r"
+expect "vush> "
+send "alias\r"
+expect {
+    -re "[\r\n]+ll='echo hi'[\r\n]+vush> " {}
+    timeout { send_user "alias listing failed\n"; exit 1 }
+}
+send "ll there\r"
+expect {
+    -re "[\r\n]+hi there[\r\n]+vush> " {}
+    timeout { send_user "alias use failed\n"; exit 1 }
+}
+send "unalias ll\r"
+expect "vush> "
+send "alias\r"
+expect "vush> "
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- implement alias table and alias/unalias builtins
- support alias expansion while parsing commands
- document alias and unalias commands
- add expect test for aliases

## Testing
- `make`
- `make test` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fd117482c8324a14ca26ff7f2c7ec