### PR TITLE
Add debugging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,23 @@ make test
 
 The test scripts under `tests/` will launch `./vush` with predefined commands and verify the output.
 
+## Debugging
+
+Compile with debugging information so that stack traces are produced:
+
+```sh
+make clean
+make CFLAGS="-g -Wall -Wextra -std=c99"
+```
+
+Run the shell under `gdb` or `valgrind` to catch crashes. Using
+
+```sh
+valgrind ./vush
+```
+
+will record a backtrace on failure, making it easier to locate memory errors.
+
 ## License
 
 This project is licensed under the terms of the GNU General Public License


### PR DESCRIPTION
## Summary
- document how to build with debug info
- explain running `valgrind ./vush` to capture stack traces

## Testing
- `make test` *(fails: ./test_*.expect not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f570ce248324a3a3111ef6cd9592