### PR TITLE
Fix temp assignment memory handling

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -148,7 +148,16 @@ static int apply_temp_assignments(PipelineSegment *pipeline) {
         char *var;
         int had_env;
         int had_var;
-    } backs[pipeline->assign_count];
+    } *backs = NULL;
+
+    if (pipeline->assign_count > 0) {
+        backs = calloc(pipeline->assign_count, sizeof(*backs));
+        if (!backs) {
+            perror("calloc");
+            last_status = 1;
+            return 1;
+        }
+    }
 
     for (int i = 0; i < pipeline->assign_count; i++) {
         char *eq = strchr(pipeline->assigns[i], '=');
@@ -265,6 +274,8 @@ static int apply_temp_assignments(PipelineSegment *pipeline) {
         free(backs[i].env);
         free(backs[i].var);
     }
+
+    free(backs);
 
     return handled;
 }


### PR DESCRIPTION
## Summary
- use `calloc` instead of a VLA for temporary variable backups
- free this memory before returning from `apply_temp_assignments`
- abort the command with an error if allocation fails

## Testing
- `make test` *(fails: Permission denied running tests)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b14913c832499afe3a33994045c