### PR TITLE
Add hashall option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ Current version: 0.1.0
 - `set -p` enters privileged mode and skips startup files; use `set +p` to
   re-enable them
 - `set -t` exits after a single command. Example:\
-  `vush$ set -t; echo hi` prints `hi` and the shell terminates.
+`vush$ set -t; echo hi` prints `hi` and the shell terminates.
+- `set -h` automatically caches command paths; use `set +h` to disable.
 - Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
  - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
   `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -b`/`set +b`, `set -m`/`set +m`,
-  `set -t`/`set +t`, `set -p`/`set +p` and `set -o OPTION` such as
+ `set -t`/`set +t`, `set -p`/`set +p`, `set -h`/`set +h` and `set -o OPTION` such as
   `pipefail` or `noclobber`
 - Use `>| file` to force overwriting a file when `noclobber` is active
 - `set --` can replace positional parameters inside the running shell

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -19,7 +19,7 @@ Execute the provided command string and exit.
 .BR -V , --version
 Print version information and exit.
 .SH STARTUP
-If no script file or -c option is given, \fB~/.vushrc\fP is read before the first prompt if it exists. When the \fBENV\fP variable is set, the file it names is processed afterward. Enabling \fBset -p\fP prevents both files from being loaded. The \fBset -t\fP option exits after a single command is executed.
+If no script file or -c option is given, \fB~/.vushrc\fP is read before the first prompt if it exists. When the \fBENV\fP variable is set, the file it names is processed afterward. Enabling \fBset -p\fP prevents both files from being loaded. The \fBset -t\fP option exits after a single command is executed. The \fBset -h\fP option caches each command after it runs.
 .SH BUILTINS
 Built-in commands cover common shell tasks such as variable
 management, flow control and job handling. Refer to README.md for the

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -25,7 +25,8 @@ When invoked without a script file, commands from `~/.vushrc` are executed
 before the first prompt if that file exists.  If the `ENV` environment
 variable is set, its file is processed afterwards.  The `set -p` option
 suppresses both files when enabled.  The `set -t` option exits after one
-command is executed.
+command is executed.  The `set -h` option caches each command after
+execution.
 
 ## Options
 
@@ -257,7 +258,7 @@ three
 ```
 ### Shell Options
 
-Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment, `set -b`/`set +b` enable or disable background job completion messages, `set -m`/`set +m` toggle job tracking, `set -t`/`set +t` exit after one command and `set -p`/`set +p` enable or disable privileged mode which skips startup files.
+Use the `set` builtin to toggle behavior. `set -e` exits on command failure, `set -u` errors on undefined variables, `set -x` prints each command before execution, `set -v` echoes input lines as they are read, `set -n` parses commands without running them, `set -f` disables wildcard expansion (use `set +f` to re-enable), `set -C` prevents `>` from overwriting existing files (use `set +C` to allow clobbering again), `set -a` exports all assignments to the environment, `set -b`/`set +b` enable or disable background job completion messages, `set -m`/`set +m` toggle job tracking, `set -t`/`set +t` exit after one command, `set -p`/`set +p` toggle privileged mode which skips startup files and `set -h`/`set +h` automatically cache commands in the hash table.
 The `set -o` form enables additional options: `pipefail` makes a pipeline return the status of the first failing command while `noclobber` (the same as `set -C`) prevents `>` from overwriting existing files. Use `set +o OPTION` or `set +C` to disable an option.
 Use `>| file` to override `noclobber` and force truncation of `file`.
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -100,6 +100,8 @@ int builtin_set(char **args) {
             opt_privileged = 1;
         else if (strcmp(args[i], "-t") == 0)
             opt_onecmd = 1;
+        else if (strcmp(args[i], "-h") == 0)
+            opt_hashall = 1;
         else if (strcmp(args[i], "-o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 1;
@@ -135,6 +137,8 @@ int builtin_set(char **args) {
             opt_privileged = 0;
         else if (strcmp(args[i], "+t") == 0)
             opt_onecmd = 0;
+        else if (strcmp(args[i], "+h") == 0)
+            opt_hashall = 0;
         else if (strcmp(args[i], "+o") == 0 && args[i+1]) {
             if (strcmp(args[i+1], "pipefail") == 0)
                 opt_pipefail = 0;

--- a/src/execute.c
+++ b/src/execute.c
@@ -283,8 +283,6 @@ static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
     int i = 0;
     int in_fd = -1;
     for (PipelineSegment *seg = pipeline; seg; seg = seg->next) {
-        if (seg->argv[0] && !strchr(seg->argv[0], '/'))
-            hash_add(seg->argv[0]);
         pid_t pid = fork_segment(seg, &in_fd);
         if (pid < 0) {
             free(pids);
@@ -575,6 +573,12 @@ static int exec_group(Command *cmd, const char *line) {
 int run_pipeline(Command *cmd, const char *line) {
     if (!cmd)
         return 0;
+    if (opt_hashall && cmd->type == CMD_PIPELINE) {
+        for (PipelineSegment *seg = cmd->pipeline; seg; seg = seg->next) {
+            if (seg->argv[0] && !strchr(seg->argv[0], '/'))
+                hash_add(seg->argv[0]);
+        }
+    }
     int r = 0;
     switch (cmd->type) {
     case CMD_PIPELINE:

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,7 @@ int opt_monitor = 1;
 int opt_notify = 1;
 int opt_privileged = 0;
 int opt_onecmd = 0;
+int opt_hashall = 0;
 int current_lineno = 0;
 pid_t parent_pid = 0;
 

--- a/src/options.h
+++ b/src/options.h
@@ -16,6 +16,7 @@ extern int opt_monitor;
 extern int opt_notify;
 extern int opt_privileged;
 extern int opt_onecmd;
+extern int opt_hashall;
 extern int current_lineno;
 extern pid_t parent_pid;
 


### PR DESCRIPTION
## Summary
- add `opt_hashall` to manage automatic command hashing
- parse `set -h` and `set +h` in builtins
- hash commands when `opt_hashall` is enabled
- document the new option in README and docs

## Testing
- `make test` *(fails: ./run_tests.sh: 153: ./test_ps1.expect: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684ae63670848324a214207d06cf6650