### PR TITLE
Fix memory leak in alias expansion

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -522,8 +522,11 @@ static int expand_aliases(PipelineSegment *seg, int *argc, char *tok) {
     collect_alias_tokens(orig, tokens, &count, visited, 0);
     free(orig);
 
-    if (!initial_alias)
+    if (!initial_alias) {
+        for (int i = 0; i < count; i++)
+            free(tokens[i]);
         return 0;
+    }
 
     for (int i = 0; i < count && *argc < MAX_TOKENS - 1; i++)
         seg->argv[(*argc)++] = tokens[i];


### PR DESCRIPTION
## Summary
- free collected alias tokens when there is no alias to expand

## Testing
- `make`
- `make test` *(fails: `./run_tests.sh: 9: ./test_env.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846f3f27aac8324a3baffc26775272b