### PR TITLE
Add jobs expect test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 failed=0
 
-tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_status.expect test_cmdsub.expect test_lineedit.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect"
+tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_status.expect test_cmdsub.expect test_lineedit.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect"
 
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_jobs.expect
+++ b/tests/test_jobs.expect
@@ -1,0 +1,18 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "sleep 5 &\r"
+expect "vush> "
+send "jobs\r"
+expect {
+    -re "\[1\] [0-9]+ sleep 5 &[\r\n]+vush> " {}
+    timeout { send_user "jobs output mismatch\n"; exit 1 }
+}
+send "kill 1\r"
+expect {
+    -re "\[vush\] job [0-9]+ finished[\r\n]+vush> " {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- add an expect script checking the `jobs` builtin
- register the script in the test runner

## Testing
- `make test` *(fails: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f40732b48324a0c76ce4ce86ee30