### PR TITLE
Add -nt/-ot/-ef tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Current version: 0.1.0
 - Conditional expressions using `[[ ... ]]` with pattern matching
 - POSIX `test` builtin supporting string, numeric and file operators
   like `-e`, `-f`, `-d`, `-r`, `-w`, `-x`, `-b`, `-c`, `-p`, `-h`/`-L`, `-s`,
-  `-O`, `-G`, `-u`, `-g`, `-k`, `-S` and `-t`
+  `-O`, `-G`, `-u`, `-g`, `-k`, `-S` and `-t`, as well as binary comparisons
+  `file1 -nt file2`, `file1 -ot file2` and `file1 -ef file2`
 - `case` selection statements with optional fall-through using `;&`
 - `select` loops presenting a numbered menu of choices
 - Input and output redirection with `<`, `>`, `>>`, `2>`, `2>>` and `&>`,
@@ -196,6 +197,8 @@ readonly MYCONST
 # Simple file tests
 test -d /tmp && echo "tmp exists"
 test -h /bin/sh && echo "linked shell"
+test file1 -nt file2 && echo "file1 newer"
+test file1 -ef link && echo "same file"
 ```
 
 ```sh

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -24,6 +24,8 @@ If no script file or -c option is given, \fB~/.vushrc\fP is read before the firs
 Built-in commands cover common shell tasks such as variable
 management, flow control and job handling. Refer to README.md for the
 complete list.
+The \fBtest\fP builtin also supports binary comparisons \fIfile1\fP \-nt
+\fIfile2\fP, \fIfile1\fP \-ot \fIfile2\fP and \fIfile1\fP \-ef \fIfile2\fP.
 .SH SHELL FEATURES
 Parameter, command and arithmetic expansion, wildcard matching,
 functions, history and background jobs are available. Expanded

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -298,7 +298,8 @@ The `set -o` form enables additional options: `pipefail` makes a pipeline return
 - `test EXPR` or `[ EXPR ]` - evaluate a conditional expression.  Supports
   string comparisons, numeric operators and POSIX unary file tests such as
   `-e`, `-f`, `-d`, `-r`, `-w`, `-x`, `-b`, `-c`, `-p`, `-h`/`-L`, `-s`, `-O`,
-  `-G`, `-u`, `-g`, `-k`, `-S` and `-t`.
+  `-G`, `-u`, `-g`, `-k`, `-S` and `-t`. Binary comparisons `file1 -nt file2`,
+  `file1 -ot file2` and `file1 -ef file2` are also available.
 - `[[ EXPR ]]` - evaluate a conditional expression with pattern matching.
 - Aliases are stored in the file specified by `VUSH_ALIASFILE` (default
   `~/.vush_aliases`).
@@ -396,6 +397,8 @@ vush> j=2; until test $j -eq 0; do echo $j; j=$(expr $j - 1); done
 1
 vush> if test -h /bin/sh; then echo link; fi
 link
+vush> test file1 -nt file2 && echo newer
+vush> test file1 -ef link && echo same
 vush> i=0; while true; do echo $i; break; done
 0
 vush> case 1 in 1) echo one ;& 2) echo two ;; esac

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -570,6 +570,25 @@ int builtin_test(char **args) {
             res = (atoi(av[0]) >= atoi(av[2])) ? 0 : 1;
         else if (strcmp(av[1], "-le") == 0)
             res = (atoi(av[0]) <= atoi(av[2])) ? 0 : 1;
+        else if (strcmp(av[1], "-nt") == 0) {
+            struct stat st1, st2;
+            if (stat(av[0], &st1) == 0 && stat(av[2], &st2) == 0)
+                res = (st1.st_mtime > st2.st_mtime) ? 0 : 1;
+            else
+                res = 1;
+        } else if (strcmp(av[1], "-ot") == 0) {
+            struct stat st1, st2;
+            if (stat(av[0], &st1) == 0 && stat(av[2], &st2) == 0)
+                res = (st1.st_mtime < st2.st_mtime) ? 0 : 1;
+            else
+                res = 1;
+        } else if (strcmp(av[1], "-ef") == 0) {
+            struct stat st1, st2;
+            if (stat(av[0], &st1) == 0 && stat(av[2], &st2) == 0)
+                res = (st1.st_dev == st2.st_dev && st1.st_ino == st2.st_ino) ? 0 : 1;
+            else
+                res = 1;
+        }
     }
     last_status = res;
     return 1;


### PR DESCRIPTION
## Summary
- support `-nt`, `-ot` and `-ef` operators in `test`
- document the new operators in README, vushdoc, and man page

## Testing
- `make`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849f8771bf48324a66a6ff3353e3f7d