### PR TITLE
Handle allocation failures in run_function

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -343,8 +343,22 @@ static int run_function(Command *body, char **args) {
     char **old_argv = script_argv;
     script_argc = argc - 1;
     script_argv = calloc(argc + 1, sizeof(char *));
-    for (int i = 0; i < argc; i++)
+    if (!script_argv) {
+        script_argc = old_argc;
+        script_argv = old_argv;
+        return 1;
+    }
+    for (int i = 0; i < argc; i++) {
         script_argv[i] = strdup(args[i]);
+        if (!script_argv[i]) {
+            for (int j = 0; j < i; j++)
+                free(script_argv[j]);
+            free(script_argv);
+            script_argv = old_argv;
+            script_argc = old_argc;
+            return 1;
+        }
+    }
     script_argv[argc] = NULL;
     func_return = 0;
     run_command_list(body, NULL);


### PR DESCRIPTION
## Summary
- validate `script_argv` after `calloc`
- clean up and restore previous state on `strdup` failure

## Testing
- `make`
- `./test_function.expect` *(fails: cannot execute expect script)*

------
https://chatgpt.com/codex/tasks/task_e_68466943c18483248f733f941bb25786