### PR TITLE
Fix shift handling for script arguments

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -81,8 +81,9 @@ void free_shell_vars(void) {
 int builtin_shift(char **args) {
     (void)args;
     if (script_argc > 0) {
-        for (int i = 1; i < script_argc; i++)
-            script_argv[i] = script_argv[i + 1];
+        free(script_argv[1]);
+        for (int i = 2; i <= script_argc; i++)
+            script_argv[i - 1] = script_argv[i];
         script_argc--;
         script_argv[script_argc + 1] = NULL;
     }


### PR DESCRIPTION
## Summary
- release memory for `$1` during `shift`
- start shifting parameters from the second index so `$0` stays unchanged

## Testing
- `make test` *(fails: `test_env.expect` etc. not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466cbf43e88324802c2f76776a3d4b