### PR TITLE
Handle asprintf failure in gather_until

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -731,7 +731,13 @@ static char *gather_until(char **p, const char **stops, int nstops, int *idx) {
         }
         if (res) {
             char *tmp;
-            asprintf(&tmp, "%s %s", res, tok);
+            int ret = asprintf(&tmp, "%s %s", res, tok);
+            if (ret == -1 || tmp == NULL) {
+                free(res);
+                free(tok);
+                res = NULL;
+                return NULL;
+            }
             free(res);
             res = tmp;
         } else {


### PR DESCRIPTION
## Summary
- check the return value of `asprintf` when building token lists

## Testing
- `make test` *(fails: `./test_env.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684668bd7d18832487076822cdf7e2fd