### PR TITLE
Add set -b option for job notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Current version: 0.1.0
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
  - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
-   `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -m`/`set +m` and `set -o OPTION` such as
-   `pipefail` or `noclobber`
+  `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -b`/`set +b`, `set -m`/`set +m` and `set -o OPTION` such as
+  `pipefail` or `noclobber`
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -261,7 +261,7 @@ Evaluate an arithmetic expression and return success if the result is non-zero.
 .TP
 \.B set [-e|-u|-x|-n|-f|-C|-a|-o \fIoption\fP|+o \fIoption\fP] [-- \fIarg ...\fP]
 Toggle shell options. \-e exits on command failure, \-u errors on
-undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -C prevents `>` from overwriting existing files (use +C to allow it again), -a exports all assignments, -m enables background job tracking (use +m to disable),
+undefined variables, \-x prints each command before execution, -v echoes input lines as they are read, -n parses commands without executing them, -f disables wildcard expansion (use +f to re-enable), -C prevents `>` from overwriting existing files (use +C to allow it again), -a exports all assignments, -b prints a message when background jobs finish (use +b to disable), -m enables background job tracking (use +m to disable),
 \-o pipefail causes pipelines to return the status of the first failing
 command and \-o noclobber has the same effect as -C.
 Use \+o with the option name or +C to disable it again.  If any arguments

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -221,7 +221,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment and `set -m`/`set +m` enable or disable background job tracking.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment, `set -b`/`set +b` enable or disable background job completion messages and `set -m`/`set +m` enable or disable background job tracking.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` (the same as `set -C`) prevents `>` from overwriting existing files. Use `set +o OPTION` or `set +C` to disable an option.
 
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -92,6 +92,8 @@ int builtin_set(char **args) {
             opt_noclobber = 1;
         else if (strcmp(args[i], "-a") == 0)
             opt_allexport = 1;
+        else if (strcmp(args[i], "-b") == 0)
+            opt_notify = 1;
         else if (strcmp(args[i], "-m") == 0)
             opt_monitor = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
@@ -121,6 +123,8 @@ int builtin_set(char **args) {
             opt_noclobber = 0;
         else if (strcmp(args[i], "+a") == 0)
             opt_allexport = 0;
+        else if (strcmp(args[i], "+b") == 0)
+            opt_notify = 0;
         else if (strcmp(args[i], "+m") == 0)
             opt_monitor = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -82,7 +82,7 @@ void check_jobs(void) {
     int status;
     pid_t pid;
     while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
-        if (opt_monitor) {
+        if (opt_monitor && opt_notify) {
             Job *curr = jobs;
             while (curr && curr->pid != pid)
                 curr = curr->next;

--- a/src/main.c
+++ b/src/main.c
@@ -53,6 +53,7 @@ int opt_noexec = 0;
 int opt_noglob = 0;
 int opt_allexport = 0;
 int opt_monitor = 1;
+int opt_notify = 1;
 int current_lineno = 0;
 
 static void process_rc_file(const char *path, FILE *input);

--- a/src/options.h
+++ b/src/options.h
@@ -11,6 +11,7 @@ extern int opt_noexec;
 extern int opt_noglob;
 extern int opt_allexport;
 extern int opt_monitor;
+extern int opt_notify;
 extern int current_lineno;
 
 #endif /* OPTIONS_H */


### PR DESCRIPTION
## Summary
- introduce `opt_notify` option
- allow `set -b`/`set +b` to toggle job notifications
- only print job completion messages when `opt_notify` is enabled
- document the new behaviour in all manuals

## Testing
- `make`
- `tests/run_tests.sh` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e001770c8324b8754bbaa31877f4