### PR TITLE
Add documentation comments for completion

### DIFF
--- a/src/completion.h
+++ b/src/completion.h
@@ -1,6 +1,18 @@
+/*
+ * Command completion helpers for the line editor.
+ * Builtin names and files are searched to complete the word at the cursor.
+ */
 #ifndef COMPLETION_H
 #define COMPLETION_H
-
+/*
+ * handle_completion() searches for completions.
+ *  prompt     - current prompt string used for redraws
+ *  buf        - input buffer being edited
+ *  lenp       - pointer to length of buf
+ *  posp       - pointer to cursor position
+ *  disp_lenp  - pointer to displayed length
+ * The function inserts the chosen completion into buf and updates the pointers.
+ */
 void handle_completion(const char *prompt, char *buf, int *lenp, int *posp,
                        int *disp_lenp);
 


### PR DESCRIPTION
## Summary
- document completion mechanism in `completion.h`
- describe `handle_completion` parameters and effect on the buffer

## Testing
- `make`
- `tests/run_tests.sh` *(fails: `test_basic_cmd.expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486d9b6da48324b437794ebf9295fb