### PR TITLE
Implement $* expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ When a script file is executed, the remaining command line arguments are stored
 as positional parameters.  `$0` expands to the script path and `$1`, `$2`, and
 so on expand to subsequent parameters.  Indexes beyond nine can be referenced
 using the full number such as `$10` or `$11`.  `$@` expands to all parameters
-separated by spaces and `$#` gives the count of arguments.  The `shift` builtin
+separated by spaces while `$*` joins them using the first character of `IFS`
+(space by default).  `$#` gives the count of arguments.  The `shift` builtin
 discards the first parameter and shifts the rest down.
 
 ## Assignments

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -39,7 +39,8 @@ When executing a script file, the remaining command line words become
 positional parameters.  \$0 expands to the script path and \$1, \$2 and
 so on expand to subsequent parameters. Indexes beyond nine may be
 referenced using the full number such as \$10 or \$11.  \$@ expands to
-all parameters separated by spaces and \$# expands to the number of
+all parameters separated by spaces while \$* joins them using the first
+character of \fBIFS\fP (space by default).  \$# expands to the number of
 parameters.  The \fBshift\fP builtin discards the first parameter and
 moves the rest down.
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -529,6 +529,28 @@ char *expand_var(const char *token) {
         }
         return res;
     }
+    if (strcmp(token, "$*") == 0) {
+        if (!script_argv || script_argc == 0)
+            return strdup("");
+        const char *ifs = get_shell_var("IFS");
+        if (!ifs) ifs = getenv("IFS");
+        char sep = (ifs && *ifs) ? ifs[0] : ' ';
+        size_t len = 0;
+        for (int i = 1; i <= script_argc; i++)
+            len += strlen(script_argv[i]) + 1;
+        char *res = malloc(len);
+        if (!res) return NULL;
+        res[0] = '\0';
+        for (int i = 1; i <= script_argc; i++) {
+            strcat(res, script_argv[i]);
+            if (i < script_argc) {
+                size_t l = strlen(res);
+                res[l] = sep;
+                res[l+1] = '\0';
+            }
+        }
+        return res;
+    }
     if (token[1] >= '0' && token[1] <= '9') {
         char *end;
         long idx = strtol(token + 1, &end, 10);


### PR DESCRIPTION
## Summary
- support `$*` parameter expansion in lexer
- use IFS when joining parameters for `$*`
- document `$*` usage in README and manual page

## Testing
- `make clean && make vush`
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbb1336c8324bdcba471f960c517