### PR TITLE
Add nested alias support

### DIFF
--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -19,6 +19,19 @@ expect "vush> "
 send "alias\r"
 expect "vush> "
 
+# Nested alias expansion
+send "alias first='echo nested'\r"
+expect "vush> "
+send "alias second=first\r"
+expect "vush> "
+send "second test\r"
+expect {
+    -re "[\r\n]+nested test[\r\n]+vush> " {}
+    timeout { send_user "nested alias failed\n"; exit 1 }
+}
+send "unalias first second\r"
+expect "vush> "
+
 # Create many aliases to ensure dynamic allocation works
 for {set i 0} {$i < 40} {incr i} {
     send "alias a$i='echo hi$i'\r"


### PR DESCRIPTION
## Summary
- support nested alias expansion with loop detection
- test alias recursion

## Testing
- `make test` *(fails: `./run_tests.sh: 9: ./test_env.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68466e65f76c8324855f6bd62f852bfe