### PR TITLE
Fix bounded copy in builtin_cd fallback

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -143,8 +143,10 @@ int builtin_cd(char **args) {
     char newpwd[PATH_MAX];
     if (physical) {
         if (!realpath(".", newpwd)) {
-            if (!getcwd(newpwd, sizeof(newpwd)))
-                strcpy(newpwd, dir);
+            if (!getcwd(newpwd, sizeof(newpwd))) {
+                strncpy(newpwd, dir, sizeof(newpwd) - 1);
+                newpwd[PATH_MAX - 1] = '\0';
+            }
         }
     } else {
         if (dir[0] == '/') {


### PR DESCRIPTION
## Summary
- replace `strcpy` with `strncpy` when falling back after `realpath`/`getcwd` errors

## Testing
- `make`
- `make test` *(fails: Permission denied running expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684a5ada1534832493d30b340ee67f3f