### PR TITLE
Add verbose input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Current version: 0.1.0
 - Startup commands read from `~/.vushrc` if the file exists
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
- - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -n`, `set -f`/`set +f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
+ - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`, `set -f`/`set +f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -257,7 +257,7 @@ Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
 \.B set [-e|-u|-x|-n|-f|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -a exports all assignments,
+undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -a exports all assignments,
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber prevents `>` from overwriting existing files.
 Use \+o with the option name to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -218,7 +218,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable) and `set -a` exports all assignments to the environment.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable) and `set -a` exports all assignments to the environment.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
 
 

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -14,6 +14,7 @@
 #include "parser.h"
 #include "execute.h"
 #include "util.h"
+#include "options.h"
 #include "scriptargs.h"
 #include "vars.h"
 #include "hash.h"
@@ -204,6 +205,8 @@ static void execute_source_file(FILE *input)
 {
     char line[MAX_LINE];
     while (read_logical_line(input, line, sizeof(line))) {
+        if (opt_verbose)
+            printf("%s\n", line);
         Command *cmds = parse_line(line);
         if (!cmds || !cmds->pipeline || !cmds->pipeline->argv[0]) {
             free_commands(cmds);

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -82,6 +82,8 @@ int builtin_set(char **args) {
             opt_nounset = 1;
         else if (strcmp(args[i], "-x") == 0)
             opt_xtrace = 1;
+        else if (strcmp(args[i], "-v") == 0)
+            opt_verbose = 1;
         else if (strcmp(args[i], "-n") == 0)
             opt_noexec = 1;
         else if (strcmp(args[i], "-f") == 0)
@@ -105,6 +107,8 @@ int builtin_set(char **args) {
             opt_nounset = 0;
         else if (strcmp(args[i], "+x") == 0)
             opt_xtrace = 0;
+        else if (strcmp(args[i], "+v") == 0)
+            opt_verbose = 0;
         else if (strcmp(args[i], "+n") == 0)
             opt_noexec = 0;
         else if (strcmp(args[i], "+f") == 0)

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -399,6 +399,8 @@ static char *expand_special(const char *token) {
             flags[pos++] = 'n';
         if (opt_nounset)
             flags[pos++] = 'u';
+        if (opt_verbose)
+            flags[pos++] = 'v';
         if (opt_xtrace)
             flags[pos++] = 'x';
         flags[pos] = '\0';

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,7 @@ char **script_argv = NULL;
 int opt_errexit = 0;
 int opt_nounset = 0;
 int opt_xtrace = 0;
+int opt_verbose = 0;
 int opt_pipefail = 0;
 int opt_noclobber = 0;
 int opt_noexec = 0;
@@ -135,6 +136,8 @@ static void process_startup_file(FILE *input)
 
     char rcline[MAX_LINE];
     while (read_logical_line(rc, rcline, sizeof(rcline))) {
+        if (opt_verbose)
+            printf("%s\n", rcline);
         char *exp = expand_history(rcline);
         if (!exp)
             continue;
@@ -181,6 +184,9 @@ static void run_command_string(const char *cmd)
     strncpy(linebuf, cmd, sizeof(linebuf) - 1);
     linebuf[sizeof(linebuf) - 1] = '\0';
     char *line = linebuf;
+
+    if (opt_verbose)
+        printf("%s\n", line);
 
     char *expanded = expand_history(line);
     if (!expanded)
@@ -238,6 +244,9 @@ static void repl_loop(FILE *input)
             line = linebuf;
         }
 
+        if (opt_verbose)
+            printf("%s\n", line);
+
         char *cmdline = strdup(line);
         if (line != linebuf)
             free(line);
@@ -270,6 +279,8 @@ static void repl_loop(FILE *input)
                     }
                     more = strdup(linebuf);
                 }
+                if (opt_verbose)
+                    printf("%s\n", more);
                 size_t len1 = strlen(cmdline);
                 size_t len2 = strlen(more);
                 char *tmp = malloc(len1 + len2 + 2);

--- a/src/options.h
+++ b/src/options.h
@@ -4,6 +4,7 @@
 extern int opt_errexit;
 extern int opt_nounset;
 extern int opt_xtrace;
+extern int opt_verbose;
 extern int opt_pipefail;
 extern int opt_noclobber;
 extern int opt_noexec;


### PR DESCRIPTION
## Summary
- add `opt_verbose` flag to options
- implement `set -v`/`+v` handling
- echo input lines when verbose mode is on
- show verbose state in `$-`
- document the new option

## Testing
- `make`
- `make test` *(fails: Permission denied for expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684998fa1ee88324bbca3072fbab624e