### PR TITLE
Implement allexport shell option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Current version: 0.1.0
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
-- Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f` and `set -o OPTION` such as `pipefail` or `noclobber`
+- Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -245,9 +245,9 @@ status is 0 while options are found and 1 when parsing ends.
 .B let expr
 Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
-\.B set [-e|-u|-x|-n|-f|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
+\.B set [-e|-u|-x|-n|-f|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion,
+undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion, -a exports all assignments,
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber prevents `>` from overwriting existing files.
 Use \+o with the option name to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -202,7 +202,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them and `set -f` disables wildcard expansion.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them, `set -f` disables wildcard expansion and `set -a` exports all assignments to the environment.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
 
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -190,6 +190,8 @@ void set_shell_var(const char *name, const char *value) {
             }
             free(v->value);
             v->value = strdup(value);
+            if (opt_allexport)
+                setenv(name, v->value ? v->value : "", 1);
             return;
         }
     }
@@ -201,6 +203,8 @@ void set_shell_var(const char *name, const char *value) {
     v->array_len = 0;
     v->next = shell_vars;
     shell_vars = v;
+    if (opt_allexport)
+        setenv(name, value ? value : "", 1);
 }
 
 /*
@@ -359,6 +363,8 @@ int builtin_set(char **args) {
             opt_noexec = 1;
         else if (strcmp(args[i], "-f") == 0)
             opt_noglob = 1;
+        else if (strcmp(args[i], "-a") == 0)
+            opt_allexport = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 1;
@@ -380,6 +386,8 @@ int builtin_set(char **args) {
             opt_noexec = 0;
         else if (strcmp(args[i], "+f") == 0)
             opt_noglob = 0;
+        else if (strcmp(args[i], "+a") == 0)
+            opt_allexport = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 0;

--- a/src/execute.c
+++ b/src/execute.c
@@ -92,11 +92,28 @@ static int apply_temp_assignments(PipelineSegment *pipeline) {
                     vals[count++] = strdup(start);
                 }
                 set_shell_array(name, vals, count);
+                if (opt_allexport) {
+                    size_t joinlen = 0;
+                    for (int j=0;j<count;j++)
+                        joinlen += strlen(vals[j]) + 1;
+                    char *joined = malloc(joinlen+1);
+                    if (joined) {
+                        joined[0] = '\0';
+                        for (int j=0;j<count;j++) {
+                            strcat(joined, vals[j]);
+                            if (j < count-1) strcat(joined, " ");
+                        }
+                        setenv(name, joined, 1);
+                        free(joined);
+                    }
+                }
                 for(int j=0;j<count;j++) free(vals[j]);
                 free(vals);
                 free(body);
             } else {
                 set_shell_var(name, val);
+                if (opt_allexport)
+                    setenv(name, val, 1);
             }
             free(name);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -48,6 +48,7 @@ int opt_pipefail = 0;
 int opt_noclobber = 0;
 int opt_noexec = 0;
 int opt_noglob = 0;
+int opt_allexport = 0;
 
 static void process_startup_file(FILE *input);
 static void run_command_string(const char *cmd);

--- a/src/options.h
+++ b/src/options.h
@@ -8,5 +8,6 @@ extern int opt_pipefail;
 extern int opt_noclobber;
 extern int opt_noexec;
 extern int opt_noglob;
+extern int opt_allexport;
 
 #endif /* OPTIONS_H */


### PR DESCRIPTION
## Summary
- add `opt_allexport` to option list
- support `set -a`/`+a` in builtin `set`
- export assignments automatically when `opt_allexport` is enabled
- document the new feature in README and manuals

## Testing
- `make test` *(fails: Permission denied)*
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6848daef573483248f4933033fa53233