### PR TITLE
Add phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ CFLAGS ?= -Wall -Wextra -std=c99
 PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
 
+.PHONY: clean test install uninstall
+
 SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c \
        src/builtins_alias.c src/builtins_func.c src/builtins_vars.c \
        src/builtins_read.c src/builtins_getopts.c src/builtins_exec.c src/vars.c \


### PR DESCRIPTION
## Summary
- list phony targets so make knows these are not files

## Testing
- `make test` *(fails: Permission denied errors from tests)*

------
https://chatgpt.com/codex/tasks/task_e_684bb197986c8324b1b3751f5b4702ec