### PR TITLE
Improve memory allocation checks in gather_until

### DIFF
--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -109,6 +109,11 @@ char *gather_until(char **p, const char **stops, int nstops, int *idx) {
             res = tmp;
         } else {
             res = strdup(tok);
+            if (!res) {
+                free(tok);
+                free(res);
+                return NULL;
+            }
         }
         free(tok);
     }


### PR DESCRIPTION
## Summary
- check results of `strdup(tok)` in `gather_until`
- free existing allocations and return `NULL` on failure

## Testing
- `make -j$(nproc)`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b640b06d48324a1880c5e7bff5fdc