### PR TITLE
Add history deletion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ line.
 - `kill [-SIGNAL] ID` - send a signal to the background job `ID`.
 - `export NAME=value` - set an environment variable for the shell.
 - `unset NAME` - remove an environment variable.
-- `history [-c]` - show previously entered commands or clear the history.
+- `history [-c|-d NUMBER]` - show command history, clear it with `-c`, or delete a specific entry with `-d`.
   Entries are read from and written to `~/.vush_history`.
   History size is controlled by the `VUSH_HISTSIZE` environment variable (default 1000).
 - `alias NAME=value` - define an alias or list all aliases when used without arguments.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -68,8 +68,8 @@ Set an environment variable for the shell.
 .B unset \fIname\fP
 Remove an environment variable.
 .TP
-.B history [-c]
-Show command history or clear it with \fB-c\fP.
+.B history [-c | -d \fInum\fP]
+Show command history, clear it with \fB-c\fP, or delete entry \fInum\fP with \fB-d\fP.
 The number of entries kept is controlled by the \fBVUSH_HISTSIZE\fP environment variable (default 1000).
 .TP
 .B alias \fIname\fP=\fIvalue\fP

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -308,8 +308,12 @@ static int builtin_history(char **args) {
         if (strcmp(args[1], "-c") == 0 && !args[2]) {
             clear_history();
             return 1;
+        } else if (strcmp(args[1], "-d") == 0 && args[2] && !args[3]) {
+            int id = atoi(args[2]);
+            delete_history_entry(id);
+            return 1;
         } else {
-            fprintf(stderr, "usage: history [-c]\n");
+            fprintf(stderr, "usage: history [-c|-d NUMBER]\n");
             return 1;
         }
     }
@@ -432,7 +436,7 @@ static int builtin_help(char **args) {
     printf("  kill [-SIGNAL] ID   Send a signal to job ID\n");
     printf("  export NAME=value   Set an environment variable\n");
     printf("  unset NAME          Remove an environment variable\n");
-    printf("  history [-c]   Show or clear command history\n");
+    printf("  history [-c|-d NUM]   Show or modify command history\n");
     printf("  alias NAME=VALUE    Set an alias\n");
     printf("  unalias NAME        Remove an alias\n");
     printf("  source FILE (. FILE)   Execute commands from FILE\n");

--- a/src/history.c
+++ b/src/history.c
@@ -187,3 +187,42 @@ void clear_history(void) {
     }
 }
 
+void delete_history_entry(int id) {
+    history_init();
+    HistEntry *e = head;
+    while (e && e->id != id)
+        e = e->next;
+    if (!e)
+        return;
+
+    if (e->prev)
+        e->prev->next = e->next;
+    else
+        head = e->next;
+
+    if (e->next)
+        e->next->prev = e->prev;
+    else
+        tail = e->prev;
+
+    if (cursor == e)
+        cursor = e->next;
+    if (search_cursor == e)
+        search_cursor = e->next;
+
+    free(e);
+    history_size--;
+
+    const char *home = getenv("HOME");
+    if (!home)
+        return;
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "%s/.vush_history", home);
+    FILE *f = fopen(path, "w");
+    if (!f)
+        return;
+    for (HistEntry *h = head; h; h = h->next)
+        fprintf(f, "%s\n", h->cmd);
+    fclose(f);
+}
+

--- a/src/history.h
+++ b/src/history.h
@@ -13,5 +13,6 @@ const char *history_search_prev(const char *term);
 const char *history_search_next(const char *term);
 void history_reset_search(void);
 void clear_history(void);
+void delete_history_entry(int id);
 
 #endif /* HISTORY_H */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 failed=0
 
-tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_dirs.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
+tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_dirs.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_history_delete.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
 
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_history_delete.expect
+++ b/tests/test_history_delete.expect
@@ -1,0 +1,28 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "echo first\r"
+expect {
+    -re "[\r\n]+first[\r\n]+vush> " {}
+    timeout { send_user "echo first failed\n"; exit 1 }
+}
+send "echo second\r"
+expect {
+    -re "[\r\n]+second[\r\n]+vush> " {}
+    timeout { send_user "echo second failed\n"; exit 1 }
+}
+send "history\r"
+expect {
+    -re "1 echo first[\r\n]+2 echo second[\r\n]+3 history[\r\n]+vush> " {}
+    timeout { send_user "history list failed\n"; exit 1 }
+}
+send "history -d 2\r"
+expect "vush> "
+send "history\r"
+expect {
+    -re "1 echo first[\r\n]+3 history[\r\n]+4 history -d 2[\r\n]+5 history[\r\n]+vush> " {}
+    timeout { send_user "history delete failed\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- implement `delete_history_entry` to remove an entry from memory and disk
- support `history -d <num>` builtin option
- document `history -d` in man page and README
- add test for deleting a history entry

## Testing
- `make -s`
- `cd tests && ./run_tests.sh` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461183f0908324acbd01289b55f640