### PR TITLE
Add PPID expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Current version: 0.1.0
 - `${VAR%pat}`, `${VAR%%pat}` and `${#VAR}`
 - `$?` expands to the exit status of the last foreground command
 - `$$` expands to the PID of the running shell and `$!` to the last background job
+- `$PPID` expands to the PID of the shell's parent process
 - `$-` expands to the currently enabled option letters
 - `$LINENO` expands to the current input line number
  - Wildcard expansion for unquoted `*` and `?` patterns (disable with `set -f`,

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -24,7 +24,10 @@ If no script file or -c option is given, \fB~/.vushrc\fP is read before the firs
 Built-in commands cover common shell tasks such as variable
 management, flow control and job handling. Refer to README.md for the
 complete list.
-The BtestP builtin recognizes the unary B!P operator and the binary B-aP and B-oP operators with standard precedence. It also supports binary comparisons Ifile1P -nt Ifile2P, Ifile1P -ot Ifile2P and Ifile1P -ef Ifile2P.
+functions, history and background jobs are available. Special
+parameters like \$\$, \$!, \$PPID and \$LINENO provide process and
+status information. Expanded examples reside in docs/vushdoc.md.
+P builtin recognizes the unary B!P operator and the binary B-aP and B-oP operators with standard precedence. It also supports binary comparisons Ifile1P -nt Ifile2P, Ifile1P -ot Ifile2P and Ifile1P -ef Ifile2P.
 The \fBtrap\fP builtin lists available signal names when invoked with \-l.
 The \fBkill\fP builtin prints a signal name when \-l is followed by a number.
 The \fBunset\fP builtin removes variables and functions; \-v targets variables and \-f functions.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -108,6 +108,8 @@ vush> echo $(echo hi)
 hi
 vush> echo $$
 12345
+vush> echo $PPID
+12344
 vush> sleep 1 &
 vush> echo $!
 12346
@@ -120,9 +122,9 @@ vush> echo $?
 ```
 
 `$$` expands to the PID of the running shell while `$!` gives the PID of the
-most recent background job. `$-` expands to a string of the current option
-letters such as `eu` when `set -e` and `set -u` are enabled. `$LINENO` holds
-the current input line number.
+most recent background job. `$PPID` yields the parent process ID. `$-` expands
+to a string of the current option letters such as `eu` when `set -e` and
+`set -u` are enabled. `$LINENO` holds the current input line number.
 
 Additional parameter expansion forms (doubling `#` or `%` removes the
 longest matching prefix or suffix):

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -368,6 +368,11 @@ static char *expand_special(const char *token) {
         snprintf(buf, sizeof(buf), "%d", (int)getpid());
         return strdup(buf);
     }
+    if (strcmp(token, "$PPID") == 0 || strcmp(token, "${PPID}") == 0) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%d", (int)parent_pid);
+        return strdup(buf);
+    }
     if (strcmp(token, "$!") == 0) {
         char buf[16];
         if (last_bg_pid == 0)

--- a/src/main.c
+++ b/src/main.c
@@ -57,6 +57,7 @@ int opt_allexport = 0;
 int opt_monitor = 1;
 int opt_notify = 1;
 int current_lineno = 0;
+pid_t parent_pid = 0;
 
 static void process_rc_file(const char *path, FILE *input);
 static void process_startup_file(FILE *input);
@@ -431,6 +432,8 @@ int main(int argc, char **argv) {
 
     FILE *input = stdin;
     char *dash_c = NULL;
+
+    parent_pid = getppid();
 
     if (argc > 1) {
         if (strcmp(argv[1], "-V") == 0 || strcmp(argv[1], "--version") == 0) {

--- a/src/options.h
+++ b/src/options.h
@@ -1,6 +1,8 @@
 #ifndef OPTIONS_H
 #define OPTIONS_H
 
+#include <sys/types.h>
+
 extern int opt_errexit;
 extern int opt_nounset;
 extern int opt_xtrace;
@@ -13,5 +15,6 @@ extern int opt_allexport;
 extern int opt_monitor;
 extern int opt_notify;
 extern int current_lineno;
+extern pid_t parent_pid;
 
 #endif /* OPTIONS_H */


### PR DESCRIPTION
## Summary
- record parent PID at startup
- expose `$PPID` in special parameter expansion
- document `$PPID` in all docs

## Testing
- `make test` *(fails: ./run_tests.sh: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684a4d6bcb188324ab8d04860205ce49