### PR TITLE
Fix fc -s buffer allocation

### DIFF
--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -117,12 +117,18 @@ int builtin_fc(char **args)
             char *eq = strchr(subst, '=');
             if (!eq)
                 return 1;
-            char old[eq - subst + 1];
+            char *old = malloc(eq - subst + 1);
+            if (!old) {
+                perror("malloc");
+                free(temp);
+                return 1;
+            }
             memcpy(old, subst, eq - subst);
             old[eq - subst] = '\0';
             const char *new = eq + 1;
             temp = replace_first(cmd, old, new);
             cmd = temp ? temp : cmd;
+            free(old);
         }
         printf("%s\n", cmd);
         char *mutable = strdup(cmd);


### PR DESCRIPTION
## Summary
- fix fc `-s` option to allocate memory for the old string
- abort the `-s` path if allocation fails

## Testing
- `make`
- `(cd tests && ./run_tests.sh)` *(fails: Permission denied for many test scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684ba80b75048324af4fa550a4d9280f