### PR TITLE
Handle strdup failure in record_local_var

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -167,6 +167,11 @@ void record_local_var(const char *name) {
     if (!lv)
         return;
     lv->name = strdup(name);
+    if (!lv->name) {
+        perror("strdup");
+        free(lv);
+        return;
+    }
     const char *val = get_shell_var(name);
     int len = 0;
     char **arr = get_shell_array(name, &len);


### PR DESCRIPTION
## Summary
- guard against `strdup` failure when recording local variables
- report the error with `perror` and clean up the partially allocated struct

## Testing
- `make`
- `make test` *(fails: invalid command name errors from expect scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684b8a4de50c832482a4fe9d6428f3e8