### PR TITLE
Fix PATH search handling

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -27,14 +27,19 @@ static char *search_path(const char *name) {
         return NULL;
     char *save = NULL;
     char *dir = strtok_r(paths, ":", &save);
-    char full[PATH_MAX];
     char *result = NULL;
     while (dir) {
-        snprintf(full, sizeof(full), "%s/%s", dir, name);
-        if (access(full, X_OK) == 0) {
-            result = strdup(full);
+        const char *d = *dir ? dir : ".";
+        char *full = NULL;
+        if (asprintf(&full, "%s/%s", d, name) < 0) {
+            result = NULL;
             break;
         }
+        if (access(full, X_OK) == 0) {
+            result = full;
+            break;
+        }
+        free(full);
         dir = strtok_r(NULL, ":", &save);
     }
     free(paths);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -148,6 +148,8 @@ tests="
     test_test_bool.expect
     test_time_p.expect
     test_base_arith.expect
+    test_path_blank.expect
+    test_path_long.expect
 "
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_path_blank.expect
+++ b/tests/test_path_blank.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [exec mktemp -d]
+set scriptdir [file normalize [file dirname [info script]]]
+set f [open "$dir/foo" "w"]
+puts $f "#!/bin/sh"
+puts $f "echo blankpath"
+close $f
+exec chmod +x "$dir/foo"
+cd $dir
+set env(PATH) ":/bin"
+spawn $scriptdir/../vush
+expect "vush> "
+send "foo\r"
+expect {
+    -re "[\r\n]+blankpath[\r\n]+vush> " {}
+    timeout { send_user "blank PATH entry failed\n"; cd $scriptdir; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect eof
+cd $scriptdir
+exec rm -rf $dir

--- a/tests/test_path_long.expect
+++ b/tests/test_path_long.expect
@@ -1,0 +1,24 @@
+#!/usr/bin/env expect
+set timeout 5
+set base [exec mktemp -d]
+set long $base
+for {set i 0} {$i < 350} {incr i} {
+    append long "/abcdefghij"
+    file mkdir $long
+}
+set f [open "$long/foo" "w"]
+puts $f "#!/bin/sh"
+puts $f "echo longpath"
+close $f
+exec chmod +x "$long/foo"
+set env(PATH) "$long:/bin"
+spawn ../vush
+expect "vush> "
+send "foo\r"
+expect {
+    -re "[\r\n]+longpath[\r\n]+vush> " {}
+    timeout { send_user "long PATH failed\n"; exec rm -rf $base; exit 1 }
+}
+send "exit\r"
+expect eof
+exec rm -rf $base


### PR DESCRIPTION
## Summary
- handle blank PATH entries in `search_path` and completion search
- dynamically allocate path buffers to avoid truncation
- add regression tests for blank and extremely long PATH values

## Testing
- `make test` *(fails: `invalid command name "` errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bb772c34c83249502f2edbce73780