### PR TITLE
Implement $- expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Current version: 0.1.0
 - `${VAR%pat}`, `${VAR%%pat}` and `${#VAR}`
 - `$?` expands to the exit status of the last foreground command
 - `$$` expands to the PID of the running shell and `$!` to the last background job
+- `$-` expands to the currently enabled option letters
  - Wildcard expansion for unquoted `*` and `?` patterns (disable with `set -f`,
    re-enable with `set +f`)
 - Brace expansion for patterns like `{foo,bar}` and `{1..3}`

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -9,7 +9,7 @@ vush is a lightweight UNIX shell supporting command execution,
 pipelines, brace groups using '{ ... ; }', subshells using '(...)', command chaining with ';', '&&' and '||', and negation with '! cmd',
 environment variable expansion using \fB$VAR\fP, \fB${VAR}\fP and forms like
 \fB${VAR:-word}\fP, \fB${VAR:=word}\fP, \fB${VAR:+word}\fP, \fB${VAR#pat}\fP,
-\fB${VAR%pat}\fP and \fB${#VAR}\fP (with "$?" storing the last exit status, "$$" the shell PID and "$!" the last background job),
+\fB${VAR%pat}\fP and \fB${#VAR}\fP (with "$?" storing the last exit status, "$$" the shell PID, "$!" the last background job and "$-" the current option letters),
 command substitution using backticks or \fB$(\fPcmd\fB)\fP,
 arithmetic expansion using \fB$((\fPexpr\fB))\fP and a \fBlet\fP builtin,
 wildcard matching for '*' and '?', brace expansion like \fB{foo,bar}\fP or \fB{1..3}\fP, input and output redirection with

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -99,7 +99,8 @@ vush> echo $?
 ```
 
 `$$` expands to the PID of the running shell while `$!` gives the PID of the
-most recent background job.
+most recent background job. `$-` expands to a string of the current option
+letters such as `eu` when `set -e` and `set -u` are enabled.
 
 Additional parameter expansion forms (doubling `#` or `%` removes the
 longest matching prefix or suffix):

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -385,6 +385,24 @@ static char *expand_special(const char *token) {
         snprintf(buf, sizeof(buf), "%d", script_argc);
         return strdup(buf);
     }
+    if (strcmp(token, "$-") == 0) {
+        char flags[16];
+        int pos = 0;
+        if (opt_allexport)
+            flags[pos++] = 'a';
+        if (opt_errexit)
+            flags[pos++] = 'e';
+        if (opt_noglob)
+            flags[pos++] = 'f';
+        if (opt_noexec)
+            flags[pos++] = 'n';
+        if (opt_nounset)
+            flags[pos++] = 'u';
+        if (opt_xtrace)
+            flags[pos++] = 'x';
+        flags[pos] = '\0';
+        return strdup(flags);
+    }
     if (strcmp(token, "$@") == 0) {
         if (!script_argv || script_argc == 0)
             return strdup("");

--- a/tests/test_pid_params.expect
+++ b/tests/test_pid_params.expect
@@ -22,5 +22,12 @@ expect {
     -re "\[1\] $bg sleep 1 &[\r\n]+vush> " {}
     timeout { send_user "jobs pid mismatch\n"; exit 1 }
 }
+send "set -e -u\r"
+expect "vush> "
+send "echo $-\r"
+expect {
+    -re "[\r\n]+eu[\r\n]+vush> " {}
+    timeout { send_user "\$- expansion failed\n"; exit 1 }
+}
 send "exit\r"
 expect eof


### PR DESCRIPTION
## Summary
- track option flags and expose them via `$-`
- document `$-` usage in README and manuals
- test `$-` expansion in the parameter test

## Testing
- `make`
- `make test` *(fails: expect missing)*

------
https://chatgpt.com/codex/tasks/task_e_684901d4a7d88324b4113a4317bc9053