### PR TITLE
Add centralized PATH_MAX header

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -17,10 +17,7 @@
 #include <unistd.h>
 
 extern int last_status;
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "common.h"
 #include <sys/wait.h>
 #include <signal.h>
 #include <fcntl.h>

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,10 @@
+#ifndef VUSH_COMMON_H
+#define VUSH_COMMON_H
+
+#include <limits.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#endif /* VUSH_COMMON_H */

--- a/src/history.c
+++ b/src/history.c
@@ -3,11 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
-
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "common.h"
 
 typedef struct HistEntry {
     int id;

--- a/src/main.c
+++ b/src/main.c
@@ -11,10 +11,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <fcntl.h>
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "common.h"
 
 #include "parser.h"
 #include "jobs.h"


### PR DESCRIPTION
## Summary
- add `src/common.h` defining `PATH_MAX` when missing
- include this header in builtins, main, and history
- remove per-file PATH_MAX definitions

## Testing
- `make test` *(fails: `expect` scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef08bac483249c0525f18b5dbdab