### PR TITLE
Fix empty command handling in fork_segment

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -210,7 +210,7 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
     if (apply_temp_assignments(pipeline))
         return last_status;
 
-    if (!pipeline->argv[0]) {
+    if (!pipeline->argv[0] || pipeline->argv[0][0] == '\0') {
         fprintf(stderr, "syntax error: missing command\n");
         last_status = 1;
         return last_status;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -35,7 +35,7 @@ void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]) {
  * and redirections before executing the command.
  */
 pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
-    if (!seg->argv[0]) {
+    if (!seg->argv[0] || seg->argv[0][0] == '\0') {
         fprintf(stderr, "syntax error: missing command\n");
         last_status = 1;
         return -1;


### PR DESCRIPTION
## Summary
- check if `seg->argv[0]` is an empty string before calling `fork`
- do the same check when launching an entire pipeline

## Testing
- `tests/run_tests.sh` *(fails: `./test_basic_cmd.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847121d45f08324ad2b21d498c24028