### PR TITLE
Implement mail list cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ environment variables:
 - `MAIL` names a mailbox file checked before each prompt. A notice is printed
   when it is modified.
 - `MAILPATH` may list multiple mailbox files separated by `:`. Each triggers a
-  `New mail in <file>` message when updated.
+  `New mail in <file>` message when updated. Memory used to remember mailbox
+  timestamps is released when the shell exits.
 - `CDPATH` provides directories searched by `cd` for relative paths. `cd` also
   accepts `-L` (logical, default) and `-P` (physical) to control how paths are
   resolved. With `-L` `PWD` reflects the logical path while `-P` resolves the

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -558,7 +558,8 @@ vush> echo $((16#ff + 2#10))
 - `MAIL` names a mailbox file checked before each prompt. A notice is printed
   when the file's modification time increases.
 - `MAILPATH` is a `:` separated list of mailbox files also checked. Each path
-  prints `New mail in <file>` when updated.
+  prints `New mail in <file>` when updated. Memory used to track mailbox
+  modification times is freed when the shell exits.
 - `VUSH_HISTFILE` names the history file; `VUSH_HISTSIZE` limits retained entries (defaults `~/.vush_history` and `1000`).
 - `VUSH_ALIASFILE` and `VUSH_FUNCFILE` store persistent aliases and functions (defaults `~/.vush_aliases` and `~/.vush_funcs`).
 - `CDPATH` lists directories searched by `cd` for relative paths.

--- a/src/main.c
+++ b/src/main.c
@@ -276,6 +276,19 @@ static void remember_mail_time(const char *path, time_t mtime)
     mail_list = e;
 }
 
+/* Free all MailEntry structures tracked for mail notifications. */
+static void free_mail_list(void)
+{
+    MailEntry *e = mail_list;
+    while (e) {
+        MailEntry *next = e->next;
+        free(e->path);
+        free(e);
+        e = next;
+    }
+    mail_list = NULL;
+}
+
 static void check_mail(void)
 {
     char *mpath = getenv("MAILPATH");
@@ -504,6 +517,7 @@ int main(int argc, char **argv) {
     run_exit_trap();
     free(script_argv);
     free_aliases();
+    free_mail_list();
     free_functions();
     return dash_c ? last_status : 0;
 }


### PR DESCRIPTION
## Summary
- free memory used by remembered mailbox entries
- run `free_mail_list()` at program shutdown
- document release of mail tracking memory

## Testing
- `make`
- `./tests/run_tests.sh` *(fails: "invalid command name", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a6cfae883249380dd8cfbc14bcb