### PR TITLE
Add comments for script arguments

### DIFF
--- a/src/scriptargs.h
+++ b/src/scriptargs.h
@@ -1,7 +1,18 @@
 #ifndef SCRIPTARGS_H
 #define SCRIPTARGS_H
 
+/*
+ * Store the argument vector for the currently running script or function.
+ *
+ * script_argv[0] holds the script name just like $0. When a shell function is
+ * invoked, these globals are replaced with copies of the function's arguments
+ * so that $1, $2, ... expand correctly within the body. They are restored once
+ * the function returns.
+ */
+
+/* Number of positional parameters; updated before a function body executes. */
 extern int script_argc;
+/* Null terminated array of parameters; swapped during function calls. */
 extern char **script_argv;
 
 #endif /* SCRIPTARGS_H */


### PR DESCRIPTION
## Summary
- add header comment for scriptargs.h explaining purpose
- document how `script_argc` and `script_argv` are swapped during function calls

## Testing
- `make`
- `make test` *(fails: expect not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486b598b2083248ab7b75edf27df1e