### PR TITLE
Improve arithmetic parser documentation

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -1,16 +1,42 @@
-/* Arithmetic evaluation module */
+/*
+ * Simple arithmetic expression evaluator used by the shell.
+ *
+ * Expressions are parsed using a tiny recursive–descent parser with the
+ * following grammar (roughly):
+ *   expr    := assign
+ *   assign  := NAME '=' assign | cmp
+ *   cmp     := add ( (== | != | >= | <= | > | <) add )*
+ *   add     := mul ( ('+' | '-') mul )*
+ *   mul     := unary ( ('*' | '/' | '%') unary )*
+ *   unary   := ('+' | '-') unary | primary
+ *   primary := NUMBER | NAME | '(' expr ')'
+ *
+ * Each parse_* function consumes characters from the input string via a
+ * char pointer passed by reference.  Variable lookups use get_shell_var()
+ * and environment variables and assignments update shell variables via
+ * set_shell_var().  eval_arith() simply calls parse_expr on the supplied
+ * string and returns the resulting numeric value.
+ */
 #include "builtins.h" // for set_shell_var and get_shell_var
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 
+/*
+ * Advance *s past any whitespace characters.
+ * No return value; *s is updated in place.
+ */
 static void skip_ws(const char **s) {
     while (isspace((unsigned char)**s)) (*s)++;
 }
 
 static long parse_expr(const char **s);
 
+/*
+ * Parse a primary expression: number, variable or parenthesised subexpression.
+ * Returns the parsed value and advances *s past the token.
+ */
 static long parse_primary(const char **s) {
     skip_ws(s);
     if (**s == '(') {
@@ -38,6 +64,10 @@ static long parse_primary(const char **s) {
     return v;
 }
 
+/*
+ * Parse unary plus/minus or a primary expression.
+ * Returns the resulting value; *s is advanced.
+ */
 static long parse_unary(const char **s) {
     skip_ws(s);
     if (**s == '+' || **s == '-') {
@@ -48,6 +78,10 @@ static long parse_unary(const char **s) {
     return parse_primary(s);
 }
 
+/*
+ * Parse multiplicative operators (*, /, %).
+ * Returns the computed value; *s is advanced past the expression.
+ */
 static long parse_mul(const char **s) {
     long v = parse_unary(s);
     while (1) {
@@ -64,6 +98,10 @@ static long parse_mul(const char **s) {
     return v;
 }
 
+/*
+ * Parse addition and subtraction operations.
+ * Returns the computed value while advancing *s.
+ */
 static long parse_add(const char **s) {
     long v = parse_mul(s);
     while (1) {
@@ -79,6 +117,10 @@ static long parse_add(const char **s) {
     return v;
 }
 
+/*
+ * Parse comparison operators and return 1 or 0.
+ * Advances *s past the comparison expression.
+ */
 static long parse_cmp(const char **s) {
     long v = parse_add(s);
     while (1) {
@@ -94,6 +136,11 @@ static long parse_cmp(const char **s) {
     return v;
 }
 
+/*
+ * Parse assignments of the form NAME=expr.
+ * Side effect: updates shell variables via set_shell_var().
+ * Returns the assigned or computed value and advances *s.
+ */
 static long parse_assign(const char **s) {
     skip_ws(s);
     const char *save = *s;
@@ -119,10 +166,15 @@ static long parse_assign(const char **s) {
     return parse_cmp(s);
 }
 
+/* Wrapper for the highest precedence expression parser. */
 static long parse_expr(const char **s) {
     return parse_assign(s);
 }
 
+/*
+ * Evaluate an arithmetic expression contained in 'expr'.
+ * Returns the resulting long value; does not modify 'expr'.
+ */
 long eval_arith(const char *expr) {
     const char *p = expr;
     long v = parse_expr(&p);


### PR DESCRIPTION
## Summary
- expand comment header for `arith.c`
- document static parser helpers
- explain use of `eval_arith`

## Testing
- `tests/run_tests.sh` *(fails: `./test_basic_cmd.expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486816eb608324ad5a7e340e19076c