### PR TITLE
Fix header for shell variable functions

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -2,6 +2,7 @@
 #include "lexer.h"
 #include "history.h"
 #include "builtins.h"
+#include "vars.h"
 #include "scriptargs.h"
 #include "options.h"
 #include "jobs.h"


### PR DESCRIPTION
## Summary
- include vars.h in lexer_expand.c so shell variable helpers have prototypes

## Testing
- `make -s`

------
https://chatgpt.com/codex/tasks/task_e_6849978dd07883249f2d2e584fce92ba