### PR TITLE
Add helper to read logical lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
 
 SRCS := src/builtins.c src/execute.c src/history.c src/jobs.c src/lineedit.c \
-       src/parser.c src/dirstack.c src/main.c
+       src/parser.c src/dirstack.c src/util.c src/main.c
 
 vush: $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $(SRCS)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -10,6 +10,7 @@
 #include "parser.h"
 #include "execute.h"
 #include "dirstack.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -725,7 +726,7 @@ static int builtin_source(char **args) {
     }
 
     char line[MAX_LINE];
-    while (read_continuation_lines(input, line, sizeof(line))) {
+    while (read_logical_line(input, line, sizeof(line))) {
 
         parse_input = input;
         Command *cmds = parse_line(line);

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 #include "lineedit.h"
 #include "scriptargs.h"
 #include "options.h"
+#include "util.h"
 
 extern FILE *parse_input;
 int last_status = 0;
@@ -81,7 +82,7 @@ int main(int argc, char **argv) {
         FILE *rc = fopen(rcpath, "r");
         if (rc) {
             char rcline[MAX_LINE];
-            while (read_continuation_lines(rc, rcline, sizeof(rcline))) {
+            while (read_logical_line(rc, rcline, sizeof(rcline))) {
 
                 char *exp = expand_history(rcline);
                 if (!exp)
@@ -159,7 +160,7 @@ int main(int argc, char **argv) {
             free(prompt);
             if (!line) break;
         } else {
-            if (!read_continuation_lines(input, linebuf, sizeof(linebuf))) break;
+            if (!read_logical_line(input, linebuf, sizeof(linebuf))) break;
             line = linebuf;
         }
         char *expanded = expand_history(line);

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,6 +7,7 @@
 #include "parser.h"
 #include "builtins.h"
 #include "history.h"
+#include "util.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -1011,36 +1012,7 @@ static Command *parse_pipeline(char **p, CmdOp *op_out) {
 
 /* Read a logical line supporting backslash continuations */
 char *read_continuation_lines(FILE *f, char *buf, size_t size) {
-    if (!fgets(buf, size, f))
-        return NULL;
-    size_t len = strlen(buf);
-    if (len && buf[len - 1] == '\n')
-        buf[--len] = '\0';
-    while (len > 0) {
-        size_t bs = 0;
-        while (bs < len && buf[len - 1 - bs] == '\\')
-            bs++;
-        if (bs % 2 == 1) {
-            buf[--len] = '\0';
-            char cont[MAX_LINE];
-            if (!fgets(cont, sizeof(cont), f))
-                break;
-            size_t nlen = strlen(cont);
-            if (nlen && cont[nlen - 1] == '\n')
-                cont[--nlen] = '\0';
-            if (len + nlen < size) {
-                memcpy(buf + len, cont, nlen + 1);
-                len += nlen;
-            } else {
-                memcpy(buf + len, cont, size - len - 1);
-                buf[size - 1] = '\0';
-                len = strlen(buf);
-            }
-        } else {
-            break;
-        }
-    }
-    return buf;
+    return read_logical_line(f, buf, size);
 }
 
 Command *parse_line(char *line) {

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <string.h>
+#include "parser.h" /* for MAX_LINE */
+#include "util.h"
+
+char *read_logical_line(FILE *f, char *buf, size_t size) {
+    if (!fgets(buf, size, f))
+        return NULL;
+    size_t len = strlen(buf);
+    if (len && buf[len - 1] == '\n')
+        buf[--len] = '\0';
+    while (len > 0) {
+        size_t bs = 0;
+        while (bs < len && buf[len - 1 - bs] == '\\')
+            bs++;
+        if (bs % 2 == 1) {
+            buf[--len] = '\0';
+            char cont[MAX_LINE];
+            if (!fgets(cont, sizeof(cont), f))
+                break;
+            size_t nlen = strlen(cont);
+            if (nlen && cont[nlen - 1] == '\n')
+                cont[--nlen] = '\0';
+            if (len + nlen < size) {
+                memcpy(buf + len, cont, nlen + 1);
+                len += nlen;
+            } else {
+                memcpy(buf + len, cont, size - len - 1);
+                buf[size - 1] = '\0';
+                len = strlen(buf);
+            }
+        } else {
+            break;
+        }
+    }
+    return buf;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,5 @@
+#ifndef VUSH_UTIL_H
+#define VUSH_UTIL_H
+#include <stdio.h>
+char *read_logical_line(FILE *f, char *buf, size_t size);
+#endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- introduce `read_logical_line()` in new util module
- use the helper in main loop and `source` builtin
- compile util.c by default

## Testing
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464379cf7c8324ae20a22411983815