### PR TITLE
Add missing command check in pipeline

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -210,6 +210,12 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
     if (apply_temp_assignments(pipeline))
         return last_status;
 
+    if (!pipeline->argv[0]) {
+        fprintf(stderr, "syntax error: missing command\n");
+        last_status = 1;
+        return last_status;
+    }
+
     return spawn_pipeline_segments(pipeline, background, line);
 }
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -35,6 +35,12 @@ void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]) {
  * and redirections before executing the command.
  */
 pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
+    if (!seg->argv[0]) {
+        fprintf(stderr, "syntax error: missing command\n");
+        last_status = 1;
+        return -1;
+    }
+
     int pipefd[2];
     if (seg->next && pipe(pipefd) < 0) {
         perror("pipe");


### PR DESCRIPTION
## Summary
- validate pipeline segments before execution
- catch missing commands in run_pipeline_internal
- prevent forking when a pipeline segment has no argv

## Testing
- `make`
- `make test` *(fails: `./run_tests.sh: ... not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846f2f30c1883248809844c7ccd04a5