### PR TITLE
Fix const pointer warning in fc builtin

### DIFF
--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -124,10 +124,17 @@ int builtin_fc(char **args)
             cmd = temp ? temp : cmd;
         }
         printf("%s\n", cmd);
-        Command *cmds = parse_line(cmd);
+        char *mutable = strdup(cmd);
+        if (!mutable) {
+            perror("strdup");
+            free(temp);
+            return 1;
+        }
+        Command *cmds = parse_line(mutable);
         if (cmds && cmds->pipeline && cmds->pipeline->argv[0])
             run_command_list(cmds, cmd);
         free_commands(cmds);
+        free(mutable);
         free(temp);
         return 1;
     }


### PR DESCRIPTION
## Summary
- fix discarded qualifiers warning in `builtin_fc` by duplicating command string
- rebuild to ensure no warnings

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684a58e8d524832498db7239ac38b47f