### PR TITLE
Add exit status argument to builtin exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and a few built-in commands.
   and `Ctrl-U` clears back to the start
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable
+- `exit` accepts an optional status argument
 
 ## Building
 
@@ -108,7 +109,7 @@ hi
 - `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`. `~user` names are expanded using the password database. After a successful change `PWD` and `OLDPWD` are updated. Use `cd -` to print and switch to `$OLDPWD`.
 - `pushd dir` - push the current directory and change to `dir`.
 - `popd` - return to the directory from the stack.
-- `exit` - terminate the shell.
+- `exit [status]` - terminate the shell with an optional status code.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.
 - `fg ID` - wait for background job `ID`.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -39,8 +39,8 @@ printed after the change.
 Switch to the directory most recently pushed with \fBpushd\fP. The stack is
 printed after the switch.
 .TP
-.B exit
-Exit the shell.
+.B exit [STATUS]
+Exit the shell with the given status (default 0).
 .TP
 .B pwd
 Print the current working directory.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -12,6 +12,7 @@
 #include "dirstack.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -168,8 +169,18 @@ static int builtin_popd(char **args) {
 }
 
 static int builtin_exit(char **args) {
-    (void)args;
-    exit(0);
+    int status = 0;
+    if (args[1]) {
+        char *end;
+        errno = 0;
+        long val = strtol(args[1], &end, 10);
+        if (*end != '\0' || errno != 0) {
+            fprintf(stderr, "usage: exit [STATUS]\n");
+            return 1;
+        }
+        status = (int)val;
+    }
+    exit(status);
 }
 
 static int builtin_pwd(char **args) {
@@ -337,7 +348,7 @@ static int builtin_help(char **args) {
     printf("  cd [dir]   Change the current directory ('cd -' toggles)\n");
     printf("  pushd DIR  Push current directory and switch to DIR\n");
     printf("  popd       Switch to directory from stack\n");
-    printf("  exit       Exit the shell\n");
+    printf("  exit [status]  Exit the shell with optional status\n");
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
     printf("  fg ID      Wait for job ID in foreground\n");


### PR DESCRIPTION
## Summary
- allow `exit` builtin to accept an optional status argument
- document the status argument in builtin help and man page
- mention the new feature in the README

## Testing
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d125bbac83248a9981d5a054d351