### PR TITLE
Add lexer header documentation

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,10 +1,31 @@
+/*
+ * Lexing helpers used by the parser.  These functions read tokens from an
+ * input string and perform shell expansions.  Expansion covers variable,
+ * history and prompt substitution as well as simple brace patterns.
+ */
 #ifndef LEXER_H
 #define LEXER_H
 
+/* Read the next token from *p applying quoting and command substitution.
+ * The returned string is newly allocated and must be freed by the caller.
+ * QUOTED is set non-zero when the token originated from quoted text. */
 char *read_token(char **p, int *quoted);
+
+/* Expand variable, arithmetic and tilde expressions found in TOKEN.
+ * Returns a newly allocated string that the caller must free. */
 char *expand_var(const char *token);
+
+/* Apply history expansion to LINE when it begins with '!'.  The expanded
+ * line is returned as a new string or NULL on error and must be freed. */
 char *expand_history(const char *line);
+
+/* Expand escape sequences and variables that appear in PROMPT using the
+ * normal token rules.  The caller must free the returned string. */
 char *expand_prompt(const char *prompt);
+
+/* Expand simple brace expressions in WORD.  COUNT_OUT is set to the number of
+ * resulting words.  Returns a malloc'd NULL-terminated array of strings which
+ * the caller must free. */
 char **expand_braces(const char *word, int *count_out);
 
 #endif /* LEXER_H */


### PR DESCRIPTION
## Summary
- document lexer header with overview of token reading and expansion helpers
- add brief comments for exported lexer functions

## Testing
- `make test` *(fails: `/usr/bin/expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486dae3fe8832485c846480373dda1