### PR TITLE
Reset getopts state when modifying $@

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -58,6 +58,9 @@ int builtin_cond(char **args);
 void list_signals(void);
 
 extern char *trap_cmds[NSIG];
+/* Maintains state across getopts calls. Must be cleared when script_argv
+ * changes so it never points into freed memory. */
+extern char *getopts_pos;
 extern char *exit_trap_cmd;
 void run_exit_trap(void);
 void free_trap_cmds(void);

--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -32,6 +32,7 @@ static int prepare_source_args(char **args, int *old_argc, char ***old_argv,
 
     script_argc = *new_argc;
     script_argv = calloc(argc + 1, sizeof(char *));
+    getopts_pos = NULL; /* $@ changed for sourced file */
     if (!script_argv) {
         script_argc = *old_argc;
         script_argv = *old_argv;
@@ -59,6 +60,7 @@ static void restore_source_args(int old_argc, char **old_argv, int new_argc)
     free(script_argv);
     script_argv = old_argv;
     script_argc = old_argc;
+    getopts_pos = NULL; /* argv replaced; reset getopts pointer */
 }
 
 static void execute_source_file(FILE *input)

--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -7,7 +7,10 @@
 #include <string.h>
 extern int last_status;
 
-static char *getopts_pos = NULL;
+/* Pointer into the current $@ item being parsed by getopts. When script_argv
+ * is replaced or freed this must be cleared so it does not reference stale
+ * memory. */
+char *getopts_pos = NULL;
 
 static int read_optind(void)
 {

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -56,6 +56,7 @@ int builtin_shift(char **args) {
         script_argv[i - n] = script_argv[i];
     script_argc -= n;
     script_argv[script_argc + 1] = NULL;
+    getopts_pos = NULL; /* shifting invalidates cached $@ state for getopts */
     return 1;
 }
 
@@ -190,6 +191,7 @@ int builtin_set(char **args) {
         }
         script_argv = newv;
         script_argc = count;
+        getopts_pos = NULL; /* new $@ invalidates getopts parsing state */
     }
     return 1;
 }

--- a/src/func_exec.c
+++ b/src/func_exec.c
@@ -44,6 +44,7 @@ int run_function(Command *body, char **args) {
     char **old_argv = script_argv;
     script_argc = argc - 1;
     script_argv = calloc(argc + 1, sizeof(char *));
+    getopts_pos = NULL; /* new $@ may invalidate getopts parsing state */
     if (!script_argv) {
         script_argc = old_argc;
         script_argv = old_argv;
@@ -70,5 +71,6 @@ int run_function(Command *body, char **args) {
     free(script_argv);
     script_argv = old_argv;
     script_argc = old_argc;
+    getopts_pos = NULL; /* freed argv, so clear getopts pointer */
     return last_status;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -525,6 +525,7 @@ int main(int argc, char **argv) {
         for (int i = 1; i <= script_argc; i++)
             free(script_argv[i]);
         free(script_argv);
+        getopts_pos = NULL;
     }
     free_aliases();
     free_mail_list();


### PR DESCRIPTION
## Summary
- clear `getopts_pos` whenever script arguments are changed
- export `getopts_pos` for other modules

## Testing
- `make clean && make`
- `make test` *(fails: ./run_tests.sh - Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b03f4908324aaf10b3f6e3d603c