### PR TITLE
Add prompt expansion for PS1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -86,10 +86,11 @@ int main(int argc, char **argv) {
     while (1) {
         check_jobs();
         if (interactive) {
-            const char *prompt = getenv("PS1");
-            if (!prompt) prompt = "vush> ";
+            const char *ps = getenv("PS1");
+            char *prompt = expand_prompt(ps ? ps : "vush> ");
             history_reset_cursor();
             line = line_edit(prompt);
+            free(prompt);
             if (!line) break;
         } else {
             if (!fgets(linebuf, sizeof(linebuf), input)) break;

--- a/src/parser.c
+++ b/src/parser.c
@@ -254,6 +254,23 @@ static char *read_token(char **p, int *quoted) {
     return do_expand ? expand_var(buf) : strdup(buf);
 }
 
+char *expand_prompt(const char *prompt) {
+    if (!prompt)
+        return strdup("");
+    size_t len = strlen(prompt);
+    char tmp[len + 3];
+    tmp[0] = '"';
+    memcpy(tmp + 1, prompt, len);
+    tmp[len + 1] = '"';
+    tmp[len + 2] = '\0';
+    char *p = tmp;
+    int quoted = 0;
+    char *res = read_token(&p, &quoted);
+    if (!res)
+        return strdup("");
+    return res;
+}
+
 Command *parse_line(char *line) {
     char *p = line;
     Command *head = NULL, *cur_cmd = NULL;

--- a/src/parser.h
+++ b/src/parser.h
@@ -38,6 +38,7 @@ typedef struct Command {
 } Command;
 
 char *expand_var(const char *token);
+char *expand_prompt(const char *prompt);
 Command *parse_line(char *line);
 void free_pipeline(PipelineSegment *p);
 void free_commands(Command *c);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 failed=0
 
-tests="test_env.expect test_ps1.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect"
+tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect"
 
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_ps1_cmdsub.expect
+++ b/tests/test_ps1_cmdsub.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/expect -f
+set timeout 5
+set start $env(PWD)
+set parent [file dirname $start]
+spawn ../vush
+expect "vush> "
+send "export PS1='$(pwd)> '\r"
+expect "$start> "
+send "cd ..\r"
+expect "$parent> "
+send "cd -\r"
+expect {
+    -re "[\r\n]+$start[\r\n]+$start> " {}
+    timeout { send_user "prompt not updated after cd -\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- expand PS1 using variable and command substitution
- use expanded prompt in interactive mode
- test prompt with `$(pwd)` after directory changes

## Testing
- `make`
- `make test` *(fails: `./test_env.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68460635677883248fe09057d9f0d45b