### PR TITLE
Refactor execute pipeline helpers

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -154,6 +154,89 @@ static void setup_redirections(PipelineSegment *seg) {
         dup2(seg->dup_err, STDERR_FILENO);
 }
 
+static void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]) {
+    if (in_fd != -1) {
+        dup2(in_fd, STDIN_FILENO);
+        close(in_fd);
+    }
+    if (seg->next) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        close(pipefd[1]);
+    }
+}
+
+static pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
+    int pipefd[2];
+    if (seg->next && pipe(pipefd) < 0) {
+        perror("pipe");
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        signal(SIGINT, SIG_DFL);
+        setup_child_pipes(seg, *in_fd, pipefd);
+        setup_redirections(seg);
+
+        for (int ai = 0; ai < seg->assign_count; ai++) {
+            char *eq = strchr(seg->assigns[ai], '=');
+            if (eq) {
+                size_t len = (size_t)(eq - seg->assigns[ai]);
+                char *name = strndup(seg->assigns[ai], len);
+                if (name) {
+                    setenv(name, eq + 1, 1);
+                    free(name);
+                }
+            }
+        }
+
+        execvp(seg->argv[0], seg->argv);
+        if (errno == ENOENT)
+            fprintf(stderr, "%s: command not found\n", seg->argv[0]);
+        else
+            fprintf(stderr, "%s: %s\n", seg->argv[0], strerror(errno));
+        exit(127);
+    } else if (pid > 0) {
+        if (*in_fd != -1)
+            close(*in_fd);
+        if (seg->next) {
+            close(pipefd[1]);
+            *in_fd = pipefd[0];
+        } else {
+            *in_fd = -1;
+        }
+    } else {
+        perror("fork");
+        if (seg->next) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+        }
+    }
+    return pid;
+}
+
+static void wait_for_pipeline(pid_t *pids, int count, int background,
+                              const char *line) {
+    int status = 0;
+    if (background) {
+        if (count > 0)
+            add_job(pids[count - 1], line);
+        last_status = 0;
+    } else {
+        for (int j = 0; j < count; j++)
+            waitpid(pids[j], &status, 0);
+        if (WIFEXITED(status))
+            last_status = WEXITSTATUS(status);
+        else if (WIFSIGNALED(status))
+            last_status = 128 + WTERMSIG(status);
+        else
+            last_status = status;
+        if (opt_errexit && last_status != 0)
+            exit(last_status);
+    }
+}
+
 static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
                                    const char *line) {
     int seg_count = 0;
@@ -165,83 +248,20 @@ static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
 
     int i = 0;
     int in_fd = -1;
-    int pipefd[2];
-
     for (PipelineSegment *seg = pipeline; seg; seg = seg->next) {
-        if (seg->next && pipe(pipefd) < 0) {
-            perror("pipe");
+        pid_t pid = fork_segment(seg, &in_fd);
+        if (pid < 0) {
             free(pids);
             last_status = 1;
             return 1;
         }
-
-        pid_t pid = fork();
-        if (pid == 0) {
-            signal(SIGINT, SIG_DFL);
-            if (in_fd != -1) {
-                dup2(in_fd, STDIN_FILENO);
-                close(in_fd);
-            }
-            if (seg->next) {
-                close(pipefd[0]);
-                dup2(pipefd[1], STDOUT_FILENO);
-                close(pipefd[1]);
-            }
-
-            setup_redirections(seg);
-
-            for (int ai = 0; ai < seg->assign_count; ai++) {
-                char *eq = strchr(seg->assigns[ai], '=');
-                if (eq) {
-                    size_t len = (size_t)(eq - seg->assigns[ai]);
-                    char *name = strndup(seg->assigns[ai], len);
-                    if (name) {
-                        setenv(name, eq + 1, 1);
-                        free(name);
-                    }
-                }
-            }
-
-            execvp(seg->argv[0], seg->argv);
-            if (errno == ENOENT)
-                fprintf(stderr, "%s: command not found\n", seg->argv[0]);
-            else
-                fprintf(stderr, "%s: %s\n", seg->argv[0], strerror(errno));
-            exit(127);
-        } else if (pid < 0) {
-            perror("fork");
-        } else {
-            pids[i++] = pid;
-            if (in_fd != -1)
-                close(in_fd);
-            if (seg->next) {
-                close(pipefd[1]);
-                in_fd = pipefd[0];
-            }
-        }
+        pids[i++] = pid;
     }
 
     if (in_fd != -1)
         close(in_fd);
 
-    int status = 0;
-    if (background) {
-        if (i > 0)
-            add_job(pids[i - 1], line);
-        last_status = 0;
-    } else {
-        for (int j = 0; j < i; j++)
-            waitpid(pids[j], &status, 0);
-        if (WIFEXITED(status))
-            last_status = WEXITSTATUS(status);
-        else if (WIFSIGNALED(status))
-            last_status = 128 + WTERMSIG(status);
-        else
-            last_status = status;
-        if (opt_errexit && last_status != 0)
-            exit(last_status);
-    }
-
+    wait_for_pipeline(pids, i, background, line);
     free(pids);
     return last_status;
 }


### PR DESCRIPTION
## Summary
- break pipeline spawning into helpers
- call helpers from the wrapper `spawn_pipeline_segments`

## Testing
- `make`
- `make test` *(fails: ./run_tests.sh: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846561b4aac8324b4e804f1e8971143