### PR TITLE
Fix Makefile build with object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,16 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/hash.c \
        src/main.c
 
-vush: $(SRCS)
-	$(CC) $(CFLAGS) -o $@ $(SRCS)
+OBJS := $(patsubst src/%.c,%.o,$(SRCS))
+
+vush: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS)
+
+%.o: src/%.c
+	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f vush *.o
+	rm -f vush $(OBJS)
 
 
 test: vush


### PR DESCRIPTION
## Summary
- compile each C source into an object file and link them
- clean up generated object files

## Testing
- `apt-get update`
- `apt-get install -y expect`
- `make`
- `make test` *(fails: invalid command names reported by expect)*

------
https://chatgpt.com/codex/tasks/task_e_684bb88c6c688324bfdbb69ae81f1479