### PR TITLE
Fix completion directory leak

### DIFF
--- a/src/completion.c
+++ b/src/completion.c
@@ -64,7 +64,12 @@ static char **collect_matches(const char *prefix, int prefix_len, int *countp) {
     }
 
     DIR *d = opendir(".");
-    if (d && matches) {
+    if (!matches) {
+        if (d)
+            closedir(d); /* early return when initial allocation failed */
+        return NULL;
+    }
+    if (d) {
         struct dirent *de;
         while ((de = readdir(d))) {
             if (strncmp(de->d_name, prefix, prefix_len) == 0) {


### PR DESCRIPTION
## Summary
- avoid leaking directory descriptor on completion errors
- document early return after memory allocation failure

## Testing
- `make`
- `make test` *(fails: Permission denied running expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a672b80832490b8dbf5815715a2