### PR TITLE
Add echo builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current version: 0.1.0
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
  - Built-in commands: `alias`, `bg`, `break`, `cd`, `command`, `continue`,
-  `dirs`, `eval`, `exec`, `exit`, `export`, `false`, `fg`, `getopts`, `hash`,
+ `dirs`, `echo`, `eval`, `exec`, `exit`, `export`, `false`, `fg`, `getopts`, `hash`,
   `help`, `history`, `jobs`, `kill`, `let`, `local`, `popd`, `printf`, `pushd`,
   `pwd`, `read`, `readonly`, `return`, `set`, `shift`, `source` (or `.`), `test`,
   `time`, `times`, `trap`, `true`, `type`, `ulimit`, `umask`, `unalias`, `unset`, `wait`, and `:`

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -145,6 +145,10 @@ printed after the switch.
 Print formatted text according to the format string using standard
 printf(3) conversions. The exit status is 0 on success.
 .TP
+.B echo [\fB-n\fP] [\fB-e\fP] \fIargs...\fP
+Print each ARG separated by spaces. With \fB-n\fP the trailing newline is
+omitted. \fB-e\fP enables interpretation of backslash escapes like \n and \t.
+.TP
 .B dirs
 Display the directory stack.
 .TP

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -209,6 +209,7 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
 - `pushd dir` - push the current directory and change to `dir`.
 - `popd` - return to the directory from the stack.
 - `printf FORMAT [args...]` - print formatted text.
+- `echo [-n] [-e] [args...]` - print arguments separated by spaces. With `-n` no newline is added and `-e` enables backslash escapes.
 - `dirs` - display the directory stack.
 - `exit [status]` - terminate the shell with an optional status code.
 - `:` - do nothing and return success.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -19,6 +19,7 @@ extern int builtin_exit(char **);
 extern int builtin_colon(char **);
 extern int builtin_true(char **);
 extern int builtin_false(char **);
+extern int builtin_echo(char **);
 extern int builtin_pwd(char **);
 extern int builtin_jobs(char **);
 extern int builtin_fg(char **);
@@ -66,6 +67,7 @@ const struct builtin builtin_table[] = {
     {":", builtin_colon},
     {"true", builtin_true},
     {"false", builtin_false},
+    {"echo", builtin_echo},
     {"pwd", builtin_pwd},
     {"jobs", builtin_jobs},
     {"fg", builtin_fg},

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -26,6 +26,7 @@ int builtin_read(char **args);
 int builtin_getopts(char **args);
 int builtin_eval(char **args);
 int builtin_printf(char **args);
+int builtin_echo(char **args);
 int builtin_exec(char **args);
 int builtin_command(char **args);
 const char **get_builtin_names(void);

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -82,6 +82,59 @@ int builtin_false(char **args)
     return 1;
 }
 
+/* Print arguments separated by spaces. Supports -n to suppress the
+ * trailing newline and -e to interpret common backslash escapes. */
+int builtin_echo(char **args)
+{
+    int newline = 1;
+    int interpret = 0;
+    int i = 1;
+    for (; args[i] && args[i][0] == '-' && args[i][1]; i++) {
+        if (strcmp(args[i], "-n") == 0) {
+            newline = 0;
+            continue;
+        }
+        if (strcmp(args[i], "-e") == 0) {
+            interpret = 1;
+            continue;
+        }
+        break;
+    }
+
+    for (; args[i]; i++) {
+        if (i > 1 && args[i-1])
+            putchar(' ');
+        const char *s = args[i];
+        if (interpret) {
+            for (const char *p = s; *p; p++) {
+                if (*p == '\\' && p[1]) {
+                    p++;
+                    switch (*p) {
+                    case 'n': putchar('\n'); break;
+                    case 't': putchar('\t'); break;
+                    case 'r': putchar('\r'); break;
+                    case 'b': putchar('\b'); break;
+                    case 'a': putchar('\a'); break;
+                    case 'f': putchar('\f'); break;
+                    case 'v': putchar('\v'); break;
+                    case '\\': putchar('\\'); break;
+                    default: putchar('\\'); putchar(*p); break;
+                    }
+                } else {
+                    putchar(*p);
+                }
+            }
+        } else {
+            fputs(s, stdout);
+        }
+    }
+    if (newline)
+        putchar('\n');
+    fflush(stdout);
+    last_status = 0;
+    return 1;
+}
+
 /* Display the command history or modify it with -c to clear or -d N to
  * delete a specific entry. */
 int builtin_history(char **args) {


### PR DESCRIPTION
## Summary
- implement `echo` builtin supporting -n and -e
- register the builtin and update header declarations
- document `echo` in README, user guide, and man page

## Testing
- `make clean`
- `make`
- `make test` *(fails: Permission denied for expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6848d1d2e99c8324b52e85c23e1ccf44