### PR TITLE
Fix NULL check when duplicating variable names

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -256,6 +256,11 @@ void set_shell_var(const char *name, const char *value) {
     struct var_entry *v = malloc(sizeof(struct var_entry));
     if (!v) { perror("malloc"); return; }
     v->name = strdup(name);
+    if (!v->name) {
+        perror("strdup");
+        free(v);
+        return;
+    }
     v->value = strdup(value);
     if (!v->value) {
         perror("strdup");


### PR DESCRIPTION
## Summary
- check result of `strdup(name)` in `set_shell_var`
- free the new struct and abort when duplication fails

## Testing
- `make`
- `make test` *(fails: Permission denied / missing expect)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b1372688324b23ce754ae9fe7d9