### PR TITLE
Improve documentation of startup and options

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -4,6 +4,8 @@ vush \- simple POSIX-style shell
 .SH SYNOPSIS
 .B vush
 .RI [ scriptfile ]
+.br
+.BR vush " -c " command
 .SH DESCRIPTION
 vush is a lightweight POSIX-style shell focused on providing the
 essentials for interactive and scripted use. It supports job control,
@@ -16,6 +18,8 @@ Execute the provided command string and exit.
 .TP
 .BR -V , --version
 Print version information and exit.
+.SH STARTUP
+If no script file or -c option is given, \fB~/.vushrc\fP is read before the first prompt if it exists. When the \fBENV\fP variable is set, the file it names is processed afterward.
 .SH BUILTINS
 Built-in commands cover common shell tasks such as variable
 management, flow control and job handling. Refer to README.md for the

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -1,3 +1,11 @@
+## Synopsis
+
+`vush [scriptfile]`
+`vush -c "command"`
+`vush --version`
+
+Invoke without arguments for an interactive shell.
+
 ## Usage
 
 Run the `vush` binary and enter commands as you would in a normal shell.  You
@@ -13,6 +21,15 @@ interactively or pass `-c` followed by a command string.
 When invoked without a script file, commands from `~/.vushrc` are executed
 before the first prompt if that file exists.  If the `ENV` environment
 variable is set, its file is processed afterwards.
+
+## Options
+
+- `-c command` - execute the specified command string and exit.
+- `-V`, `--version` - display version information and exit.
+
+## Startup Files
+
+`~/.vushrc` is executed before the first prompt if it exists. When the `ENV` environment variable is set, the file it names is read after `~/.vushrc`.
 
 ### Shebang Scripts
 


### PR DESCRIPTION
## Summary
- document usage in new SYNOPSIS section
- describe command line options and startup files
- update man page to show `-c` usage and startup order

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849f27ca0bc8324890ba3e76943efe5