### PR TITLE
Refactor pipeline management into new modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCS := src/builtins.c src/builtins_fs.c src/builtins_jobs.c \
        src/builtins_misc.c src/execute.c src/history.c \
        src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
        src/parser.c src/lexer.c src/arith.c \
-       src/dirstack.c src/util.c \
+       src/dirstack.c src/util.c src/pipeline.c src/func_exec.c \
        src/main.c
 
 vush: $(SRCS)

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "parser.h" /* for MAX_LINE */
+#include "func_exec.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,7 +11,6 @@
 #include <linux/limits.h>
 
 extern int last_status;
-extern int func_return;
 
 struct func_entry {
     char *name;

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -4,6 +4,7 @@
 #include "history.h"
 #include "parser.h"
 #include "execute.h"
+#include "func_exec.h"
 #include "scriptargs.h"
 #include "arith.h"
 #include "options.h"
@@ -15,7 +16,6 @@
 #include <linux/limits.h>
 
 extern int last_status;
-extern int func_return;
 
 struct var_entry {
     char *name;

--- a/src/func_exec.c
+++ b/src/func_exec.c
@@ -1,0 +1,45 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+
+#include "func_exec.h"
+#include "execute.h"
+#include "scriptargs.h"
+
+extern int last_status;
+
+int func_return = 0;
+
+int run_function(Command *body, char **args) {
+    int argc = 0;
+    while (args[argc]) argc++;
+    int old_argc = script_argc;
+    char **old_argv = script_argv;
+    script_argc = argc - 1;
+    script_argv = calloc(argc + 1, sizeof(char *));
+    if (!script_argv) {
+        script_argc = old_argc;
+        script_argv = old_argv;
+        return 1;
+    }
+    for (int i = 0; i < argc; i++) {
+        script_argv[i] = strdup(args[i]);
+        if (!script_argv[i]) {
+            for (int j = 0; j < i; j++)
+                free(script_argv[j]);
+            free(script_argv);
+            script_argv = old_argv;
+            script_argc = old_argc;
+            return 1;
+        }
+    }
+    script_argv[argc] = NULL;
+    func_return = 0;
+    run_command_list(body, NULL);
+    for (int i = 0; i < argc; i++)
+        free(script_argv[i]);
+    free(script_argv);
+    script_argv = old_argv;
+    script_argc = old_argc;
+    return last_status;
+}

--- a/src/func_exec.h
+++ b/src/func_exec.h
@@ -1,0 +1,8 @@
+#ifndef FUNC_EXEC_H
+#define FUNC_EXEC_H
+#include "parser.h"
+
+extern int func_return;
+int run_function(Command *body, char **args);
+
+#endif /* FUNC_EXEC_H */

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1,0 +1,99 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/wait.h>
+
+#include "pipeline.h"
+#include "jobs.h"
+#include "options.h"
+extern int last_status;
+
+extern void setup_redirections(PipelineSegment *seg);
+
+void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]) {
+    if (in_fd != -1) {
+        dup2(in_fd, STDIN_FILENO);
+        close(in_fd);
+    }
+    if (seg->next) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        close(pipefd[1]);
+    }
+}
+
+pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
+    int pipefd[2];
+    if (seg->next && pipe(pipefd) < 0) {
+        perror("pipe");
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        signal(SIGINT, SIG_DFL);
+        setup_child_pipes(seg, *in_fd, pipefd);
+        setup_redirections(seg);
+
+        for (int ai = 0; ai < seg->assign_count; ai++) {
+            char *eq = strchr(seg->assigns[ai], '=');
+            if (eq) {
+                size_t len = (size_t)(eq - seg->assigns[ai]);
+                char *name = strndup(seg->assigns[ai], len);
+                if (name) {
+                    setenv(name, eq + 1, 1);
+                    free(name);
+                }
+            }
+        }
+
+        execvp(seg->argv[0], seg->argv);
+        if (errno == ENOENT)
+            fprintf(stderr, "%s: command not found\n", seg->argv[0]);
+        else
+            fprintf(stderr, "%s: %s\n", seg->argv[0], strerror(errno));
+        exit(127);
+    } else if (pid > 0) {
+        if (*in_fd != -1)
+            close(*in_fd);
+        if (seg->next) {
+            close(pipefd[1]);
+            *in_fd = pipefd[0];
+        } else {
+            *in_fd = -1;
+        }
+    } else {
+        perror("fork");
+        if (seg->next) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+        }
+    }
+    return pid;
+}
+
+void wait_for_pipeline(pid_t *pids, int count, int background, const char *line) {
+    int status = 0;
+    if (background) {
+        if (count > 0)
+            add_job(pids[count - 1], line);
+        last_status = 0;
+    } else {
+        for (int j = 0; j < count; j++)
+            waitpid(pids[j], &status, 0);
+        if (WIFEXITED(status))
+            last_status = WEXITSTATUS(status);
+        else if (WIFSIGNALED(status))
+            last_status = 128 + WTERMSIG(status);
+        else
+            last_status = status;
+        if (opt_errexit && last_status != 0)
+            exit(last_status);
+    }
+}
+

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -1,0 +1,10 @@
+#ifndef PIPELINE_H
+#define PIPELINE_H
+#include "parser.h"
+#include <sys/types.h>
+
+void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]);
+pid_t fork_segment(PipelineSegment *seg, int *in_fd);
+void wait_for_pipeline(pid_t *pids, int count, int background, const char *line);
+
+#endif /* PIPELINE_H */


### PR DESCRIPTION
## Summary
- add `pipeline.c` and `func_exec.c` modules
- export helper declarations in new headers
- update build system and builtin modules for new headers
- adjust `execute.c` to delegate to the new modules

## Testing
- `make clean && make`
- `make test` *(fails: ./test_env.expect: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467b54e8408324b11550f525401ab5