### PR TITLE
Fix varbuf overflow warnings

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -211,8 +211,12 @@ static char *parse_quoted_word(char **p, int *quoted, int *do_expand_out) {
                 if (**p == '}') {
                     (*p)++;
                     name[n] = '\0';
-                    char varbuf[MAX_LINE];
-                    snprintf(varbuf, sizeof(varbuf), "${%s}", name);
+                    char varbuf[MAX_LINE + 4];
+                    int needed = snprintf(varbuf, sizeof(varbuf), "${%s}", name);
+                    if (needed < 0 || needed >= (int)sizeof(varbuf)) {
+                        fprintf(stderr, "variable expansion too long\n");
+                        return NULL;
+                    }
                     char *res = expand_var(varbuf);
                     for (int ci = 0; res[ci] && len < MAX_LINE - 1; ci++)
                         buf[len++] = res[ci];
@@ -304,8 +308,12 @@ char *read_token(char **p, int *quoted) {
             if (**p == '}') {
                 (*p)++;
                 name[n] = '\0';
-                char varbuf[MAX_LINE];
-                snprintf(varbuf, sizeof(varbuf), "${%s}", name);
+                char varbuf[MAX_LINE + 4];
+                int needed = snprintf(varbuf, sizeof(varbuf), "${%s}", name);
+                if (needed < 0 || needed >= (int)sizeof(varbuf)) {
+                    fprintf(stderr, "variable expansion too long\n");
+                    return NULL;
+                }
                 char *res = expand_var(varbuf);
                 for (int ci = 0; res[ci] && len < MAX_LINE - 1; ci++)
                     buf[len++] = res[ci];


### PR DESCRIPTION
## Summary
- avoid truncated writes when expanding variables in `parse_quoted_word` and `read_token`

## Testing
- `make`
- `make test` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684736efb7988324a5e66904434935f4