### PR TITLE
Fix prompt expansion buffer allocation

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -732,7 +732,9 @@ char *expand_prompt(const char *prompt) {
     if (!prompt)
         return strdup("");
     size_t len = strlen(prompt);
-    char tmp[len + 3];
+    char *tmp = malloc(len + 3);
+    if (!tmp)
+        return strdup("");
     tmp[0] = '"';
     memcpy(tmp + 1, prompt, len);
     tmp[len + 1] = '"';
@@ -740,6 +742,7 @@ char *expand_prompt(const char *prompt) {
     char *p = tmp;
     int quoted = 0;
     char *res = read_token(&p, &quoted);
+    free(tmp);
     if (!res)
         return strdup("");
     return res;


### PR DESCRIPTION
## Summary
- allocate the prompt buffer with `malloc` instead of using a VLA
- free the temporary buffer before returning

## Testing
- `make`
- `make test` *(fails: `test_basic_cmd.expect` and others due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b61a09f7883248e67b83d86b4aeb4