### PR TITLE
Add job monitoring toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Current version: 0.1.0
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
  - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
-   `set -f`/`set +f`, `set -C`/`set +C`, `set -a` and `set -o OPTION` such as
+   `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -m`/`set +m` and `set -o OPTION` such as
    `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -261,7 +261,7 @@ Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
 \.B set [-e|-u|-x|-n|-f|-C|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -C prevents `>` from overwriting existing files (use +C to allow it again), -a exports all assignments,
+undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -C prevents `>` from overwriting existing files (use +C to allow it again), -a exports all assignments, -m enables background job tracking (use +m to disable),
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber has the same effect as -C.
 Use \+o with the option name or +C to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -221,7 +221,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again) and `set -a` exports all assignments to the environment.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment and `set -m`/`set +m` enable or disable background job tracking.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` (the same as `set -C`) prevents `>` from overwriting existing files. Use `set +o OPTION` or `set +C` to disable an option.
 
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -92,6 +92,8 @@ int builtin_set(char **args) {
             opt_noclobber = 1;
         else if (strcmp(args[i], "-a") == 0)
             opt_allexport = 1;
+        else if (strcmp(args[i], "-m") == 0)
+            opt_monitor = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 1;
@@ -119,6 +121,8 @@ int builtin_set(char **args) {
             opt_noclobber = 0;
         else if (strcmp(args[i], "+a") == 0)
             opt_allexport = 0;
+        else if (strcmp(args[i], "+m") == 0)
+            opt_monitor = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@ int opt_noclobber = 0;
 int opt_noexec = 0;
 int opt_noglob = 0;
 int opt_allexport = 0;
+int opt_monitor = 1;
 int current_lineno = 0;
 
 static void process_rc_file(const char *path, FILE *input);
@@ -237,7 +238,11 @@ static void repl_loop(FILE *input)
     int interactive = (input == stdin);
 
     while (1) {
-        check_jobs();
+        if (opt_monitor)
+            check_jobs();
+        else
+            while (waitpid(-1, NULL, WNOHANG) > 0)
+                ;
         if (interactive) {
             const char *ps = getenv("PS1");
             char *prompt = expand_prompt(ps ? ps : "vush> ");

--- a/src/options.h
+++ b/src/options.h
@@ -10,6 +10,7 @@ extern int opt_noclobber;
 extern int opt_noexec;
 extern int opt_noglob;
 extern int opt_allexport;
+extern int opt_monitor;
 extern int current_lineno;
 
 #endif /* OPTIONS_H */


### PR DESCRIPTION
## Summary
- track background jobs only when the new `opt_monitor` is enabled
- add `-m`/`+m` option handling to `set`
- document the monitor option in the manual and README

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849deb58490832480bfe8543f763841