### PR TITLE
Add numeric break/continue counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Current version: 0.1.0
 
 - Command line parsing with rudimentary quoting support
 - Execution of external commands via `fork` and `exec`
- - Built-in commands: `alias`, `bg`, `break`, `cd`, `command`, `continue`,
+ - Built-in commands: `alias`, `bg`, `break [N]`, `cd`, `command`, `continue [N]`,
  `dirs`, `echo`, `eval`, `exec`, `exit`, `export`, `false`, `fc`, `fg`, `getopts`, `hash`,
   `help`, `history`, `jobs`, `kill`, `let`, `local`, `popd`, `printf`, `pushd`,
   `pwd`, `read`, `readonly`, `return`, `set`, `shift`, `source` (or `.`), `test`,

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -237,11 +237,11 @@ Return from a shell function with the given status (default 0).
 .B shift [n]
 Shift positional parameters down by \fIn\fP (default 1).
 .TP
-.B break
-Exit the innermost loop.
+.B break [n]
+Exit \fIn\fP levels of enclosing loops (default 1).
 .TP
-.B continue
-Skip to the next iteration of the innermost loop.
+.B continue [n]
+Skip to the next iteration of the \fIn\fPth enclosing loop (default 1).
 .TP
 .B getopts optstring var
 Parse positional parameters according to \fIoptstring\fP. The next option

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -243,8 +243,8 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
 - `read [-r] VAR...` - read a line of input into variables.
 - `return [status]` - return from a shell function with an optional status.
 - `shift [N]` - drop the first `N` positional parameters (default 1).
-- `break` - exit the nearest loop.
-- `continue` - start the next iteration of the nearest loop.
+- `break [N]` - exit `N` levels of loops (default 1).
+- `continue [N]` - start the next iteration of the `N`th enclosing loop (default 1).
 - `getopts OPTSTRING VAR` - parse positional parameters, storing the
   current option letter in `VAR`, any argument in `OPTARG`, and advancing
   `OPTIND`.

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -862,16 +862,40 @@ int builtin_trap(char **args)
 /* Signal a loop to terminate after the current iteration. */
 int builtin_break(char **args)
 {
-    (void)args;
-    loop_break = 1;
+    int n = 1;
+    if (args[1]) {
+        char *end;
+        errno = 0;
+        long val = strtol(args[1], &end, 10);
+        if (*end != '\0' || errno != 0 || val <= 0) {
+            fprintf(stderr, "usage: break [N]\n");
+            return 1;
+        }
+        n = (int)val;
+    }
+    if (n > loop_depth)
+        n = loop_depth;
+    loop_break = n;
     return 1;
 }
 
 /* Skip directly to the next iteration of the innermost loop. */
 int builtin_continue(char **args)
 {
-    (void)args;
-    loop_continue = 1;
+    int n = 1;
+    if (args[1]) {
+        char *end;
+        errno = 0;
+        long val = strtol(args[1], &end, 10);
+        if (*end != '\0' || errno != 0 || val <= 0) {
+            fprintf(stderr, "usage: continue [N]\n");
+            return 1;
+        }
+        n = (int)val;
+    }
+    if (n > loop_depth)
+        n = loop_depth;
+    loop_continue = n;
     return 1;
 }
 

--- a/src/execute.h
+++ b/src/execute.h
@@ -9,8 +9,8 @@
  * parsed command structures produced by the parser.  Pipelines are expanded to
  * builtins, shell functions or external programs and control-flow constructs
  * like if/while/for are dispatched to the appropriate helpers.  The globals
- * loop_break and loop_continue are used by the break and continue builtins to
- * signal loop control to the executor.
+ * loop_break and loop_continue store the number of loop levels remaining
+ * to break or continue, as set by the builtins of the same name.
  */
 
 #include "parser.h"
@@ -23,8 +23,9 @@ int run_pipeline(Command *cmd, const char *line);
  * status of the last command. */
 int run_command_list(Command *cmds, const char *line);
 
-/* Set non-zero by builtins to break or continue the innermost loop. */
+/* Remaining loop levels to break or continue (0 when inactive). */
 extern int loop_break;
 extern int loop_continue;
+extern int loop_depth;
 
 #endif /* EXECUTE_H */


### PR DESCRIPTION
## Summary
- extend loop control variables to store a count
- parse optional numeric args for `break` and `continue`
- unwind requested loop levels during execution
- document `break [N]` and `continue [N]`

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6848e614bd2c8324b4f60854ea39ca42