### PR TITLE
Fix export list output formatting

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -238,7 +238,7 @@ static void list_exports(void)
     for (char **e = environ; *e; e++) {
         char *eq = strchr(*e, '=');
         if (eq)
-            printf("export %.*s='%s'\n", (int)(eq - *e), eq + 1);
+            printf("export %.*s='%s'\n", (int)(eq - *e), *e, eq + 1);
         else
             printf("export %s\n", *e);
     }


### PR DESCRIPTION
## Summary
- fix missing argument in list_exports printf call

## Testing
- `make`
- `make test` *(fails: test scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849963586b88324ad779ee3dfa3f478