### PR TITLE
Fix trap cleanup

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -60,6 +60,7 @@ void list_signals(void);
 extern char *trap_cmds[NSIG];
 extern char *exit_trap_cmd;
 void run_exit_trap(void);
+void free_trap_cmds(void);
 int builtin_trap(char **args);
 
 #endif /* BUILTINS_H */

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -183,3 +183,14 @@ int builtin_continue(char **args)
     return 1;
 }
 
+/* Free all registered trap command strings. */
+void free_trap_cmds(void)
+{
+    for (int i = 0; i < NSIG; i++) {
+        if (trap_cmds[i]) {
+            free(trap_cmds[i]);
+            trap_cmds[i] = NULL;
+        }
+    }
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -128,6 +128,8 @@ void run_exit_trap(void)
     }
     free_commands(cmds);
     parse_input = prev;
+    free(exit_trap_cmd);
+    exit_trap_cmd = NULL;
 }
 
 /*
@@ -519,6 +521,7 @@ int main(int argc, char **argv) {
     free_aliases();
     free_mail_list();
     free_functions();
+    free_trap_cmds();
     return dash_c ? last_status : 0;
 }
 


### PR DESCRIPTION
## Summary
- clean up all trap command strings on exit
- release EXIT trap string after running it

## Testing
- `make`
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b8a6530f483248e8f841a6a29d286