### PR TITLE
Fix strdup checks in read builtin array handling

### DIFF
--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -53,6 +53,13 @@ static char **split_array_values(char *line, int *count, char sep) {
         }
         vals = tmp;
         vals[*count] = strdup(start);
+        if (!vals[*count]) {
+            for (int i = 0; i < *count; i++)
+                free(vals[i]);
+            free(vals);
+            *count = 0;
+            return NULL;
+        }
         (*count)++;
     }
     return vals;
@@ -121,12 +128,12 @@ int builtin_read(char **args) {
     if (array_mode) {
         int count = 0;
         char **vals = split_array_values(line, &count, sep);
-        if (!vals)
-            count = 0;
-        set_shell_array(array_name, vals, count);
-        for (int i = 0; i < count; i++)
-            free(vals[i]);
-        free(vals);
+        if (vals) {
+            set_shell_array(array_name, vals, count);
+            for (int i = 0; i < count; i++)
+                free(vals[i]);
+            free(vals);
+        }
     } else {
         int var_count = 0;
         for (int i = idx; args[i]; i++)


### PR DESCRIPTION
## Summary
- check `strdup` results in `split_array_values`
- free previously allocated elements on failure
- skip setting the array if allocation fails

## Testing
- `make`
- `make test` *(fails: invalid Expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b640c7e5c8324a81c87ccc62dcefb