### PR TITLE
Handle alias allocation failures

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -72,52 +72,97 @@ static int is_assignment(const char *tok) {
 }
 
 /* alias expansion helpers */
-static void collect_alias_tokens(const char *name, char **out, int *count,
-                                 char visited[][MAX_LINE], int depth) {
+static int collect_alias_tokens(const char *name, char **out, int *count,
+                                char visited[][MAX_LINE], int depth) {
     if (*count >= MAX_TOKENS - 1)
-        return;
+        return 0;
+
+    int start = *count;
+
     if (depth >= MAX_ALIAS_DEPTH) {
-        out[(*count)++] = strdup(name);
-        return;
+        char *cp = strdup(name);
+        if (!cp)
+            return -1;
+        out[(*count)++] = cp;
+        return 0;
     }
+
     for (int i = 0; i < depth; i++) {
         if (strcmp(visited[i], name) == 0) {
-            out[(*count)++] = strdup(name);
-            return;
+            char *cp = strdup(name);
+            if (!cp)
+                return -1;
+            out[(*count)++] = cp;
+            return 0;
         }
     }
+
     const char *alias = get_alias(name);
     if (!alias) {
-        out[(*count)++] = strdup(name);
-        return;
+        char *cp = strdup(name);
+        if (!cp)
+            return -1;
+        out[(*count)++] = cp;
+        return 0;
     }
+
     strncpy(visited[depth], name, MAX_LINE);
     visited[depth][MAX_LINE - 1] = '\0';
+
     char *dup = strdup(alias);
+    if (!dup)
+        return -1;
+
     char *sp = NULL;
     char *word = strtok_r(dup, " \t", &sp);
     if (!word) {
         free(dup);
-        return;
+        return 0;
     }
-    collect_alias_tokens(word, out, count, visited, depth + 1);
+
+    if (collect_alias_tokens(word, out, count, visited, depth + 1) == -1) {
+        free(dup);
+        goto error;
+    }
+
     word = strtok_r(NULL, " \t", &sp);
     while (word && *count < MAX_TOKENS - 1) {
-        out[(*count)++] = strdup(word);
+        char *cp = strdup(word);
+        if (!cp) {
+            free(dup);
+            goto error;
+        }
+        out[(*count)++] = cp;
         word = strtok_r(NULL, " \t", &sp);
     }
+
     free(dup);
+    return 0;
+
+error:
+    for (int i = start; i < *count; i++)
+        free(out[i]);
+    *count = start;
+    return -1;
 }
 
 static int expand_aliases_in_segment(PipelineSegment *seg, int *argc, char *tok) {
     const char *alias = get_alias(tok);
     if (!alias)
         return 0;
+
     char *orig = tok;
     char *tokens[MAX_TOKENS];
     int count = 0;
     char visited[MAX_ALIAS_DEPTH][MAX_LINE];
-    collect_alias_tokens(orig, tokens, &count, visited, 0);
+
+    if (collect_alias_tokens(orig, tokens, &count, visited, 0) == -1) {
+        free(orig);
+        for (int i = 0; i < count; i++)
+            free(tokens[i]);
+        return -1;
+    }
+
     free(orig);
     for (int i = 0; i < count && *argc < MAX_TOKENS - 1; i++)
         seg->argv[(*argc)++] = tokens[i];
@@ -376,7 +421,10 @@ static int handle_assignment_or_alias(PipelineSegment *seg, int *argc, char **p,
         return 1;
     }
     if (!quoted && *argc == 0) {
-        if (expand_aliases_in_segment(seg, argc, tok)) {
+        int r = expand_aliases_in_segment(seg, argc, tok);
+        if (r == -1)
+            return -1;
+        if (r == 1) {
             *tok_ptr = NULL;
             return 1;
         }


### PR DESCRIPTION
## Summary
- free duplicate tokens on strdup failure
- propagate alias expansion errors
- abort alias expansion when allocation fails

## Testing
- `make`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b641000248324b819718c7800a8ff