### PR TITLE
Support closing output descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Current version: 0.1.0
 - `case` selection statements with optional fall-through using `;&`
 - `select` loops presenting a numbered menu of choices
 - Input and output redirection with `<`, `>`, `>>`, `2>`, `2>>` and `&>`,
-  including descriptor duplication like `2>&1` or `>&file`
+  including descriptor duplication like `2>&1` or `>&file` and descriptor
+  closure using `>&-` or `2>&-`
 - Persistent command history saved to `~/.vush_history` (overridable with `VUSH_HISTFILE`)
 - Maximum history size of 1000 entries (overridable with `VUSH_HISTSIZE`)
 - Alias definitions persisted in `~/.vush_aliases` (overridable with `VUSH_ALIASFILE`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -383,6 +383,7 @@ redirected with '>' or '>>' to append.  Likewise, file descriptor 2
 (standard error) can be redirected using '2>' or '2>>'.
 Both descriptors may be sent to the same file with '&>' or '>&file'.
 File descriptors can also be duplicated, e.g. '2>&1' or '>&2'.
+Use '>&-' or '2>&-' to close the descriptor instead of redirecting it.
 Here-documents can be created with '<<WORD'. Lines are read until a
 line containing only WORD is found and the intervening text becomes the
 command's standard input.  A single word may be used directly as input

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -300,6 +300,8 @@ vush> ls nonexistent &>both.txt
 vush> cat both.txt
 vush> echo dup >&dup.txt
 vush> ls nonexistent 2>&1 >>dup.txt
+vush> echo nothing >&-
+vush> ls nonexistent 2>&-
 ```
 
 Here-documents feed inline text to a command:

--- a/src/execute.c
+++ b/src/execute.c
@@ -255,9 +255,13 @@ void setup_redirections(PipelineSegment *seg) {
         }
     }
 
-    if (seg->dup_out != -1)
+    if (seg->close_out)
+        close(STDOUT_FILENO);
+    else if (seg->dup_out != -1)
         dup2(seg->dup_out, STDOUT_FILENO);
-    if (seg->dup_err != -1)
+    if (seg->close_err)
+        close(STDERR_FILENO);
+    else if (seg->dup_err != -1)
         dup2(seg->dup_err, STDERR_FILENO);
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -19,9 +19,11 @@ typedef struct PipelineSegment {
     char *out_file;
     int append;
     int dup_out;      /* > &N duplication */
+    int close_out;    /* >&- close descriptor */
     char *err_file;
     int err_append;
     int dup_err;      /* 2>&N duplication */
+    int close_err;    /* 2>&- close descriptor */
     char **assigns;   /* NAME=value pairs preceding the command */
     int assign_count;
     struct PipelineSegment *next;

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -232,7 +232,10 @@ static int parse_output_redirect(PipelineSegment *seg, char **p, char *tok) {
     if (**p == '&') {
         (*p)++;
         while (**p == ' ' || **p == '\t') (*p)++;
-        if (isdigit(**p)) {
+        if (**p == '-') {
+            seg->close_out = 1;
+            (*p)++;
+        } else if (isdigit(**p)) {
             seg->dup_out = strtol(*p, p, 10);
         } else if (**p) {
             int q = 0;
@@ -259,7 +262,10 @@ static int parse_error_redirect(PipelineSegment *seg, char **p, char *tok) {
     if (**p == '&') {
         (*p)++;
         while (**p == ' ' || **p == '\t') (*p)++;
-        if (isdigit(**p)) {
+        if (**p == '-') {
+            seg->close_err = 1;
+            (*p)++;
+        } else if (isdigit(**p)) {
             seg->dup_err = strtol(*p, p, 10);
         } else if (**p) {
             int q = 0;


### PR DESCRIPTION
## Summary
- detect `>&-` and `2>&-` in redirection parser
- close stdout/stderr when parsed as closed
- document descriptor-closing redirects

## Testing
- `make`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849b61202f88324b7c3a109299e2e39