### PR TITLE
Add -C noclobber alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Current version: 0.1.0
   environment variable if set
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
- - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`, `set -f`/`set +f`, `set -a` and `set -o OPTION` such as `pipefail` or `noclobber`
+ - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
+   `set -f`/`set +f`, `set -C`/`set +C`, `set -a` and `set -o OPTION` such as
+   `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -258,12 +258,12 @@ status is 0 while options are found and 1 when parsing ends.
 .B let expr
 Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
-\.B set [-e|-u|-x|-n|-f|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
+\.B set [-e|-u|-x|-n|-f|-C|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -a exports all assignments,
+undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -C prevents `>` from overwriting existing files (use +C to allow it again), -a exports all assignments,
 \-o pipefail causes pipelines to return the status of the first failing
-command and \-o noclobber prevents `>` from overwriting existing files.
-Use \+o with the option name to disable it again.  If any arguments
+command and \-o noclobber has the same effect as -C.
+Use \+o with the option name or +C to disable it again.  If any arguments
 remain after option processing, they replace the positional parameters
 `$1`, `$2`, ... and `$#`. When called with no operands, all shell
 variables and functions are printed in a reusable form.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -221,8 +221,8 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable) and `set -a` exports all assignments to the environment.
-The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` prevents `>` from overwriting existing files. Use `set +o OPTION` to disable an option.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again) and `set -a` exports all assignments to the environment.
+The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` (the same as `set -C`) prevents `>` from overwriting existing files. Use `set +o OPTION` or `set +C` to disable an option.
 
 
 ## Built-in Commands

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -88,6 +88,8 @@ int builtin_set(char **args) {
             opt_noexec = 1;
         else if (strcmp(args[i], "-f") == 0)
             opt_noglob = 1;
+        else if (strcmp(args[i], "-C") == 0)
+            opt_noclobber = 1;
         else if (strcmp(args[i], "-a") == 0)
             opt_allexport = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
@@ -113,6 +115,8 @@ int builtin_set(char **args) {
             opt_noexec = 0;
         else if (strcmp(args[i], "+f") == 0)
             opt_noglob = 0;
+        else if (strcmp(args[i], "+C") == 0)
+            opt_noclobber = 0;
         else if (strcmp(args[i], "+a") == 0)
             opt_allexport = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {


### PR DESCRIPTION
## Summary
- support `set -C` and `set +C` for the noclobber option
- document the new aliases in README, vushdoc.md and the man page

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849c963b8bc8324a8aa0ca763f9f1cd