### PR TITLE
Improve error handling in define_function

### DIFF
--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -105,11 +105,20 @@ void define_function(const char *name, Command *body, const char *text)
 {
     for (struct func_entry *f = functions; f; f = f->next) {
         if (strcmp(f->name, name) == 0) {
+            char *new_name = strdup(name);
+            char *new_text = strdup(text);
+            if (!new_name || !new_text) {
+                perror("strdup");
+                free(new_name);
+                free(new_text);
+                free_commands(body);
+                return;
+            }
             free(f->name);
             free(f->text);
             free_commands(f->body);
-            f->name = strdup(name);
-            f->text = strdup(text);
+            f->name = new_name;
+            f->text = new_text;
             f->body = body;
             return;
         }
@@ -117,10 +126,21 @@ void define_function(const char *name, Command *body, const char *text)
     struct func_entry *fn = malloc(sizeof(struct func_entry));
     if (!fn) {
         perror("malloc");
+        free_commands(body);
         return;
     }
-    fn->name = strdup(name);
-    fn->text = strdup(text);
+    char *name_copy = strdup(name);
+    char *text_copy = strdup(text);
+    if (!name_copy || !text_copy) {
+        perror("strdup");
+        free(name_copy);
+        free(text_copy);
+        free(fn);
+        free_commands(body);
+        return;
+    }
+    fn->name = name_copy;
+    fn->text = text_copy;
     fn->body = body;
     fn->next = functions;
     functions = fn;


### PR DESCRIPTION
## Summary
- validate `strdup` return values in `define_function`
- clean up resources when duplications fail
- keep existing function definitions intact on error

## Testing
- `make`
- `make test` *(fails: invalid Expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b640e43ec8324a682abf6f0e16164