### PR TITLE
Add dirs builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and a few built-in commands.
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
-- Built-in commands: `cd`, `pushd`, `popd`, `exit`, `pwd`, `jobs`, `fg`,
+ - Built-in commands: `cd`, `pushd`, `popd`, `dirs`, `exit`, `pwd`, `jobs`, `fg`,
   `bg`, `kill`, `export`, `unset`, `history`, `alias`, `unalias`, `type`,
   `source` (or `.`), and `help`
 - Environment variable expansion using `$VAR` or `${VAR}` syntax
@@ -133,6 +133,7 @@ line.
 - `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`. `~user` names are expanded using the password database. After a successful change `PWD` and `OLDPWD` are updated. Use `cd -` to print and switch to `$OLDPWD`.
 - `pushd dir` - push the current directory and change to `dir`.
 - `popd` - return to the directory from the stack.
+- `dirs` - display the directory stack.
 - `exit [status]` - terminate the shell with an optional status code.
 - `pwd` - print the current working directory.
 - `jobs` - list background jobs started with `&`.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -41,6 +41,9 @@ printed after the change.
 Switch to the directory most recently pushed with \fBpushd\fP. The stack is
 printed after the switch.
 .TP
+.B dirs
+Display the directory stack.
+.TP
 .B exit [STATUS]
 Exit the shell with the given status (default 0).
 .TP

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -221,6 +221,15 @@ static int builtin_popd(char **args) {
     return 1;
 }
 
+int builtin_dirs(char **args) {
+    if (args[1]) {
+        fprintf(stderr, "usage: dirs\n");
+        return 1;
+    }
+    dirstack_print();
+    return 1;
+}
+
 static int builtin_exit(char **args) {
     int status = 0;
     if (args[1]) {
@@ -414,6 +423,7 @@ static int builtin_help(char **args) {
     printf("  cd [dir]   Change the current directory ('cd -' toggles)\n");
     printf("  pushd DIR  Push current directory and switch to DIR\n");
     printf("  popd       Switch to directory from stack\n");
+    printf("  dirs       Display the directory stack\n");
     printf("  exit [status]  Exit the shell with optional status\n");
     printf("  pwd        Print the current working directory\n");
     printf("  jobs       List running background jobs\n");
@@ -439,6 +449,7 @@ static struct builtin builtins[] = {
     {"cd", builtin_cd},
     {"pushd", builtin_pushd},
     {"popd", builtin_popd},
+    {"dirs", builtin_dirs},
     {"exit", builtin_exit},
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -8,6 +8,7 @@
 
 int run_builtin(char **args);
 int builtin_type(char **args);
+int builtin_dirs(char **args);
 const char **get_builtin_names(void);
 const char *get_alias(const char *name);
 void load_aliases(void);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 failed=0
 
-tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
+tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_dirs.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
 
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_dirs.expect
+++ b/tests/test_dirs.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "pushd /tmp\r"
+expect {
+    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    timeout { send_user "pushd output mismatch\n"; exit 1 }
+}
+send "dirs\r"
+expect {
+    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    timeout { send_user "dirs output mismatch\n"; exit 1 }
+}
+send "popd\r"
+expect {
+    -re "[\r\n]+vush> " {}
+    timeout { send_user "popd output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- implement `builtin_dirs` and register in builtin table
- document `dirs` builtin in README and man page
- expose the new builtin in the header
- add expect test for directory stack output

## Testing
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461041b2948324915adda3eceef5c3