### PR TITLE
Fix zero-length array handling

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -283,7 +283,8 @@ void set_shell_array(const char *name, char **values, int count) {
     }
     for (struct var_entry *v = shell_vars; v; v = v->next) {
         if (strcmp(v->name, name) == 0) {
-            char **new_arr = calloc(count, sizeof(char *));
+            size_t alloc_count = count ? count : 1;
+            char **new_arr = calloc(alloc_count, sizeof(char *));
             if (!new_arr) {
                 perror("calloc");
                 return;
@@ -323,7 +324,8 @@ void set_shell_array(const char *name, char **values, int count) {
     }
     v->value = NULL;
 
-    char **new_arr = calloc(count, sizeof(char *));
+    size_t alloc_count = count ? count : 1;
+    char **new_arr = calloc(alloc_count, sizeof(char *));
     if (!new_arr) {
         perror("calloc");
         free(v->name);


### PR DESCRIPTION
## Summary
- prevent `calloc(0, ...)` in `set_shell_array`
- allocate one element when arrays are empty

## Testing
- `make test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b198fb88324bffcf463812426ea