### PR TITLE
Add header comments for function execution

### DIFF
--- a/src/func_exec.h
+++ b/src/func_exec.h
@@ -1,8 +1,14 @@
+
+/*
+ * Shell function execution helpers.
+ * Exposes helpers for executing parsed shell functions.
+ */
 #ifndef FUNC_EXEC_H
 #define FUNC_EXEC_H
 #include "parser.h"
 
 extern int func_return;
+/* Execute parsed function BODY with argument vector ARGS and return its exit status. */
 int run_function(Command *body, char **args);
 
 #endif /* FUNC_EXEC_H */


### PR DESCRIPTION
## Summary
- document `func_exec.h` purpose
- add brief note above `run_function`

## Testing
- `./tests/run_tests.sh` *(fails: `./run_tests.sh: 9: ./test_basic_cmd.expect: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68486b57f42483248ef087bed8e6ee48