### PR TITLE
Fix implicit declaration in builtins_misc

### DIFF
--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -4,6 +4,7 @@
 #include "history.h"
 #include "parser.h"
 #include "execute.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- include util.h in builtins_misc.c so `read_logical_line` is declared

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6846683968908324be9da1b88c4c1cf4