### PR TITLE
Fix printf %b failure leak

### DIFF
--- a/src/builtins_print.c
+++ b/src/builtins_print.c
@@ -206,6 +206,7 @@ int builtin_printf(char **args)
             if (!buf) {
                 perror("printf");
                 last_status = 1;
+                free(fmt);
                 return 1;
             }
             char *bp = buf;


### PR DESCRIPTION
## Summary
- fix memory leak if buffer allocation fails in builtin `printf`

## Testing
- `make -j$(nproc)`
- `make test` *(fails: Permission denied running test scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a72a1f4832487fa9b7f7fddad42