### PR TITLE
Clear command history before shutdown

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -517,6 +517,7 @@ int main(int argc, char **argv) {
     if (input != stdin)
         fclose(input);
     run_exit_trap();
+    clear_history();
     free(script_argv);
     free_aliases();
     free_mail_list();


### PR DESCRIPTION
## Summary
- clear command history when exiting

## Testing
- `make -j4`
- `make test` *(fails: ./test_basic_cmd.expect: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b96c030348324aea2df1d3c27cfe6