### PR TITLE
Include arith header in execute.c

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "pipeline.h"
 #include "func_exec.h"
+#include "arith.h"
 
 extern int last_status;
 


### PR DESCRIPTION
## Summary
- include `arith.h` in `execute.c` so `eval_arith` is declared

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6847b12acd808324ac847633a7309761