### PR TITLE
Make aliases dynamic

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -8,5 +8,6 @@
 
 int run_builtin(char **args);
 const char *get_alias(const char *name);
+void free_aliases(void);
 
 #endif /* BUILTINS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -122,6 +122,7 @@ int main(int argc, char **argv) {
     }
     if (input != stdin)
         fclose(input);
+    free_aliases();
     return 0;
 }
 

--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -18,5 +18,21 @@ send "unalias ll\r"
 expect "vush> "
 send "alias\r"
 expect "vush> "
+
+# Create many aliases to ensure dynamic allocation works
+for {set i 0} {$i < 40} {incr i} {
+    send "alias a$i='echo hi$i'\r"
+    expect "vush> "
+}
+send "alias\r"
+expect {
+    -re "a39='echo hi39'" {}
+    timeout { send_user "alias storage failed\n"; exit 1 }
+}
+send "a39 world\r"
+expect {
+    -re "[\r\n]+hi39 world[\r\n]+vush> " {}
+    timeout { send_user "alias expanded failed\n"; exit 1 }
+}
 send "exit\r"
 expect eof


### PR DESCRIPTION
## Summary
- allow unlimited aliases using a linked list
- free aliases on shell exit
- add regression test that adds more than 32 aliases

## Testing
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f4adf7488324a5de5f04f379cb67