### PR TITLE
Improve safety around printf parsing and script args

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -489,11 +489,27 @@ int main(int argc, char **argv) {
             script_argv = calloc(argc, sizeof(char *));
             if (!script_argv) {
                 perror("calloc");
+                fclose(input);
                 return 1;
             }
-            script_argv[0] = argv[1];
-            for (int i = 0; i < script_argc; i++)
-                script_argv[i + 1] = argv[i + 2];
+            script_argv[0] = strdup(argv[1]);
+            if (!script_argv[0]) {
+                perror("strdup");
+                free(script_argv);
+                fclose(input);
+                return 1;
+            }
+            for (int i = 0; i < script_argc; i++) {
+                script_argv[i + 1] = strdup(argv[i + 2]);
+                if (!script_argv[i + 1]) {
+                    perror("strdup");
+                    for (int j = 0; j <= i; j++)
+                        free(script_argv[j]);
+                    free(script_argv);
+                    fclose(input);
+                    return 1;
+                }
+            }
             script_argv[script_argc + 1] = NULL;
         }
     }


### PR DESCRIPTION
## Summary
- duplicate script arguments so the strings can be freed
- avoid overrunning printf format spec buffer
- free unused tokens from alias and brace expansion

## Testing
- `make test` *(fails: Permission denied running test scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684ba0493478832483fe8f61db0d68d0