### PR TITLE
Use last status for exit

### DIFF
--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -19,7 +19,7 @@ extern FILE *parse_input;
 #include <signal.h>
 
 int builtin_exit(char **args) {
-    int status = 0;
+    int status = last_status;
     if (args[1]) {
         char *end;
         errno = 0;


### PR DESCRIPTION
## Summary
- default `exit` status to previous command's status

## Testing
- `make vush`
- `make test` *(fails: `/usr/bin/expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466daffbd48324b46f9e9a4a95737e