### PR TITLE
Check for expect before running tests

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
 failed=0
 
 tests="


### PR DESCRIPTION
## Summary
- ensure `tests/run_tests.sh` fails fast if `expect` is missing

## Testing
- `make test` *(fails: invalid command name)*

------
https://chatgpt.com/codex/tasks/task_e_684bb78e8e008324a1dc248718106ae2