### PR TITLE
Add positional parameter support to set builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Current version: 0.1.0
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
 - Shell options toggled with `set -e`, `set -u`, `set -x` and `set -o OPTION` such as `pipefail` or `noclobber`
+- `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)
 - History expansion with `!!`, `!n`, `!prefix`, `!$`, `!*`

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -226,12 +226,14 @@ status is 0 while options are found and 1 when parsing ends.
 .B let expr
 Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
-\.B set [-e|-u|-x|-o \fIoption\fP|+o \fIoption\fP]
+\.B set [-e|-u|-x|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
 undefined variables, \-x prints each command before execution,
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber prevents `>` from overwriting existing files.
-Use \+o with the option name to disable it again.
+Use \+o with the option name to disable it again.  If any arguments
+remain after option processing, they replace the positional parameters
+`$1`, `$2`, ... and `$#`.
 .TP
 Aliases are saved to the file specified by \fBVUSH_ALIASFILE\fP (default \fB~/.vush_aliases\fP), one \fIname\fP=\fIvalue\fP per line.
 .TP

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -231,7 +231,7 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
   current option letter in `VAR`, any argument in `OPTARG`, and advancing
   `OPTIND`.
 - `let EXPR` - evaluate an arithmetic expression.
-- `set [options]` - set shell options or positional parameters.
+- `set [options] [-- args...]` - set shell options or replace positional parameters.
 - `test EXPR` or `[ EXPR ]` - evaluate a conditional expression.
 - `[[ EXPR ]]` - evaluate a conditional expression with pattern matching.
 - Aliases are stored in the file specified by `VUSH_ALIASFILE` (default

--- a/tests/test_set_positional.expect
+++ b/tests/test_set_positional.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "set -- foo bar\r"
+expect "vush> "
+send "echo \"$1,$2,$#\"\r"
+expect {
+    -re "[\r\n]+foo,bar,2[\r\n]+vush> " {}
+    timeout { send_user "set positional failed\n"; exit 1 }
+}
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- implement argument handling for `set` builtin
- allocate `script_argv` and `script_argc` for new parameters
- document `set --` usage
- test setting positional parameters

## Testing
- `make test` *(fails: expect not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c57838908324b9ab314c236cec3a