### PR TITLE
Support base prefix in arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current version: 0.1.0
 - Command substitution using backticks or `$(...)`
 - Arithmetic expansion using `$((...))` and a `let` builtin
 - Numbers may specify a base using `<base>#<digits>` inside arithmetic expressions
+  (bases 2–36)
 - Background job management using `&`
 - Simple pipelines using `|` to connect commands
 - Process substitution using `<(cmd)` and `>(cmd)`

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -27,7 +27,9 @@ complete list.
 functions, history and background jobs are available. Special
 parameters like \$\$, \$!, \$PPID and \$LINENO provide process and
 status information. Expanded examples reside in docs/vushdoc.md.
-P builtin recognizes the unary B!P operator and the binary B-aP and B-oP operators with standard precedence. It also supports binary comparisons Ifile1P -nt Ifile2P, Ifile1P -ot Ifile2P and Ifile1P -ef Ifile2P.
+functions, history and background jobs are available. Numbers may be
+prefixed with \fIbase\fB#\fRdigits to select bases 2\(en36. Expanded
+B!P operator and the binary B-aP and B-oP operators with standard precedence. It also supports binary comparisons Ifile1P -nt Ifile2P, Ifile1P -ot Ifile2P and Ifile1P -ef Ifile2P.
 The \fBtrap\fP builtin lists available signal names when invoked with \-l.
 The \fBkill\fP builtin prints a signal name when \-l is followed by a number.
 The \fBunset\fP builtin removes variables and functions; \-v targets variables and \-f functions.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -519,6 +519,9 @@ two
 
 ## Arithmetic Example
 
+Numbers inside arithmetic expressions may begin with `<base>#` to specify
+bases 2–36.
+
 ```sh
 vush> echo $((16#ff + 2#10))
 257

--- a/src/arith.c
+++ b/src/arith.c
@@ -58,17 +58,18 @@ static long parse_primary(const char **s) {
         if (!val) val = getenv(name);
         return val ? strtol(val, NULL, 10) : 0;
     }
+    const char *p = *s;
     char *end;
-    long base = strtol(*s, &end, 10);
-    if (end > *s && *end == '#') {
+    long base = strtol(p, &end, 10);
+    if (end > p && *end == '#') {
         if (base >= 2 && base <= 36) {
-            const char *num = end + 1;
-            long val = strtol(num, &end, (int)base);
+            p = end + 1;
+            long val = strtol(p, &end, (int)base);
             *s = end;
             return val;
         }
     }
-    long v = strtol(*s, &end, 10);
+    long v = strtol(p, &end, 10);
     *s = end;
     return v;
 }


### PR DESCRIPTION
## Summary
- parse primary numbers of the form `<base>#<number>`
- mention the base prefix syntax in README, docs/vushdoc.md and man page

## Testing
- `tests/run_tests.sh` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684a50f160248324aa5f80e1c2573e94