### PR TITLE
Handle allocation failures in parse_pipeline

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -595,6 +595,8 @@ static Command *parse_pipeline(char **p, CmdOp *op_out) {
         return cmd;
     }
     PipelineSegment *seg_head = calloc(1, sizeof(PipelineSegment));
+    if (!seg_head)
+        return NULL;
     seg_head->dup_out = -1;
     seg_head->dup_err = -1;
     seg_head->out_fd = STDOUT_FILENO;
@@ -611,6 +613,10 @@ static Command *parse_pipeline(char **p, CmdOp *op_out) {
     }
     finalize_segment(seg, argc, &background);
     Command *cmd = calloc(1, sizeof(Command));
+    if (!cmd) {
+        free_pipeline(seg_head);
+        return NULL;
+    }
     cmd->pipeline = seg_head;
     cmd->background = background;
     cmd->negate = negate;


### PR DESCRIPTION
## Summary
- guard allocations of `PipelineSegment` and `Command`
- free intermediate structures on failure

## Testing
- `make test` *(fails: test suite scripts not executable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684b66a7da9883248fe0e0a8706c37e2