### PR TITLE
Support REPLY in read builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ does; consult [docs/vushdoc.md](docs/vushdoc.md) for complete usage details.
 - `fc` and `history` &ndash; edit or list command history
 - `echo [-n] [-e] [args...]` &ndash; print text
 - `printf FORMAT [args...]` &ndash; formatted output
-- `read [-r] VAR...` &ndash; read a line of input
+- `read [-r] [-a NAME] [VAR...]` &ndash; read a line of input, storing it in
+  `$REPLY` when no variables are listed
 - `test EXPR` and `[[ EXPR ]]` &ndash; evaluate conditions
 - `:`/`true`/`false` &ndash; return fixed status codes
 - `return [status]` &ndash; exit from a function
@@ -207,6 +208,12 @@ test -d /tmp && echo "tmp exists"
 test -h /bin/sh && echo "linked shell"
 test file1 -nt file2 && echo "file1 newer"
 test file1 -ef link && echo "same file"
+```
+
+```sh
+# Read with no variable names stores the line in $REPLY
+read
+echo "You typed $REPLY"
 ```
 
 ```sh

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -91,6 +91,13 @@ Stored functions.
 starts an interactive shell. To run a script file use
 .B "vush script.vsh".
 More examples can be found in docs/vushdoc.md.
+.PP
+Reading without naming a variable stores the line in \fBREPLY\fP:
+.PP
+.nf
+$ printf "foo\n" | vush -c 'read; echo $REPLY'
+foo
+.fi
 .SH SEE ALSO
 README.md \- overview and quick start, docs/vushdoc.md \- examples and
 detailed explanations, the POSIX Shell specification

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -462,6 +462,13 @@ $ printf "hello\n" | ./vush script.vsh
 You typed: hello
 ```
 
+When no variable name is given the input goes into `$REPLY`:
+
+```sh
+read
+echo "You typed: $REPLY"
+```
+
 ## Type Example
 
 ```

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -24,9 +24,7 @@ static int parse_read_options(char **args, int *raw, const char **array_name,
         i += 2;
     }
 
-    if (!args[i])
-        return -1;
-
+    /* Do not error when no variable names remain */
     *idx = i;
     return 0;
 }
@@ -79,7 +77,7 @@ int builtin_read(char **args) {
     const char *array_name = NULL;
     int idx;
     if (parse_read_options(args, &raw, &array_name, &idx) != 0) {
-        fprintf(stderr, "usage: read [-r] [-a NAME] NAME...\n");
+        fprintf(stderr, "usage: read [-r] [-a NAME] [NAME...]\n");
         last_status = 1;
         return 1;
     }
@@ -119,7 +117,14 @@ int builtin_read(char **args) {
             free(vals[i]);
         free(vals);
     } else {
-        assign_read_vars(args, idx, line);
+        int var_count = 0;
+        for (int i = idx; args[i]; i++)
+            var_count++;
+        if (var_count == 0) {
+            set_shell_var("REPLY", line);
+        } else {
+            assign_read_vars(args, idx, line);
+        }
     }
     last_status = 0;
     return 1;


### PR DESCRIPTION
## Summary
- allow `read` with no variable names by adjusting option parsing
- store data in `REPLY` when the variable list is empty
- note the new behaviour in docs and manual

## Testing
- `make`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684a04568ee48324bfa365bbd833b4da