### PR TITLE
Implement unset -v option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Current version: 0.1.0
 - Maximum history size of 1000 entries (overridable with `VUSH_HISTSIZE`)
 - Alias definitions persisted in `~/.vush_aliases` (overridable with `VUSH_ALIASFILE`)
 - Function definitions persisted in `~/.vush_funcs` (overridable with `VUSH_FUNCFILE`)
-- Functions can be removed with `unset -f`
+- Variables can be removed with `unset -v` and functions with `unset -f`
 - Arrow-key command line editing with history recall
 - `Ctrl-A`/`Home` moves to the beginning of the line, `Ctrl-E`/`End` to the end
   and `Ctrl-U` clears back to the start
@@ -88,7 +88,7 @@ does; consult [docs/vushdoc.md](docs/vushdoc.md) for complete usage details.
 - `export [-p|-n NAME] NAME[=VALUE]` &ndash; set or display exported variables
 - `readonly [-p] NAME[=VALUE]` &ndash; mark variables read-only
 - `local NAME[=VALUE]` &ndash; define a local variable in a function
-- `unset [-f] NAME` &ndash; remove variables or functions
+- `unset [-f|-v] NAME` &ndash; remove functions with `-f`, variables with `-v`, or both
 - `set [options] [-- args...]` &ndash; change shell options or parameters
 - `shift [N]` &ndash; rotate positional parameters
 - `alias [-p] [NAME[=VALUE]]` &ndash; define command aliases

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -28,6 +28,7 @@ The \fBtest\fP builtin also supports binary comparisons \fIfile1\fP \-nt
 \fIfile2\fP, \fIfile1\fP \-ot \fIfile2\fP and \fIfile1\fP \-ef \fIfile2\fP.
 The \fBtrap\fP builtin lists available signal names when invoked with \-l.
 The \fBkill\fP builtin prints a signal name when \-l is followed by a number.
+The \fBunset\fP builtin removes variables and functions; \-v targets variables and \-f functions.
 The \fBfg\fP and \fBbg\fP builtins operate on the most recently started
 background job when no ID is given.
 History can be manipulated using \fBfc\fP.  The \-n flag omits numbers when

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -290,7 +290,7 @@ Use `>| file` to override `noclobber` and force truncation of `file`.
   Without `=VALUE` the variable is created with an empty value if undefined.
   With `-p` the variables are printed using `readonly NAME=value` format.
 - `local NAME[=VALUE]` - define a variable scoped to the current function.
-- `unset [-f] NAME` - remove an environment variable or function with `-f`.
+- `unset [-f|-v] NAME` - remove functions with `-f`, variables with `-v`, or both.
 - `history [-c|-d NUMBER]` - show command history, clear it with `-c`, or delete a specific entry with `-d`.
   Entries are read from and written to the file specified by `VUSH_HISTFILE`
   (default `~/.vush_history`). History size is controlled by the

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -454,7 +454,7 @@ int builtin_help(char **args) {
     printf("  kill [-s SIG|-SIGNAL] [-l] ID|PID  Send a signal or list signals\n");
     printf("  export [-p|-n NAME] NAME[=VALUE]  Manage exported variables\n");
     printf("  readonly [-p] NAME[=VALUE]  Mark variable as read-only or list them\n");
-    printf("  unset NAME          Remove an environment variable\n");
+    printf("  unset [-f|-v] NAME  Remove functions with -f or variables with -v\n");
     printf("  history [-c|-d NUM]   Show or modify command history\n");
     printf("  hash [-r] [name...]   Manage cached command paths\n");
     printf("  alias [-p] [NAME[=VALUE]]  Set or list aliases\n");

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -206,21 +206,33 @@ int builtin_let(char **args) {
  */
 int builtin_unset(char **args) {
     int remove_func = 0;
+    int remove_vars = 0;
     int i = 1;
-    if (args[i] && strcmp(args[i], "-f") == 0) {
-        remove_func = 1;
+    while (args[i] && args[i][0] == '-') {
+        if (strcmp(args[i], "-f") == 0)
+            remove_func = 1;
+        else if (strcmp(args[i], "-v") == 0)
+            remove_vars = 1;
+        else
+            break;
         i++;
     }
+    if (!remove_func && !remove_vars) {
+        remove_func = remove_vars = 1;
+    }
     if (!args[i]) {
-        fprintf(stderr, "usage: unset [-f] NAME...\n");
+        fprintf(stderr, "usage: unset [-f|-v] NAME...\n");
         return 1;
     }
     for (; args[i]; i++) {
         char *name = args[i];
         if (remove_func) {
             remove_function(name);
-            continue;
+            if (!remove_vars)
+                continue;
         }
+        if (!remove_vars)
+            continue;
         char *lb = strchr(name, '[');
         if (lb && name[strlen(name)-1] == ']') {
             char *endptr;


### PR DESCRIPTION
## Summary
- extend `unset` to accept `-v` along with `-f`
- update builtin help and usage messages
- document the new option across docs and README

## Testing
- `./run_tests.sh` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684a07b739c083248eab4e566ad9109b