### PR TITLE
Refactor line edit helpers into modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ MANPREFIX ?= $(PREFIX)/share/man
 SRCS := src/builtins.c src/builtins_fs.c src/builtins_jobs.c \
        src/builtins_alias.c src/builtins_func.c src/builtins_vars.c \
        src/builtins_misc.c src/execute.c src/history.c \
-       src/jobs.c src/lineedit.c src/parser.c src/lexer.c src/arith.c \
+       src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
+       src/parser.c src/lexer.c src/arith.c \
        src/dirstack.c src/util.c \
        src/main.c
 

--- a/src/completion.c
+++ b/src/completion.c
@@ -1,0 +1,87 @@
+#define _GNU_SOURCE
+#include "completion.h"
+#include "builtins.h"
+#include "parser.h" /* for MAX_LINE */
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int cmpstr(const void *a, const void *b) {
+    const char *aa = *(const char **)a;
+    const char *bb = *(const char **)b;
+    return strcmp(aa, bb);
+}
+
+void handle_completion(const char *prompt, char *buf, int *lenp, int *posp,
+                       int *disp_lenp) {
+    int start = *posp;
+    while (start > 0 && buf[start - 1] != ' ' && buf[start - 1] != '\t')
+        start--;
+
+    char prefix[MAX_LINE];
+    memcpy(prefix, &buf[start], *posp - start);
+    prefix[*posp - start] = '\0';
+
+    int mcount = 0;
+    int mcap = 16;
+    char **matches = malloc(mcap * sizeof(char *));
+    if (!matches)
+        matches = NULL;
+    const char **bn = get_builtin_names();
+    if (matches)
+    for (int i = 0; bn[i]; i++) {
+        if (strncmp(bn[i], prefix, *posp - start) == 0) {
+            if (mcount == mcap) {
+                mcap *= 2;
+                matches = realloc(matches, mcap * sizeof(char *));
+                if (!matches) break;
+            }
+            matches[mcount++] = strdup(bn[i]);
+        }
+    }
+    DIR *d = opendir(".");
+    if (d && matches) {
+        struct dirent *de;
+        while ((de = readdir(d))) {
+            if (strncmp(de->d_name, prefix, *posp - start) == 0) {
+                if (mcount == mcap) {
+                    mcap *= 2;
+                    matches = realloc(matches, mcap * sizeof(char *));
+                    if (!matches) break;
+                }
+                matches[mcount++] = strdup(de->d_name);
+            }
+        }
+        closedir(d);
+    }
+    if (matches) {
+        if (mcount == 1) {
+            const char *match = matches[0];
+            int mlen = strlen(match);
+            if (*lenp + mlen - (*posp - start) < MAX_LINE - 1) {
+                memmove(&buf[start + mlen], &buf[*posp], *lenp - *posp);
+                memcpy(&buf[start], match, mlen);
+                *lenp += mlen - (*posp - start);
+                *posp = start + mlen;
+                buf[*lenp] = '\0';
+                printf("\r%s%s", prompt, buf);
+                if (*lenp > *disp_lenp)
+                    *disp_lenp = *lenp;
+            }
+        } else if (mcount > 1) {
+            qsort(matches, mcount, sizeof(char *), cmpstr);
+            printf("\r\n");
+            for (int i = 0; i < mcount; i++)
+                printf("%s%s", matches[i], i == mcount - 1 ? "" : " ");
+            printf("\r\n");
+            printf("\r%s%s", prompt, buf);
+            if (*lenp > *disp_lenp)
+                *disp_lenp = *lenp;
+        }
+        for (int i = 0; i < mcount; i++)
+            free(matches[i]);
+        free(matches);
+    }
+}
+

--- a/src/completion.h
+++ b/src/completion.h
@@ -1,0 +1,7 @@
+#ifndef COMPLETION_H
+#define COMPLETION_H
+
+void handle_completion(const char *prompt, char *buf, int *lenp, int *posp,
+                       int *disp_lenp);
+
+#endif /* COMPLETION_H */

--- a/src/history_search.c
+++ b/src/history_search.c
@@ -1,0 +1,161 @@
+#include "history_search.h"
+#include "history.h"
+#include "parser.h" /* for MAX_LINE */
+#include <termios.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+
+/* helper to redraw the search prompt */
+static int redraw_search(const char *label, const char *search,
+                         const char *match, int prev_len) {
+    char line[MAX_LINE * 2];
+    int len = snprintf(line, sizeof(line), "(%s)`%s`: %s",
+                        label, search, match ? match : "");
+    printf("\r%s", line);
+    if (prev_len > len) {
+        for (int i = len; i < prev_len; i++)
+            putchar(' ');
+        printf("\r%s", line);
+    }
+    fflush(stdout);
+    return len;
+}
+
+int reverse_search(const char *prompt, char *buf, int *lenp, int *posp,
+                   int *disp_lenp) {
+    char search[MAX_LINE];
+    int s_len = 0;
+    search[0] = '\0';
+    char saved[MAX_LINE];
+    int saved_len = *lenp;
+    int saved_pos = *posp;
+    strncpy(saved, buf, MAX_LINE - 1);
+    saved[MAX_LINE - 1] = '\0';
+    const char *match = NULL;
+    history_reset_search();
+    int disp = 0;
+
+    while (1) {
+        disp = redraw_search("reverse-i-search", search, match, disp);
+        char c;
+        if (read(STDIN_FILENO, &c, 1) != 1)
+            return -1;
+        if (c == 0x07 || c == '\033') { /* Ctrl-G or Esc cancel */
+            strncpy(buf, saved, MAX_LINE - 1);
+            buf[MAX_LINE - 1] = '\0';
+            *lenp = saved_len;
+            *posp = saved_pos;
+            printf("\r%s%s", prompt, buf);
+            if (*lenp > *disp_lenp)
+                *disp_lenp = *lenp;
+            history_reset_search();
+            return 0;
+        } else if (c == 0x12) { /* Ctrl-R cycle */
+            const char *h = history_search_prev(search);
+            if (h)
+                match = h;
+        } else if (c == 0x7f) { /* backspace */
+            if (s_len > 0) {
+                search[--s_len] = '\0';
+                history_reset_search();
+                match = history_search_prev(search);
+            }
+        } else if (c == '\r' || c == '\n') {
+            if (match) {
+                strncpy(buf, match, MAX_LINE - 1);
+                buf[MAX_LINE - 1] = '\0';
+                *lenp = *posp = strlen(buf);
+                *disp_lenp = *lenp;
+                printf("\r%s%s\n", prompt, buf);
+            } else {
+                printf("\r\n");
+                *lenp = *posp = 0;
+                buf[0] = '\0';
+            }
+            history_reset_search();
+            return 1;
+        } else if (c >= 32 && c < 127) {
+            if (s_len < MAX_LINE - 1) {
+                search[s_len++] = c;
+                search[s_len] = '\0';
+                history_reset_search();
+                match = history_search_prev(search);
+            }
+        }
+    }
+}
+
+int forward_search(const char *prompt, char *buf, int *lenp, int *posp,
+                   int *disp_lenp) {
+    char search[MAX_LINE];
+    int s_len = 0;
+    search[0] = '\0';
+    char saved[MAX_LINE];
+    int saved_len = *lenp;
+    int saved_pos = *posp;
+    strncpy(saved, buf, MAX_LINE - 1);
+    saved[MAX_LINE - 1] = '\0';
+    const char *match = NULL;
+    history_reset_search();
+    int disp = 0;
+
+    while (1) {
+        disp = redraw_search("forward-i-search", search, match, disp);
+        char c;
+        if (read(STDIN_FILENO, &c, 1) != 1)
+            return -1;
+        if (c == 0x07 || c == '\033') {
+            strncpy(buf, saved, MAX_LINE - 1);
+            buf[MAX_LINE - 1] = '\0';
+            *lenp = saved_len;
+            *posp = saved_pos;
+            printf("\r%s%s", prompt, buf);
+            if (*lenp > *disp_lenp)
+                *disp_lenp = *lenp;
+            history_reset_search();
+            return 0;
+        } else if (c == 0x13) { /* Ctrl-S cycle */
+            const char *h = history_search_next(search);
+            if (h)
+                match = h;
+        } else if (c == 0x7f) {
+            if (s_len > 0) {
+                search[--s_len] = '\0';
+                history_reset_search();
+                match = history_search_next(search);
+            }
+        } else if (c == '\r' || c == '\n') {
+            if (match) {
+                strncpy(buf, match, MAX_LINE - 1);
+                buf[MAX_LINE - 1] = '\0';
+                *lenp = *posp = strlen(buf);
+                *disp_lenp = *lenp;
+                printf("\r%s%s\n", prompt, buf);
+            } else {
+                printf("\r\n");
+                *lenp = *posp = 0;
+                buf[0] = '\0';
+            }
+            history_reset_search();
+            return 1;
+        } else if (c >= 32 && c < 127) {
+            if (s_len < MAX_LINE - 1) {
+                search[s_len++] = c;
+                search[s_len] = '\0';
+                history_reset_search();
+                match = history_search_next(search);
+            }
+        }
+    }
+}
+
+int handle_history_search(char c, const char *prompt, char *buf,
+                          int *lenp, int *posp, int *disp_lenp) {
+    if (c == 0x12)
+        return reverse_search(prompt, buf, lenp, posp, disp_lenp);
+    else if (c == 0x13)
+        return forward_search(prompt, buf, lenp, posp, disp_lenp);
+    return 0;
+}
+

--- a/src/history_search.h
+++ b/src/history_search.h
@@ -1,0 +1,11 @@
+#ifndef HISTORY_SEARCH_H
+#define HISTORY_SEARCH_H
+
+int reverse_search(const char *prompt, char *buf, int *lenp, int *posp,
+                   int *disp_lenp);
+int forward_search(const char *prompt, char *buf, int *lenp, int *posp,
+                   int *disp_lenp);
+int handle_history_search(char c, const char *prompt, char *buf,
+                          int *lenp, int *posp, int *disp_lenp);
+
+#endif /* HISTORY_SEARCH_H */


### PR DESCRIPTION
## Summary
- extract history search logic to `history_search.c`
- move completion code to new `completion.c`
- simplify `lineedit.c` to call helper modules
- update Makefile for new source files

## Testing
- `make`
- `./tests/run_tests.sh` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684679f1a2c48324b1279e71e20ac598