### PR TITLE
Document PS1 export safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ environment variables:
   (default 1000).
 - `VUSH_ALIASFILE` holds persistent aliases (default `~/.vush_aliases`).
 - `VUSH_FUNCFILE` holds persistent functions (default `~/.vush_funcs`).
-- `PS1` sets the command prompt displayed before each input line.
+- `PS1` sets the command prompt displayed before each input line and may be exported safely.
 - `PS2` is shown when more input is needed, such as for unmatched quotes.
 - `PS3` is the prompt used by the `select` builtin.
 - `PS4` prefixes trace output produced by `set -x`.

--- a/docs/vush.1
+++ b/docs/vush.1
@@ -33,7 +33,8 @@ B!P operator and the binary B-aP and B-oP operators with standard precedenc
 Path to the running shell executable.
 .TP
 P, Primary command prompt string. May be exported safely.
-P -ot Ifile2P and Ifile1P -ef Ifile2P.
+Primary command prompt string. May be exported safely.
+Ifile2P and Ifile1P -ef Ifile2P.
 The \fBtrap\fP builtin lists available signal names when invoked with \-l.
 The \fBkill\fP builtin prints a signal name when \-l is followed by a number.
 The \fBunset\fP builtin removes variables and functions; \-v targets variables and \-f functions.


### PR DESCRIPTION
## Summary
- clarify in `README.md` that `PS1` can be exported safely
- document `PS1` export safety in the manual

## Testing
- `make test` *(fails: `/usr/bin/expect` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684afde97d1c8324b45d9259102815ec