### PR TITLE
Improve docs for job builtins

### DIFF
--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -1,4 +1,13 @@
-/* Job control builtins */
+/*
+ * Job control builtins
+ *
+ * This file exposes the shell commands used to manipulate background
+ * processes: `jobs`, `fg`, `bg` and `kill`.  These builtins are thin
+ * wrappers around the helpers implemented in jobs.c, which maintains
+ * the job list and performs the actual process management.  The
+ * functions here simply parse command arguments and invoke those
+ * helpers so the user can inspect, resume or signal running jobs.
+ */
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "jobs.h"
@@ -6,12 +15,16 @@
 #include <stdlib.h>
 #include <signal.h>
 
+/* builtin_jobs - usage: jobs
+ * Print the list of background jobs recorded by jobs.c and return 1. */
 int builtin_jobs(char **args) {
     (void)args;
     print_jobs();
     return 1;
 }
 
+/* builtin_fg - usage: fg ID
+ * Bring the specified job to the foreground using wait_job and return 1. */
 int builtin_fg(char **args) {
     if (!args[1]) {
         fprintf(stderr, "usage: fg ID\n");
@@ -22,6 +35,8 @@ int builtin_fg(char **args) {
     return 1;
 }
 
+/* builtin_bg - usage: bg ID
+ * Resume a stopped job in the background via bg_job and return 1. */
 int builtin_bg(char **args) {
     if (!args[1]) {
         fprintf(stderr, "usage: bg ID\n");
@@ -32,6 +47,8 @@ int builtin_bg(char **args) {
     return 1;
 }
 
+/* builtin_kill - usage: kill [-SIGNAL] ID
+ * Send a signal (default SIGTERM) to a job using kill_job and return 1. */
 int builtin_kill(char **args) {
     if (!args[1]) {
         fprintf(stderr, "usage: kill [-SIGNAL] ID\n");


### PR DESCRIPTION
## Summary
- expand file header in `builtins_jobs.c`
- document usage and return values of the job-related builtin functions

## Testing
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848655eaa2483249c8b0dc88f02cb34