### PR TITLE
Add pipefail and noclobber docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and a few built-in commands.
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
- - Shell options toggled with `set -e`, `set -u`, `set -x` and `set -o OPTION`
+- Shell options toggled with `set -e`, `set -u`, `set -x` and `set -o OPTION` such as `pipefail` or `noclobber`
 
 ## Building
 
@@ -221,6 +221,12 @@ one
 two
 three
 ```
+### Shell Options
+
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure,
+`set -u` errors on undefined variables and `set -x` prints each command before execution.
+The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
+
 
 ## Built-in Commands
 


### PR DESCRIPTION
## Summary
- mention `pipefail` and `noclobber` options in feature list
- describe these options in the shell options section

## Testing
- `make test` *(fails: `test_basic_cmd.expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b6ec74c88324aca765bf925c71d5