### PR TITLE
Fix export PS1 crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Current version: 0.1.0
 - `set -k` treats `NAME=value` after the command name as a temporary
   environment assignment. Example:\
 `vush$ set -k; sh -c 'echo $FOO' FOO=bar` prints `bar`.
-- Prompt string configurable via the `PS1` environment variable (see [docs/vush.1](docs/vush.1) for details)
+ - Prompt string configurable via the `PS1` environment variable, which may be exported safely (see [docs/vush.1](docs/vush.1) for details)
 - `exit` accepts an optional status argument
  - Shell options toggled with `set -e`, `set -u`, `set -x`, `set -v`, `set -n`,
   `set -f`/`set +f`, `set -C`/`set +C`, `set -a`, `set -b`/`set +b`, `set -m`/`set +m`,

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -32,7 +32,8 @@ prefixed with \fIbase\fB#\fRdigits to select bases 2\(en36. Expanded
 B!P operator and the binary B-aP and B-oP operators with standard precedence. It also supports binary comparisons Ifile1P -nt Ifile2.B SHELL
 Path to the running shell executable.
 .TP
-P, Ifile1P -ot Ifile2P and Ifile1P -ef Ifile2P.
+P, Primary command prompt string. May be exported safely.
+P -ot Ifile2P and Ifile1P -ef Ifile2P.
 The \fBtrap\fP builtin lists available signal names when invoked with \-l.
 The \fBkill\fP builtin prints a signal name when \-l is followed by a number.
 The \fBunset\fP builtin removes variables and functions; \-v targets variables and \-f functions.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -550,7 +550,7 @@ vush> echo $((16#ff + 2#10))
 ## Configuration
 
 ### Environment Variables
-- `PS1` sets the prompt before each command (default `vush> `).
+ - `PS1` sets the prompt before each command (default `vush> `) and may be exported safely.
 - `PS2` appears when more input is needed such as after an unclosed quote (default `> `).
 - `PS3` is used by the `select` builtin when prompting for a choice.
 - `PS4` prefixes tracing output produced by `set -x`.

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -315,9 +315,13 @@ int builtin_export(char **args) {
         char *eq = strchr(arg, '=');
         if (eq) {
             *eq = '\0';
-            if (setenv(arg, eq + 1, 1) != 0)
-                perror("export");
-            set_shell_var(arg, eq + 1);
+            char *valdup = strdup(eq + 1);
+            if (valdup) {
+                if (setenv(arg, valdup, 1) != 0)
+                    perror("export");
+                set_shell_var(arg, valdup);
+                free(valdup);
+            }
             *eq = '=';
         } else {
             const char *val = get_shell_var(arg);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,6 +6,7 @@ tests="
     test_basic_cmd.expect
     test_env.expect
     test_ps1.expect
+    test_export_ps1.expect
     test_ps1_cmdsub.expect
     test_pwd.expect
     test_cd_dash.expect

--- a/tests/test_export_ps1.expect
+++ b/tests/test_export_ps1.expect
@@ -1,0 +1,8 @@
+#!/usr/bin/expect -f
+set timeout 5
+spawn ../vush
+expect "vush> "
+send "export PS1='custom> '\r"
+expect "custom> "
+send "exit\r"
+expect eof


### PR DESCRIPTION
## Summary
- duplicate export value before calling `setenv`
- add regression test for exporting PS1
- document that PS1 can be exported safely

## Testing
- `make`
- `make test` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684af6c484bc83248e7b21cc95b53904