### PR TITLE
Implement readonly -p listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current version: 0.1.0
 
 - `export -p` lists all exported variables and `export -n NAME` removes the export
   attribute while leaving the variable defined.
+- `readonly -p` prints all read-only variables using `readonly NAME=value` format.
 
 - Environment variable expansion using `$VAR`, `${VAR}` and forms like
   `${VAR:-word}`, `${VAR:=word}`, `${VAR:+word}`, `${VAR#pat}`, `${VAR##pat}`,

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -200,7 +200,8 @@ lists all exported variables. Using \fB-n\fP \fIname\fP removes the export
 attribute from \fIname\fP without unsetting it.
 .TP
 .B readonly [-p] NAME[=VALUE]...
-Mark each variable as read-only or list all read-only variables.
+Mark each variable as read-only or list all read-only variables. When listing,
+the variables are printed as \fBreadonly NAME=value\fP.
 .TP
 .B local \fIname\fP[=value] ...
 Mark each variable as local to the current function. Previous values are

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -243,10 +243,11 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
 - `kill [-s SIGNAL|-SIGNAL] [-l] ID|PID` - send a signal to the given job or process. Use `-l` to list signals.
 - `wait [ID|PID]` - wait for the given job or process to finish.
  - `trap [-p | 'cmd' SIGNAL]` - execute `cmd` when `SIGNAL` is received or list traps with `-p` or with no arguments. Use `trap SIGNAL` to clear. Use `EXIT` or `0` for a command run when the shell exits.
- - `export [-p|-n NAME] NAME=value` - manage exported variables or set one.
-   Use `-p` to list all exported variables. `-n NAME` stops exporting `NAME`
-   without removing it.
+- `export [-p|-n NAME] NAME=value` - manage exported variables or set one.
+  Use `-p` to list all exported variables. `-n NAME` stops exporting `NAME`
+  without removing it.
 - `readonly [-p] NAME[=VALUE]` - mark variables as read-only or list them.
+  With `-p` the variables are printed using `readonly NAME=value` format.
 - `local NAME[=VALUE]` - define a variable scoped to the current function.
 - `unset [-f] NAME` - remove an environment variable or function with `-f`.
 - `history [-c|-d NUMBER]` - show command history, clear it with `-c`, or delete a specific entry with `-d`.

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -426,7 +426,7 @@ int builtin_help(char **args) {
     printf("  bg ID      Continue job ID in background\n");
     printf("  kill [-s SIG|-SIGNAL] [-l] ID|PID  Send a signal or list signals\n");
     printf("  export [-p|-n NAME] NAME=value  Manage exported variables\n");
-    printf("  readonly NAME[=VALUE]  Mark variable as read-only\n");
+    printf("  readonly [-p] NAME[=VALUE]  Mark variable as read-only or list them\n");
     printf("  unset NAME          Remove an environment variable\n");
     printf("  history [-c|-d NUM]   Show or modify command history\n");
     printf("  hash [-r] [name...]   Manage cached command paths\n");

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -275,17 +275,29 @@ int builtin_export(char **args) {
 }
 
 int builtin_readonly(char **args) {
-    if (!args[1]) {
-        fprintf(stderr, "usage: readonly NAME[=VALUE]...\n");
-        return 1;
+    int pflag = 0;
+    int i = 1;
+
+    for (; args[i] && args[i][0] == '-'; i++) {
+        if (strcmp(args[i], "-p") == 0) {
+            pflag = 1;
+        } else {
+            fprintf(stderr, "usage: readonly [-p] NAME[=VALUE]...\n");
+            return 1;
+        }
     }
 
-    if (strcmp(args[1], "-p") == 0 && !args[2]) {
+    if (pflag && !args[i]) {
         print_readonly_vars();
         return 1;
     }
 
-    for (int i = 1; args[i]; i++) {
+    if (!args[i]) {
+        fprintf(stderr, "usage: readonly [-p] NAME[=VALUE]...\n");
+        return 1;
+    }
+
+    for (; args[i]; i++) {
         char *arg = args[i];
         char *eq = strchr(arg, '=');
         if (eq) {

--- a/tests/test_readonly_p.expect
+++ b/tests/test_readonly_p.expect
@@ -6,7 +6,7 @@ send "readonly FOO=bar\r"
 expect "vush> "
 send "readonly -p\r"
 expect {
-    -re "readonly FOO=bar" {}
+    -re "readonly FOO=bar\r?\n" {}
     timeout { send_user "readonly -p output mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- support `readonly -p` flag to list read-only variables
- document `readonly -p` in README and docs
- show `-p` usage in builtin help output
- test the new `readonly -p` behaviour

## Testing
- `make test` *(fails: Permission denied - expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849124cfb048324822edf9c33041756