### PR TITLE
Fix realloc failure handling in read builtin

### DIFF
--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -43,9 +43,15 @@ static char **split_array_values(char *line, int *count, char sep) {
             p++;
         if (*p)
             *p++ = '\0';
-        vals = realloc(vals, sizeof(char *) * (*count + 1));
-        if (!vals)
+        char **tmp = realloc(vals, sizeof(char *) * (*count + 1));
+        if (!tmp) {
+            for (int i = 0; i < *count; i++)
+                free(vals[i]);
+            free(vals);
+            *count = 0;
             return NULL;
+        }
+        vals = tmp;
         vals[*count] = strdup(start);
         (*count)++;
     }


### PR DESCRIPTION
## Summary
- use temporary pointer for realloc in split_array_values
- free intermediate strings if realloc fails

## Testing
- `make`
- `make test` *(fails: `expect` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a5f4864748324b8c1b8699b1846eb