### PR TITLE
Add Ctrl-W, Ctrl-K and Ctrl-L line editing

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -17,7 +17,9 @@ and causes the rest of the line to be ignored.
 When run interactively, arrow keys allow editing the current line and
 recalling previous commands from history.  `Ctrl-A` or the Home key moves
 the cursor to the start of the line, `Ctrl-E` or End moves to the end and
-`Ctrl-U` clears from the cursor back to the beginning.
+`Ctrl-U` clears from the cursor back to the beginning.  `Ctrl-W` deletes
+the word before the cursor, `Ctrl-K` deletes from the cursor to the end
+of the line and `Ctrl-L` clears the screen and redraws the current line.
 If \fB~/.vushrc\fP exists, commands from this file are executed before
 the first prompt is shown.
 .SH OPTIONS

--- a/src/lineedit.c
+++ b/src/lineedit.c
@@ -171,6 +171,30 @@ char *line_edit(const char *prompt) {
                 redraw_line(prompt, buf, disp_len, pos);
                 disp_len = len;
             }
+        } else if (c == 0x17) { /* Ctrl-W */
+            if (pos > 0) {
+                int end = pos;
+                while (pos > 0 && (buf[pos-1] == ' ' || buf[pos-1] == '\t'))
+                    pos--;
+                while (pos > 0 && buf[pos-1] != ' ' && buf[pos-1] != '\t')
+                    pos--;
+                memmove(&buf[pos], &buf[end], len - end);
+                len -= end - pos;
+                redraw_line(prompt, buf, disp_len, pos);
+                if (len > disp_len)
+                    disp_len = len;
+            }
+        } else if (c == 0x0b) { /* Ctrl-K */
+            if (pos < len) {
+                buf[pos] = '\0';
+                len = pos;
+                redraw_line(prompt, buf, disp_len, pos);
+                disp_len = len;
+            }
+        } else if (c == 0x0c) { /* Ctrl-L */
+            printf("\x1b[H\x1b[2J");
+            redraw_line(prompt, buf, disp_len, pos);
+            fflush(stdout);
         } else if (c == '\t') { /* Tab completion */
             int start = pos;
             while (start > 0 && buf[start-1] != ' ' && buf[start-1] != '\t')

--- a/tests/test_lineedit.expect
+++ b/tests/test_lineedit.expect
@@ -27,5 +27,29 @@ expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "history recall down failed\n"; exit 1 }
 }
+send "echo one two"
+send "\027"
+send "three\r"
+expect {
+    -re "[\r\n]+one three[\r\n]+vush> " {}
+    timeout { send_user "Ctrl-W failed\n"; exit 1 }
+}
+send "echo foo bar"
+send "\033[D"
+send "\033[D"
+send "\033[D"
+send "\013"
+send "baz\r"
+expect {
+    -re "[\r\n]+foo baz[\r\n]+vush> " {}
+    timeout { send_user "Ctrl-K failed\n"; exit 1 }
+}
+send "echo clear"
+send "\014"
+send "\r"
+expect {
+    -re "[\r\n]+clear[\r\n]+vush> " {}
+    timeout { send_user "Ctrl-L failed\n"; exit 1 }
+}
 send "exit\r"
 expect eof


### PR DESCRIPTION
## Summary
- support more line editing keys
- document these keys in the man page
- test deleting words, killing to end-of-line and clearing the screen

## Testing
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846077006a08324b2282dba98bee57b