### PR TITLE
Fix source builtin input restoration

### DIFF
--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -59,15 +59,16 @@ int builtin_source(char **args) {
         return 1;
     }
 
+    FILE *prev_input = parse_input;
     FILE *input = fopen(args[1], "r");
     if (!input) {
         perror(args[1]);
         return 1;
     }
 
+    parse_input = input;
     char line[MAX_LINE];
     while (read_logical_line(input, line, sizeof(line))) {
-        parse_input = input;
         Command *cmds = parse_line(line);
         if (!cmds || !cmds->pipeline || !cmds->pipeline->argv[0]) {
             free_commands(cmds);
@@ -90,7 +91,7 @@ int builtin_source(char **args) {
         free_commands(cmds);
     }
     fclose(input);
-    parse_input = stdin;
+    parse_input = prev_input;
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- ensure builtin `source` preserves `parse_input` across nested calls
- set `parse_input` back to previous value after sourcing completes

## Testing
- `make test` *(fails: `/usr/bin/expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466791e3148324b5edade4f125c003