### PR TITLE
Handle strdup failures in brace expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -632,6 +632,10 @@ char **expand_braces(const char *word, int *count_out) {
         char **res = malloc(2 * sizeof(char *));
         if (!res) return NULL;
         res[0] = strdup(word);
+        if (!res[0]) {
+            free(res);
+            return NULL;
+        }
         res[1] = NULL;
         if (count_out) *count_out = 1;
         return res;

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -417,21 +417,20 @@ static int start_new_segment(char **p, PipelineSegment **seg_ptr, int *argc) {
 }
 
 static char **expand_token_braces(char *tok, int quoted, int *count) {
-    char **btoks = NULL;
-    if (!quoted)
-        btoks = expand_braces(tok, count);
-    if (!btoks) {
-        btoks = malloc(2 * sizeof(char *));
-        if (!btoks) {
-            free(tok);
-            return NULL;
-        }
-        btoks[0] = tok;
-        btoks[1] = NULL;
-        if (count) *count = 1;
-    } else {
+    if (!quoted) {
+        char **btoks = expand_braces(tok, count);
         free(tok);
+        return btoks;
     }
+
+    char **btoks = malloc(2 * sizeof(char *));
+    if (!btoks) {
+        free(tok);
+        return NULL;
+    }
+    btoks[0] = tok;
+    btoks[1] = NULL;
+    if (count) *count = 1;
     return btoks;
 }
 


### PR DESCRIPTION
## Summary
- check `strdup` results in `expand_braces`
- return NULL on brace expansion allocation failures
- propagate errors from `expand_braces` to callers

## Testing
- `make -j4`
- `make test` *(fails: Permission denied running expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b641185c083249adf0703d54963ca