### PR TITLE
Fix readonly with undefined var

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current version: 0.1.0
 - `export -p` lists all exported variables and `export -n NAME` removes the export
   attribute while leaving the variable defined.
 - `set` with no arguments prints all shell variables and functions.
-- `readonly -p` prints all read-only variables using `readonly NAME=value` format.
+- `readonly NAME[=VALUE]` marks a variable as read-only, creating it with an empty value when `VALUE` is omitted. `readonly -p` lists read-only variables using `readonly NAME=value` format.
 
 - Environment variable expansion using `$VAR`, `${VAR}` and forms like
   `${VAR:-word}`, `${VAR:=word}`, `${VAR:+word}`, `${VAR#pat}`, `${VAR##pat}`,
@@ -145,6 +145,8 @@ cd -P /tmp/my_link
 # Mark a variable for export without changing its value
 MYVAR=example
 export MYVAR
+# Create an empty read-only variable
+readonly MYCONST
 ```
 
 ```sh

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -203,8 +203,9 @@ variables. Using \fB-n\fP \fIname\fP removes the export attribute from
 current value is exported and it is created with an empty value if undefined.
 .TP
 .B readonly [-p] NAME[=VALUE]...
-Mark each variable as read-only or list all read-only variables. When listing,
-the variables are printed as \fBreadonly NAME=value\fP.
+Mark each variable as read-only or list all read-only variables. If no
+\fIvalue\fP is given and the variable does not exist, it is created with an
+empty value. When listing, the variables are printed as \fBreadonly NAME=value\fP.
 .TP
 .B local \fIname\fP[=value] ...
 Mark each variable as local to the current function. Previous values are

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -252,6 +252,7 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
   without removing it. Without `=VALUE` the variable's current value is
   exported and it is created with an empty value if undefined.
 - `readonly [-p] NAME[=VALUE]` - mark variables as read-only or list them.
+  Without `=VALUE` the variable is created with an empty value if undefined.
   With `-p` the variables are printed using `readonly NAME=value` format.
 - `local NAME[=VALUE]` - define a variable scoped to the current function.
 - `unset [-f] NAME` - remove an environment variable or function with `-f`.

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -328,8 +328,9 @@ int builtin_readonly(char **args) {
             add_readonly(arg);
             *eq = '=';
         } else {
-            if (get_shell_var(arg) || get_shell_array(arg, NULL))
-                add_readonly(arg);
+            if (!get_shell_var(arg) && !get_shell_array(arg, NULL))
+                set_shell_var(arg, "");
+            add_readonly(arg);
         }
     }
     return 1;


### PR DESCRIPTION
## Summary
- create variable with empty value when marking undefined names readonly
- document readonly variable creation and show example usage

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd2eb2bc8324a081ccf8915a34f3