### PR TITLE
Fix unused stop variable

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -837,7 +837,6 @@ static Command *parse_for_clause(char **p) {
     if (!tok || strcmp(tok, "in") != 0) { free(var); free(tok); return NULL; }
     free(tok);
     char **words = NULL; int count = 0;
-    const char *stop[] = {"do"};
     while (1) {
         while (**p == ' ' || **p == '\t') (*p)++;
         if (**p == '\0') { free(var); free(words); return NULL; }


### PR DESCRIPTION
## Summary
- remove an unused `stop` array from `parse_for_clause`
- rebuild to ensure no warnings

## Testing
- `make vush`
- `./tests/test_for.expect` *(fails: `cannot execute: required file not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684669e1ab5c83248f94cfa869077f8d