### PR TITLE
Fix last_bg_id update logic

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -46,19 +46,19 @@ static int last_bg_id = 0;
  */
 void add_job(pid_t pid, const char *cmd) {
     last_bg_pid = pid;
-    last_bg_id = next_job_id;
     if (!opt_monitor)
         return;
     Job *job = malloc(sizeof(Job));
-    if (!job) return;
+    if (!job)
+        return;
     job->id = next_job_id++;
-    last_bg_id = job->id;
     job->pid = pid;
     job->state = JOB_RUNNING;
     strncpy(job->cmd, cmd, MAX_LINE - 1);
     job->cmd[MAX_LINE - 1] = '\0';
     job->next = jobs;
     jobs = job;
+    last_bg_id = job->id;
 }
 
 /*


### PR DESCRIPTION
## Summary
- update `add_job` so `last_bg_id` is set only after allocating a job entry
- keep `last_bg_id` unchanged when memory allocation fails

## Testing
- `make test` *(fails: invalid command name errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b66df3a7883248c7645e81a9a829e