### PR TITLE
Fix script argument cleanup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -521,7 +521,11 @@ int main(int argc, char **argv) {
     run_exit_trap();
     clear_history();
     dirstack_clear();
-    free(script_argv);
+    if (script_argv) {
+        for (int i = 1; i <= script_argc; i++)
+            free(script_argv[i]);
+        free(script_argv);
+    }
     free_aliases();
     free_mail_list();
     free_functions();


### PR DESCRIPTION
## Summary
- free each script argument before freeing `script_argv`

## Testing
- `make test` *(fails: `./run_tests.sh: 154: ./test_env.expect: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_684b982ab8b4832493a49f01e4f1232c