### PR TITLE
Refactor read builtin

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -222,21 +222,79 @@ int builtin_set(char **args) {
     return 1;
 }
 
+/* ---- helper functions for builtin_read -------------------------------- */
+
+static int parse_read_options(char **args, int *raw, const char **array_name,
+                              int *idx) {
+    int i = 1;
+    *raw = 0;
+    *array_name = NULL;
+
+    if (args[i] && strcmp(args[i], "-r") == 0) {
+        *raw = 1;
+        i++;
+    }
+
+    if (args[i] && strcmp(args[i], "-a") == 0 && args[i + 1]) {
+        *array_name = args[i + 1];
+        i += 2;
+    }
+
+    if (!args[i])
+        return -1;
+
+    *idx = i;
+    return 0;
+}
+
+static char **split_array_values(char *line, int *count) {
+    char **vals = NULL;
+    *count = 0;
+    char *p = line;
+    while (*p) {
+        while (*p == ' ' || *p == '\t')
+            p++;
+        if (*p == '\0')
+            break;
+        char *start = p;
+        while (*p && *p != ' ' && *p != '\t')
+            p++;
+        if (*p)
+            *p++ = '\0';
+        vals = realloc(vals, sizeof(char *) * (*count + 1));
+        if (!vals)
+            return NULL;
+        vals[*count] = strdup(start);
+        (*count)++;
+    }
+    return vals;
+}
+
+static void assign_read_vars(char **args, int idx, char *line) {
+    int var_count = 0;
+    for (int i = idx; args[i]; i++)
+        var_count++;
+
+    char *p = line;
+    for (int i = 0; i < var_count; i++) {
+        while (*p == ' ' || *p == '\t')
+            p++;
+        char *val = p;
+        if (i < var_count - 1) {
+            while (*p && *p != ' ' && *p != '\t')
+                p++;
+            if (*p)
+                *p++ = '\0';
+        }
+        set_shell_var(args[idx + i], val);
+    }
+}
+
 int builtin_read(char **args) {
     int raw = 0;
-    int idx = 1;
-    if (args[idx] && strcmp(args[idx], "-r") == 0) {
-        raw = 1;
-        idx++;
-    }
-    int array_mode = 0;
     const char *array_name = NULL;
-    if (args[idx] && strcmp(args[idx], "-a") == 0 && args[idx+1]) {
-        array_mode = 1;
-        array_name = args[idx+1];
-        idx += 2;
-    }
-    if (!args[idx]) {
+    int idx;
+    if (parse_read_options(args, &raw, &array_name, &idx) != 0) {
         fprintf(stderr, "usage: read [-r] [-a NAME] NAME...\n");
         last_status = 1;
         return 1;
@@ -266,43 +324,18 @@ int builtin_read(char **args) {
         *dst = '\0';
     }
 
+    int array_mode = array_name != NULL;
     if (array_mode) {
         int count = 0;
-        char **vals = NULL;
-        char *p = line;
-        while (*p) {
-            while (*p == ' ' || *p == '\t') p++;
-            if (*p == '\0') break;
-            char *start = p;
-            while (*p && *p != ' ' && *p != '\t') p++;
-            if (*p) *p++ = '\0';
-            vals = realloc(vals, sizeof(char*)*(count+1));
-            vals[count++] = strdup(start);
-        }
-        if (!vals) { count = 0; }
+        char **vals = split_array_values(line, &count);
+        if (!vals)
+            count = 0;
         set_shell_array(array_name, vals, count);
-        for (int i=0;i<count;i++) free(vals[i]);
+        for (int i = 0; i < count; i++)
+            free(vals[i]);
         free(vals);
     } else {
-        int var_count = 0;
-        for (int i = idx; args[i]; i++)
-            var_count++;
-
-        char *p = line;
-        for (int i = 0; i < var_count; i++) {
-            while (*p == ' ' || *p == '\t')
-                p++;
-            char *val = p;
-            if (i < var_count - 1) {
-                while (*p && *p != ' ' && *p != '\t')
-                    p++;
-                if (*p)
-                    *p++ = '\0';
-            } else {
-                /* last variable gets the rest of the line */
-            }
-            set_shell_var(args[idx + i], val);
-        }
+        assign_read_vars(args, idx, line);
     }
     last_status = 0;
     return 1;


### PR DESCRIPTION
## Summary
- refactor `builtin_read` to use helper functions for option parsing, array splitting and variable assignment
- add `parse_read_options`, `split_array_values`, and `assign_read_vars` helpers

## Testing
- `make -B`
- `tests/run_tests.sh` *(fails: `./test_basic_cmd.expect: not found` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684846c385a083249e5c99c9ad88a3e5