### PR TITLE
Validate segment count in canonicalize_logical

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Current version: 0.1.0
 - Maximum history size of 1000 entries (overridable with `VUSH_HISTSIZE`)
 - Alias definitions persisted in `~/.vush_aliases` (overridable with `VUSH_ALIASFILE`)
 - Function definitions persisted in `~/.vush_funcs` (overridable with `VUSH_FUNCFILE`)
+- Logical path cleanup handles at most `PATH_MAX/2` components
 - Variables can be removed with `unset -v` and functions with `unset -f`
 - Arrow-key command line editing with history recall
 - `Ctrl-A`/`Home` moves to the beginning of the line, `Ctrl-E`/`End` to the end

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -282,6 +282,7 @@ hi
 ## Built-in Commands
 
 - `cd [-L|-P] [dir]` - change the current directory. Without an argument it switches to `$HOME`. `~user` names are expanded using the password database. After a successful change `PWD` and `OLDPWD` are updated. Use `cd -` to print and switch to `$OLDPWD`. `-L` (default) keeps `PWD` as the logical path while `-P` resolves the target with `realpath()` and sets `PWD` to the physical location. If `dir` does not begin with `/` or `.`, each directory listed in the `CDPATH` environment variable is searched. When a `CDPATH` entry is used the resulting path is printed.
+  Logical canonicalization processes at most `PATH_MAX/2` components.
 - `pushd dir` - push the current directory and change to `dir`.
 - `popd` - return to the directory from the stack.
 - `printf FORMAT [args...]` - print formatted text. Backslash escapes in

--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -26,6 +26,7 @@ static void canonicalize_logical(const char *path, char *out)
     tmp[PATH_MAX - 1] = '\0';
     char *parts[PATH_MAX / 2];
     int sp = 0;
+    const int max_parts = sizeof(parts) / sizeof(parts[0]);
     char *save;
     for (char *t = strtok_r(tmp, "/", &save); t; t = strtok_r(NULL, "/", &save)) {
         if (strcmp(t, ".") == 0) {
@@ -34,6 +35,11 @@ static void canonicalize_logical(const char *path, char *out)
             if (sp > 0)
                 sp--;
         } else {
+            if (sp >= max_parts) {
+                fprintf(stderr,
+                        "cd: path has too many components\n");
+                break;
+            }
             parts[sp++] = t;
         }
     }


### PR DESCRIPTION
## Summary
- guard against overflow in `canonicalize_logical`
- note maximum supported path components in the documentation

## Testing
- `make`
- `tests/run_tests.sh` *(fails: `expect` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b66d97ff483248be7c3dbbeac5315