### PR TITLE
Add unset builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ vush> echo $?
 - `fg ID` - wait for background job `ID`.
 - `kill [-SIGNAL] ID` - send a signal to the background job `ID`.
 - `export NAME=value` - set an environment variable for the shell.
+- `unset NAME` - remove an environment variable.
 - `history` - show previously entered commands.
   Entries are read from and written to `~/.vush_history`.
 - `alias NAME=value` - define an alias or list all aliases when used without arguments.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -39,6 +39,9 @@ Send a signal to job ID.
 .B export NAME=value
 Set an environment variable for the shell.
 .TP
+.B unset \fIname\fP
+Remove an environment variable.
+.TP
 .B history
 Show command history.
 .TP

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -198,6 +198,16 @@ static int builtin_unalias(char **args) {
     return 1;
 }
 
+static int builtin_unset(char **args) {
+    if (!args[1]) {
+        fprintf(stderr, "usage: unset NAME...\n");
+        return 1;
+    }
+    for (int i = 1; args[i]; i++)
+        unsetenv(args[i]);
+    return 1;
+}
+
 static int builtin_export(char **args) {
     if (!args[1] || !strchr(args[1], '=')) {
         fprintf(stderr, "usage: export NAME=value\n");
@@ -268,6 +278,7 @@ static int builtin_help(char **args) {
     printf("  fg ID      Wait for job ID in foreground\n");
     printf("  kill [-SIGNAL] ID   Send a signal to job ID\n");
     printf("  export NAME=value   Set an environment variable\n");
+    printf("  unset NAME          Remove an environment variable\n");
     printf("  history    Show command history\n");
     printf("  alias NAME=VALUE    Set an alias\n");
     printf("  unalias NAME        Remove an alias\n");
@@ -289,6 +300,7 @@ static struct builtin builtins[] = {
     {"fg", builtin_fg},
     {"kill", builtin_kill},
     {"export", builtin_export},
+    {"unset", builtin_unset},
     {"history", builtin_history},
     {"alias", builtin_alias},
     {"unalias", builtin_unalias},

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 failed=0
-tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_status.expect"
+tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_status.expect"
 for test in $tests; do
     echo "Running $test"
     if ! ./$test; then

--- a/tests/test_unset.expect
+++ b/tests/test_unset.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "export FOO=bar\r"
+expect "vush> "
+send "unset FOO\r"
+expect "vush> "
+send "echo $FOO\r"
+expect {
+    -re "[\r\n]+vush> " {}
+    timeout { send_user "unset failed\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- implement builtin_unset for removing environment variables
- register it in builtins list and help text
- document `unset` in README and man page
- add expect test for unset

## Testing
- `make test` *(fails: ./test_env.expect not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd393f84c8324bb04b95ffa1cfaaa