### PR TITLE
Add CDPATH support to cd builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ vush> cd -
 /home/user
 vush> echo $HOME
 vush> cd ~otheruser
+vush> export CDPATH=/usr
+vush> cd bin
+/usr/bin
 vush> sleep 5 &
 ```
 
@@ -130,7 +133,7 @@ line.
 
 ## Built-in Commands
 
-- `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`. `~user` names are expanded using the password database. After a successful change `PWD` and `OLDPWD` are updated. Use `cd -` to print and switch to `$OLDPWD`.
+- `cd [dir]` - change the current directory. Without an argument it switches to `$HOME`. `~user` names are expanded using the password database. After a successful change `PWD` and `OLDPWD` are updated. Use `cd -` to print and switch to `$OLDPWD`. If `dir` does not begin with `/` or `.`, each directory listed in the `CDPATH` environment variable is searched. When a `CDPATH` entry is used the resulting path is printed.
 - `pushd dir` - push the current directory and change to `dir`.
 - `popd` - return to the directory from the stack.
 - `dirs` - display the directory stack.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -30,8 +30,10 @@ None.
 Change the current directory. Without an argument it switches to \fB$HOME\fP.
 Both \fB~\fP and \fB~user\fP expand to home directories using the password
 database. After a successful change \fB$PWD\fP and \fB$OLDPWD\fP are updated.
-Using \fBcd -\fP prints and switches to \fB$OLDPWD\fP.
-Example: \fBcd ~otheruser\fP
+Using \fBcd -\fP prints and switches to \fB$OLDPWD\fP. When the directory does
+not begin with \fB/\fP or \fB.\fP, each entry in the \fBCDPATH\fP environment
+variable is searched. If a path from \fBCDPATH\fP is used the resolved
+directory is printed on success. Example: \fBcd ~otheruser\fP
 .TP
 .B pushd dir
 Push the current directory onto a stack and switch to \fIdir\fP. The stack is

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 failed=0
 
-tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_pushd.expect test_dirs.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_history_delete.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
+tests="test_env.expect test_ps1.expect test_ps1_cmdsub.expect test_pwd.expect test_cd_dash.expect test_cdpath.expect test_pushd.expect test_dirs.expect test_tilde_user.expect test_export.expect test_unset.expect test_script.expect test_comments.expect test_history.expect test_history_clear.expect test_history_limit.expect test_history_delete.expect test_pipe.expect test_redir.expect test_source.expect test_fg.expect test_bg.expect test_kill.expect test_sequence.expect test_andor.expect test_glob.expect test_alias.expect test_alias_persist.expect test_status.expect test_badcmd.expect test_cmdsub.expect test_lineedit.expect test_completion.expect test_reverse_search.expect test_forward_search.expect test_err_redir.expect test_fd_dup.expect test_vushrc.expect test_var_brace.expect test_unmatched.expect test_jobs.expect test_type.expect"
 
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_cdpath.expect
+++ b/tests/test_cdpath.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+set timeout 5
+set dir [exec mktemp -d]
+file mkdir "$dir/a"
+set env(CDPATH) $dir
+spawn ../vush
+expect "vush> "
+send "cd a\r"
+expect {
+    -re "[\r\n]+$dir/a[\r\n]+vush> " {}
+    timeout { send_user "cdpath not used\n"; exec rm -rf $dir; exit 1 }
+}
+send "pwd\r"
+expect {
+    -re "[\r\n]+$dir/a[\r\n]+vush> " {}
+    timeout { send_user "cdpath didn't cd\n"; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect eof
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- support `CDPATH` lookup in `cd`
- print the used directory if `CDPATH` resolves it
- document `CDPATH` usage in README and manual
- add expect test for CDPATH and hook into test runner

## Testing
- `make` *(passes)*
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684614a50a548324bdc6b1405b5dba0a