### PR TITLE
Add noexec and noglob shell options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current version: 0.1.0
   `${VAR:-word}`, `${VAR:=word}`, `${VAR:+word}`, `${VAR#pat}`, `${VAR##pat}`,
   `${VAR%pat}`, `${VAR%%pat}` and `${#VAR}`
 - `$?` expands to the exit status of the last foreground command
-- Wildcard expansion for unquoted `*` and `?` patterns
+- Wildcard expansion for unquoted `*` and `?` patterns (disable with `set -f`)
 - Brace expansion for patterns like `{foo,bar}` and `{1..3}`
 - Command substitution using backticks or `$(...)`
 - Arithmetic expansion using `$((...))` and a `let` builtin
@@ -44,7 +44,7 @@ Current version: 0.1.0
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
-- Shell options toggled with `set -e`, `set -u`, `set -x` and `set -o OPTION` such as `pipefail` or `noclobber`
+- Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f` and `set -o OPTION` such as `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -13,6 +13,7 @@ environment variable expansion using \fB$VAR\fP, \fB${VAR}\fP and forms like
 command substitution using backticks or \fB$(\fPcmd\fB)\fP,
 arithmetic expansion using \fB$((\fPexpr\fB))\fP and a \fBlet\fP builtin,
 wildcard matching for '*' and '?', brace expansion like \fB{foo,bar}\fP or \fB{1..3}\fP, input and output redirection with
+Wildcard expansion may be disabled with set -f.
 \'<\', \'\>', \'>>\', \"2>\", \"2>>\" and \"&>\", process substitution using \fB<(cmd)\fP and \fB>(cmd)\fP, and background jobs.  When a
 \fIscriptfile\fP is supplied, commands are read from that file
 instead of standard input.  A `#` outside of quotes begins a comment
@@ -244,9 +245,9 @@ status is 0 while options are found and 1 when parsing ends.
 .B let expr
 Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
-\.B set [-e|-u|-x|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
+\.B set [-e|-u|-x|-n|-f|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution,
+undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion,
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber prevents `>` from overwriting existing files.
 Use \+o with the option name to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -57,7 +57,7 @@ expanding variables. Use a backslash to escape the next character. A `#` that
 appears outside of quotes starts a comment and everything after it on the line
 is ignored.
 
-Unquoted words containing `*` or `?` are expanded to matching filenames.  If no
+Unquoted words containing `*` or `?` are expanded to matching filenames (disable with `set -f`).  If no
 files match, the pattern is left unchanged.
 
 Commands enclosed in backticks or `$(...)` are executed and their output
@@ -202,8 +202,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure,
-`set -u` errors on undefined variables and `set -x` prints each command before execution.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them and `set -f` disables wildcard expansion.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
 
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -355,6 +355,10 @@ int builtin_set(char **args) {
             opt_nounset = 1;
         else if (strcmp(args[i], "-x") == 0)
             opt_xtrace = 1;
+        else if (strcmp(args[i], "-n") == 0)
+            opt_noexec = 1;
+        else if (strcmp(args[i], "-f") == 0)
+            opt_noglob = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 1;
@@ -372,6 +376,10 @@ int builtin_set(char **args) {
             opt_nounset = 0;
         else if (strcmp(args[i], "+x") == 0)
             opt_xtrace = 0;
+        else if (strcmp(args[i], "+n") == 0)
+            opt_noexec = 0;
+        else if (strcmp(args[i], "+f") == 0)
+            opt_noglob = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 0;

--- a/src/execute.c
+++ b/src/execute.c
@@ -315,8 +315,16 @@ int run_command_list(Command *cmds, const char *line) {
             else if (prev == OP_OR)
                 run = (last_status != 0);
         }
-        if (run)
-            run_pipeline(c, line);
+        if (run) {
+            if (opt_noexec) {
+                if (c->type == CMD_PIPELINE && c->pipeline &&
+                    c->pipeline->argv[0] &&
+                    strcmp(c->pipeline->argv[0], "set") == 0)
+                    run_pipeline(c, line);
+            } else {
+                run_pipeline(c, line);
+            }
+        }
         prev = c->op;
         if (func_return || loop_break || loop_continue)
             break;

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,8 @@ int opt_nounset = 0;
 int opt_xtrace = 0;
 int opt_pipefail = 0;
 int opt_noclobber = 0;
+int opt_noexec = 0;
+int opt_noglob = 0;
 
 static void process_startup_file(FILE *input);
 static void run_command_string(const char *cmd);

--- a/src/options.h
+++ b/src/options.h
@@ -6,5 +6,7 @@ extern int opt_nounset;
 extern int opt_xtrace;
 extern int opt_pipefail;
 extern int opt_noclobber;
+extern int opt_noexec;
+extern int opt_noglob;
 
 #endif /* OPTIONS_H */

--- a/src/parser.c
+++ b/src/parser.c
@@ -1191,7 +1191,7 @@ static int parse_pipeline_segment(char **p, PipelineSegment **seg_ptr, int *argc
 
         for (int bi = 0; bi < bcount && *argc < MAX_TOKENS - 1; bi++) {
             char *bt = btoks[bi];
-            if (!quoted && (strchr(bt, '*') || strchr(bt, '?'))) {
+            if (!quoted && !opt_noglob && (strchr(bt, '*') || strchr(bt, '?'))) {
                 glob_t g;
                 int r = glob(bt, 0, NULL, &g);
                 if (r == 0 && g.gl_pathc > 0) {


### PR DESCRIPTION
## Summary
- support `set -n`/`+n` and `set -f`/`+f`
- stop executing commands when `opt_noexec` is active
- allow turning off wildcard expansion with `opt_noglob`
- update documentation for new options

## Testing
- `make`
- `./tests/run_tests.sh` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d8ece5548324b6b99507eaccbdb4