### PR TITLE
Remove linux limits headers

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
-#include <linux/limits.h>
 
 struct alias_entry {
     char *name;

--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
-#include <linux/limits.h>
 
 int builtin_cd(char **args) {
     char prev[PATH_MAX];

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
-#include <linux/limits.h>
 
 extern int last_status;
 

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -11,7 +11,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <limits.h>
-#include <linux/limits.h>
 #include <ctype.h>
 #include <sys/stat.h>
 #include <fnmatch.h>

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -13,7 +13,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
-#include <linux/limits.h>
 
 extern int last_status;
 


### PR DESCRIPTION
## Summary
- drop unused `<linux/limits.h>` includes

## Testing
- `make`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b8f4e86883248d30d162834de0ef