### PR TITLE
Fix missing free on history expansion failure

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -609,8 +609,10 @@ char *expand_history(const char *line) {
     size_t exp_len = strlen(expansion);
     size_t rest_len = strlen(rest);
     char *res = malloc(pre_len + exp_len + rest_len + 1);
-    if (!res)
+    if (!res) {
+        free(expansion);
         return NULL;
+    }
     memcpy(res, line, pre_len);
     memcpy(res + pre_len, expansion, exp_len);
     memcpy(res + pre_len + exp_len, rest, rest_len + 1);


### PR DESCRIPTION
## Summary
- free `expansion` when allocation of `res` fails in `expand_history`

## Testing
- `make test` *(fails: expect scripts have CRLF issues / environment problems)*

------
https://chatgpt.com/codex/tasks/task_e_684b619f65288324bfd245da82c42987