### PR TITLE
Fix missing vars header include

### DIFF
--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -15,6 +15,7 @@
 #include "execute.h"
 #include "util.h"
 #include "scriptargs.h"
+#include "vars.h"
 #include "hash.h"
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- include `vars.h` in builtins_misc.c so functions like `free_shell_vars` are declared

## Testing
- `make test` *(fails: Permission denied while running tests)*

------
https://chatgpt.com/codex/tasks/task_e_684996dae56c832487ba946c025f5f40