### PR TITLE
Fix cd path overflow check

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -151,7 +151,11 @@ int builtin_cd(char **args) {
             strncpy(newpwd, dir, sizeof(newpwd));
             newpwd[PATH_MAX - 1] = '\0';
         } else {
-            snprintf(newpwd, sizeof(newpwd), "%s/%s", oldpwd, dir);
+            int n = snprintf(newpwd, sizeof(newpwd), "%s/%s", oldpwd, dir);
+            if (n < 0 || n >= (int)sizeof(newpwd)) {
+                fprintf(stderr, "cd: path too long\n");
+                return 1;
+            }
         }
         canonicalize_logical(newpwd, newpwd);
     }


### PR DESCRIPTION
## Summary
- detect buffer overflow when composing `PWD` in builtin_cd

## Testing
- `make test` *(fails: Permission denied on expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6849959a76b4832483d9feb389ddb1a2