### PR TITLE
Fix cleanup for here-doc and parse errors

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3,6 +3,7 @@
  */
 #include "parser.h"
 #include <stdlib.h>
+#include <unistd.h>
 
 FILE *parse_input = NULL;
 int parse_need_more = 0;
@@ -16,6 +17,8 @@ void free_pipeline(PipelineSegment *p) {
         for (int i = 0; i < p->assign_count; i++)
             free(p->assigns[i]);
         free(p->assigns);
+        if (p->here_doc && p->in_file)
+            unlink(p->in_file);
         free(p->in_file);
         free(p->out_file);
         if (p->err_file && p->err_file != p->out_file)

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -649,6 +649,7 @@ Command *parse_line(char *line) {
             cmd = parse_pipeline(&p, &op);
         if (!cmd) {
             free_commands(head);
+            cleanup_proc_subs();
             if (!parse_need_more)
                 last_status = 1;
             return NULL;


### PR DESCRIPTION
## Summary
- remove here-doc temp files when freeing pipeline segments
- clean up process substitutions if `parse_line` errors

## Testing
- `make -B`
- `make test` *(fails: invalid command name errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b96c993b08324b581ed7395afb2d8