### PR TITLE
Document noglob option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Current version: 0.1.0
   `${VAR:-word}`, `${VAR:=word}`, `${VAR:+word}`, `${VAR#pat}`, `${VAR##pat}`,
   `${VAR%pat}`, `${VAR%%pat}` and `${#VAR}`
 - `$?` expands to the exit status of the last foreground command
-- Wildcard expansion for unquoted `*` and `?` patterns (disable with `set -f`)
+ - Wildcard expansion for unquoted `*` and `?` patterns (disable with `set -f`,
+   re-enable with `set +f`)
 - Brace expansion for patterns like `{foo,bar}` and `{1..3}`
 - Command substitution using backticks or `$(...)`
 - Arithmetic expansion using `$((...))` and a `let` builtin
@@ -44,7 +45,7 @@ Current version: 0.1.0
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
-- Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
+ - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f`/`set +f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -13,7 +13,7 @@ environment variable expansion using \fB$VAR\fP, \fB${VAR}\fP and forms like
 command substitution using backticks or \fB$(\fPcmd\fB)\fP,
 arithmetic expansion using \fB$((\fPexpr\fB))\fP and a \fBlet\fP builtin,
 wildcard matching for '*' and '?', brace expansion like \fB{foo,bar}\fP or \fB{1..3}\fP, input and output redirection with
-Wildcard expansion may be disabled with set -f.
+Wildcard expansion may be disabled with set -f and re-enabled with set +f.
 \'<\', \'\>', \'>>\', \"2>\", \"2>>\" and \"&>\", process substitution using \fB<(cmd)\fP and \fB>(cmd)\fP, and background jobs.  When a
 \fIscriptfile\fP is supplied, commands are read from that file
 instead of standard input.  A `#` outside of quotes begins a comment
@@ -247,7 +247,7 @@ Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
 \.B set [-e|-u|-x|-n|-f|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion, -a exports all assignments,
+undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -a exports all assignments,
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber prevents `>` from overwriting existing files.
 Use \+o with the option name to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -57,7 +57,7 @@ expanding variables. Use a backslash to escape the next character. A `#` that
 appears outside of quotes starts a comment and everything after it on the line
 is ignored.
 
-Unquoted words containing `*` or `?` are expanded to matching filenames (disable with `set -f`).  If no
+Unquoted words containing `*` or `?` are expanded to matching filenames (disable with `set -f`, re-enable with `set +f`).  If no
 files match, the pattern is left unchanged.
 
 Commands enclosed in backticks or `$(...)` are executed and their output
@@ -202,7 +202,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them, `set -f` disables wildcard expansion and `set -a` exports all assignments to the environment.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable) and `set -a` exports all assignments to the environment.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
 
 


### PR DESCRIPTION
## Summary
- clarify how to re-enable wildcard expansion with `set +f`
- mention noglob toggling in README, vushdoc and manual page

## Testing
- `make -j4`
- `./run_tests.sh` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6848dc13ee54832483f08b8215c09d1a