### PR TITLE
Fix alias expansion cleanup

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -164,8 +164,11 @@ static int expand_aliases_in_segment(PipelineSegment *seg, int *argc, char *tok)
     }
 
     free(orig);
-    for (int i = 0; i < count && *argc < MAX_TOKENS - 1; i++)
+    int i = 0;
+    for (; i < count && *argc < MAX_TOKENS - 1; i++)
         seg->argv[(*argc)++] = tokens[i];
+    for (; i < count; i++)
+        free(tokens[i]);
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- free any uninserted alias tokens

## Testing
- `make test` *(fails: `expect` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba044072c83248a9cd0b1766b08a8