### PR TITLE
Check strdup result in repl

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -374,6 +374,10 @@ static void repl_loop(FILE *input)
         char *cmdline = strdup(line);
         if (line != linebuf)
             free(line);
+        if (!cmdline) {
+            perror("strdup");
+            break;
+        }
 
         while (1) {
             char *expanded = expand_history(cmdline);


### PR DESCRIPTION
## Summary
- guard `cmdline` allocation in `repl_loop`

## Testing
- `make test` *(fails: `expect` scripts report "invalid command name" errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ba8372d908324b76fc3976e441bb9