### PR TITLE
Fix NULL check in REPL line concatenation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -389,6 +389,13 @@ static void repl_loop(FILE *input)
                 size_t len1 = strlen(cmdline);
                 size_t len2 = strlen(more);
                 char *tmp = malloc(len1 + len2 + 2);
+                if (!tmp) {
+                    perror("malloc");
+                    free(cmdline);
+                    free(more);
+                    cmdline = NULL;
+                    break;
+                }
                 memcpy(tmp, cmdline, len1);
                 tmp[len1] = '\n';
                 memcpy(tmp + len1 + 1, more, len2 + 1);


### PR DESCRIPTION
## Summary
- check for `malloc` failure when joining continued command lines
- report the error and exit the line-reading loop when allocation fails

## Testing
- `make`
- `make test` *(fails: expect interpreter missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a5fd73c888324b0ea1c54be9b330e