### PR TITLE
Add multi-digit positional parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ one two
 ### Positional Parameters
 
 When a script file is executed, the remaining command line arguments are stored
-as positional parameters.  `$0` expands to the script path while `$1` through
-`$9` contain subsequent arguments.  `$@` expands to all parameters separated by
-spaces and `$#` gives the count of arguments.  The `shift` builtin discards the
-first parameter and shifts the rest down.
+as positional parameters.  `$0` expands to the script path and `$1`, `$2`, and
+so on expand to subsequent parameters.  Indexes beyond nine can be referenced
+using the full number such as `$10` or `$11`.  `$@` expands to all parameters
+separated by spaces and `$#` gives the count of arguments.  The `shift` builtin
+discards the first parameter and shifts the rest down.
 
 ## Assignments
 

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -36,10 +36,12 @@ Execute the provided command string non-interactively and exit with its
 status.
 .SH POSITIONAL PARAMETERS
 When executing a script file, the remaining command line words become
-positional parameters.  \$0 expands to the script path, \$1 through \$9
-refer to subsequent parameters, \$@ expands to all parameters separated
-by spaces and \$# expands to the number of parameters.  The
-\fBshift\fP builtin discards the first parameter and moves the rest down.
+positional parameters.  \$0 expands to the script path and \$1, \$2 and
+so on expand to subsequent parameters. Indexes beyond nine may be
+referenced using the full number such as \$10 or \$11.  \$@ expands to
+all parameters separated by spaces and \$# expands to the number of
+parameters.  The \fBshift\fP builtin discards the first parameter and
+moves the rest down.
 
 .SH ASSIGNMENTS
 .PP

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -529,23 +529,26 @@ char *expand_var(const char *token) {
         }
         return res;
     }
-    if (token[1] >= '0' && token[1] <= '9' && token[2] == '\0') {
-        int idx = token[1] - '0';
-        const char *val = NULL;
-        if (script_argv) {
-            if (idx == 0)
-                val = script_argv[0];
-            else if (idx <= script_argc)
-                val = script_argv[idx];
-        }
-        if (!val) {
-            if (opt_nounset) {
-                fprintf(stderr, "%c: unbound variable\n", token[1]);
-                last_status = 1;
+    if (token[1] >= '0' && token[1] <= '9') {
+        char *end;
+        long idx = strtol(token + 1, &end, 10);
+        if (*end == '\0') {
+            const char *val = NULL;
+            if (script_argv) {
+                if (idx == 0)
+                    val = script_argv[0];
+                else if (idx <= script_argc)
+                    val = script_argv[idx];
             }
-            val = "";
+            if (!val) {
+                if (opt_nounset) {
+                    fprintf(stderr, "%ld: unbound variable\n", idx);
+                    last_status = 1;
+                }
+                val = "";
+            }
+            return strdup(val);
         }
-        return strdup(val);
     }
     const char *val = get_shell_var(token + 1);
     if (!val) val = getenv(token + 1);


### PR DESCRIPTION
## Summary
- expand `$NUM` where `NUM` has multiple digits
- document support for `$10`, `$11` etc.

## Testing
- `make -j$(nproc)`
- `tests/run_tests.sh` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847baa421fc8324849ab8d7126d3dd1