### PR TITLE
Dynamic path buffer allocation

### DIFF
--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -114,9 +114,15 @@ int builtin_source(char **args) {
                 char *save = NULL;
                 for (char *p = strtok_r(paths, ":", &save); p; p = strtok_r(NULL, ":", &save)) {
                     const char *base = *p ? p : ".";
-                    char full[PATH_MAX];
-                    snprintf(full, sizeof(full), "%s/%s", base, args[1]);
+                    size_t len = strlen(base) + strlen(args[1]) + 2;
+                    char *full = malloc(len);
+                    if (!full) {
+                        input = NULL;
+                        break;
+                    }
+                    snprintf(full, len, "%s/%s", base, args[1]);
                     input = fopen(full, "r");
+                    free(full);
                     if (input)
                         break;
                 }
@@ -246,16 +252,21 @@ int builtin_command(char **args) {
             char *dir = strtok_r(paths, ":", &saveptr);
             int found = 0;
             while (dir) {
-                char full[PATH_MAX];
-                snprintf(full, sizeof(full), "%s/%s", dir, args[i]);
+                size_t len = strlen(dir) + strlen(args[i]) + 2;
+                char *full = malloc(len);
+                if (!full)
+                    break;
+                snprintf(full, len, "%s/%s", dir, args[i]);
                 if (access(full, X_OK) == 0) {
                     if (opt_V)
                         printf("%s is %s\n", args[i], full);
                     else
                         printf("%s\n", full);
                     found = 1;
+                    free(full);
                     break;
                 }
+                free(full);
                 dir = strtok_r(NULL, ":", &saveptr);
             }
             free(paths);

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -124,13 +124,18 @@ int builtin_type(char **args) {
         char *dir = strtok_r(paths, ":", &saveptr);
         int found = 0;
         while (dir) {
-            char full[PATH_MAX];
-            snprintf(full, sizeof(full), "%s/%s", dir, args[i]);
+            size_t len = strlen(dir) + strlen(args[i]) + 2;
+            char *full = malloc(len);
+            if (!full)
+                break;
+            snprintf(full, len, "%s/%s", dir, args[i]);
             if (access(full, X_OK) == 0) {
                 printf("%s is %s\n", args[i], full);
+                free(full);
                 found = 1;
                 break;
             }
+            free(full);
             dir = strtok_r(NULL, ":", &saveptr);
         }
         free(paths);

--- a/src/completion.c
+++ b/src/completion.c
@@ -121,8 +121,9 @@ static char **collect_matches(const char *prefix, int prefix_len, int *countp) {
                         if (strncmp(pe->d_name, prefix, prefix_len) == 0) {
                             if (has_match(matches, count, pe->d_name))
                                 continue;
-                            char *full = NULL;
-                            if (asprintf(&full, "%s/%s", d, pe->d_name) < 0) {
+                            size_t len = strlen(d) + strlen(pe->d_name) + 2;
+                            char *full = malloc(len);
+                            if (!full) {
                                 for (int j = 0; j < count; j++)
                                     free(matches[j]);
                                 free(matches);
@@ -130,6 +131,7 @@ static char **collect_matches(const char *prefix, int prefix_len, int *countp) {
                                 free(pdup);
                                 return NULL;
                             }
+                            snprintf(full, len, "%s/%s", d, pe->d_name);
                             if (access(full, X_OK) == 0) {
                                 if (count == cap) {
                                     cap *= 2;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -155,6 +155,7 @@ tests="
     test_base_arith.expect
     test_path_blank.expect
     test_path_long.expect
+    test_command_v_path_long.expect
 "
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_command_v_path_long.expect
+++ b/tests/test_command_v_path_long.expect
@@ -1,0 +1,25 @@
+#!/usr/bin/env expect
+set timeout 5
+set base [exec mktemp -d]
+set long $base
+for {set i 0} {$i < 350} {incr i} {
+    append long "/abcdefghij"
+    file mkdir $long
+}
+set f [open "$long/foo" "w"]
+puts $f "#!/bin/sh"
+puts $f "echo longcmd"
+close $f
+exec chmod +x "$long/foo"
+set env(PATH) "$long:/bin"
+spawn ../vush
+expect "vush> "
+send "command -v foo\r"
+expect {
+    -re "[\r\n]+$long/foo[\r\n]+vush> " {}
+    timeout { send_user "long PATH command -v failed\n"; exec rm -rf $base; exit 1 }
+}
+send "exit\r"
+expect eof
+exec rm -rf $base
+


### PR DESCRIPTION
## Summary
- allocate buffers dynamically for executable lookups
- build completion search paths with dynamic memory
- add regression test for long PATH handling in `command -v`

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bb9703f488324970d1408a3c6c234