### PR TITLE
Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC ?= cc
 CFLAGS ?= -Wall -Wextra -std=c99
+PREFIX ?= /usr/local
+MANPREFIX ?= $(PREFIX)/share/man
 
 SRCS := src/builtins.c src/execute.c src/history.c src/jobs.c src/lineedit.c \
        src/parser.c src/dirstack.c src/main.c
@@ -13,3 +15,13 @@ clean:
 
 test: vush
 	cd tests && ./run_tests.sh
+
+install: vush
+	install -d $(PREFIX)/bin
+	install -m 755 vush $(PREFIX)/bin
+	install -d $(MANPREFIX)/man1
+	install -m 644 docs/vush.1 $(MANPREFIX)/man1
+
+uninstall:
+	rm -f $(PREFIX)/bin/vush
+	rm -f $(MANPREFIX)/man1/vush.1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ The resulting binary will be `./vush`. Remove the binary with:
 make clean
 ```
 
+## Installation
+
+Install the binary and manual page with:
+
+```sh
+make install
+```
+
+By default files are placed under `/usr/local`. Set `PREFIX` to a different
+location if desired. Uninstall with:
+
+```sh
+make uninstall
+```
+
 ## Usage
 
 Run the `vush` binary and enter commands as you would in a normal shell.  You


### PR DESCRIPTION
## Summary
- install vush and manpage via `make install`
- add uninstall target
- document the new installation steps

## Testing
- `make clean`
- `make`
- `make test` *(fails: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee06dae48324b5b1b1b521e6fdf3