### PR TITLE
Update local scope management

### DIFF
--- a/src/func_exec.c
+++ b/src/func_exec.c
@@ -61,7 +61,14 @@ int run_function(Command *body, char **args) {
         }
     }
     script_argv[argc] = NULL;
-    push_local_scope();
+    if (!push_local_scope()) {
+        for (int i = 0; i < argc; i++)
+            free(script_argv[i]);
+        free(script_argv);
+        script_argv = old_argv;
+        script_argc = old_argc;
+        return 1;
+    }
     func_return = 0;
     run_command_list(body, NULL);
     pop_local_scope();

--- a/src/vars.c
+++ b/src/vars.c
@@ -117,12 +117,13 @@ static struct local_var *find_local_var(struct local_frame *f, const char *name)
     return NULL;
 }
 
-void push_local_scope(void) {
+int push_local_scope(void) {
     struct local_frame *f = calloc(1, sizeof(*f));
     if (!f)
-        return;
+        return 0;
     f->next = local_stack;
     local_stack = f;
+    return 1;
 }
 
 void pop_local_scope(void) {

--- a/src/vars.h
+++ b/src/vars.h
@@ -7,7 +7,12 @@ void set_shell_var(const char *name, const char *value);
 void set_shell_array(const char *name, char **values, int count);
 void unset_shell_var(const char *name);
 void free_shell_vars(void);
-void push_local_scope(void);
+/*
+ * Push a new local scope for shell variables.
+ *
+ * Returns 1 on success and 0 if memory allocation fails.
+ */
+int push_local_scope(void);
 void pop_local_scope(void);
 void add_readonly(const char *name);
 void record_local_var(const char *name);


### PR DESCRIPTION
## Summary
- return success indicator from `push_local_scope`
- check return value in `run_function`
- document `push_local_scope` return value

## Testing
- `make vush`
- `make test` *(fails: `test_basic_cmd.expect` and others due to missing `expect` interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b0ec8388324b3eef4b501ec91c1