### PR TITLE
Add >| redirection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Current version: 0.1.0
   `file1 -nt file2`, `file1 -ot file2` and `file1 -ef file2`
 - `case` selection statements with optional fall-through using `;&`
 - `select` loops presenting a numbered menu of choices
-- Input and output redirection with `<`, `>`, `>>`, `2>`, `2>>` and `&>`,
+- Input and output redirection with `<`, `>`, `>|`, `>>`, `2>`, `2>>` and `&>`,
   including descriptor duplication like `2>&1` or `>&file` and descriptor
   closure using `>&-` or `2>&-`
 - Persistent command history saved to `~/.vush_history` (overridable with `VUSH_HISTFILE`)
@@ -60,6 +60,7 @@ Current version: 0.1.0
  - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
   `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -b`/`set +b`, `set -m`/`set +m` and `set -o OPTION` such as
   `pipefail` or `noclobber`
+- Use `>| file` to force overwriting a file when `noclobber` is active
 - `set --` can replace positional parameters inside the running shell
 - Array assignments and `${name[index]}` access
 - Here-documents (`<<`) and here-strings (`<<<`)

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -34,6 +34,7 @@ optional text substitution.
 Parameter, command and arithmetic expansion, wildcard matching,
 functions, history and background jobs are available. Expanded
 examples reside in docs/vushdoc.md.
+The redirection operator \fB>|\fP forces truncation even when the \fBnoclobber\fP option is set.
 .SH ENVIRONMENT
 .TP
 .B VUSH_HISTFILE

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -255,6 +255,7 @@ three
 
 Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment, `set -b`/`set +b` enable or disable background job completion messages and `set -m`/`set +m` enable or disable background job tracking.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` (the same as `set -C`) prevents `>` from overwriting existing files. Use `set +o OPTION` or `set +C` to disable an option.
+Use `>| file` to override `noclobber` and force truncation of `file`.
 
 
 ## Built-in Commands

--- a/src/execute.c
+++ b/src/execute.c
@@ -228,7 +228,7 @@ void setup_redirections(PipelineSegment *seg) {
 
     if (seg->out_file && seg->err_file && strcmp(seg->out_file, seg->err_file) == 0 &&
         seg->append == seg->err_append) {
-        int fd = open_redirect(seg->out_file, seg->append);
+        int fd = open_redirect(seg->out_file, seg->append, seg->force);
         if (fd < 0) {
             perror(seg->out_file);
             exit(1);
@@ -238,7 +238,7 @@ void setup_redirections(PipelineSegment *seg) {
         close(fd);
     } else {
         if (seg->out_file) {
-            int fd = open_redirect(seg->out_file, seg->append);
+            int fd = open_redirect(seg->out_file, seg->append, seg->force);
             if (fd < 0) {
                 perror(seg->out_file);
                 exit(1);
@@ -246,7 +246,7 @@ void setup_redirections(PipelineSegment *seg) {
             redirect_fd(fd, STDOUT_FILENO);
         }
         if (seg->err_file) {
-            int fd = open_redirect(seg->err_file, seg->err_append);
+            int fd = open_redirect(seg->err_file, seg->err_append, 0);
             if (fd < 0) {
                 perror(seg->err_file);
                 exit(1);

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -38,6 +38,14 @@ static char *parse_redirect_token(char **p) {
         buf[len] = '\0';
         return strdup(buf);
     }
+    if (**p == '>' && *(*p + 1) == '|') {
+        buf[len++] = '>';
+        (*p)++;
+        buf[len++] = '|';
+        (*p)++;
+        buf[len] = '\0';
+        return strdup(buf);
+    }
     if (**p == '&' && *(*p + 1) != '&' && *(*p + 1) != '>') {
         buf[len++] = '&';
         (*p)++;

--- a/src/parser.h
+++ b/src/parser.h
@@ -18,6 +18,7 @@ typedef struct PipelineSegment {
     int here_doc;     /* input file is temporary here-doc */
     char *out_file;
     int append;
+    int force;       /* >| force overwrite */
     int dup_out;      /* > &N duplication */
     int close_out;    /* >&- close descriptor */
     char *err_file;

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -225,9 +225,10 @@ static int parse_input_redirect(PipelineSegment *seg, char **p, char *tok) {
 }
 
 static int parse_output_redirect(PipelineSegment *seg, char **p, char *tok) {
-    if (!(strcmp(tok, ">") == 0 || strcmp(tok, ">>") == 0))
+    if (!(strcmp(tok, ">") == 0 || strcmp(tok, ">>") == 0 || strcmp(tok, ">|") == 0))
         return 0;
     seg->append = (tok[1] == '>');
+    seg->force = (strcmp(tok, ">|") == 0);
     while (**p == ' ' || **p == '\t') (*p)++;
     if (**p == '&') {
         (*p)++;

--- a/src/util.c
+++ b/src/util.c
@@ -45,9 +45,9 @@ char *read_logical_line(FILE *f, char *buf, size_t size) {
     return buf;
 }
 
-int open_redirect(const char *path, int append) {
+int open_redirect(const char *path, int append, int force) {
     int flags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
-    if (opt_noclobber && !append)
+    if (opt_noclobber && !append && !force)
         flags |= O_EXCL;
     return open(path, flags, 0644);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -11,6 +11,7 @@
 char *read_logical_line(FILE *f, char *buf, size_t size);
 /* Open PATH for output redirection.
  * APPEND non-zero opens in append mode.
+ * FORCE overrides the noclobber option when set.
  * Returns a file descriptor or -1 on failure. */
-int open_redirect(const char *path, int append);
+int open_redirect(const char *path, int append, int force);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- support `>|` to override `noclobber`
- pass new `force` flag to `open_redirect`
- document the new syntax in README and docs

## Testing
- `make`
- `make test` *(fails: Permission denied running expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6849fd57acf88324aa9d2480a2d64911