### PR TITLE
Escape shell variables in expect tests

### DIFF
--- a/tests/test_array.expect
+++ b/tests/test_array.expect
@@ -4,19 +4,19 @@ spawn ../vush
 expect "vush> "
 send "nums=(one two three)\r"
 expect "vush> "
-send "echo ${nums[1]}\r"
+send "echo \${nums\[1\]}\r"
 expect {
     -re "[\r\n]+two[\r\n]+vush> " {}
     timeout { send_user "subscript failed\n"; exit 1 }
 }
-send "for n in ${nums[@]}; do echo $n; done\r"
+send "for n in \${nums\[@\]}; do echo \$n; done\r"
 expect {
     -re "one[\r\n]+two[\r\n]+three[\r\n]+vush> " {}
     timeout { send_user "iteration failed\n"; exit 1 }
 }
 send "unset nums[1]\r"
 expect "vush> "
-send "for n in ${nums[@]}; do echo $n; done\r"
+send "for n in \${nums\[@\]}; do echo \$n; done\r"
 expect {
     -re "one[\r\n]+three[\r\n]+vush> " {}
     timeout { send_user "unset index failed\n"; exit 1 }

--- a/tests/test_assign.expect
+++ b/tests/test_assign.expect
@@ -2,19 +2,19 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "FOO=bar echo $FOO\r"
+send "FOO=bar echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "assignment failed\n"; exit 1 }
 }
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+vush> " {}
     timeout { send_user "variable persisted\n"; exit 1 }
 }
 send "FOO=bar\r"
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "persistent assignment failed\n"; exit 1 }

--- a/tests/test_badcmd.expect
+++ b/tests/test_badcmd.expect
@@ -7,7 +7,7 @@ expect {
     -re "[\r\n]+idontexist: command not found[\r\n]+vush> " {}
     timeout { send_user "missing command not found message\n"; exit 1 }
 }
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+127[\r\n]+vush> " {}
     timeout { send_user "status code mismatch\n"; exit 1 }

--- a/tests/test_bang_words.expect
+++ b/tests/test_bang_words.expect
@@ -7,7 +7,7 @@ expect {
     -re "[\r\n]+foo bar[\r\n]+vush> " {}
     timeout { send_user "echo foo bar failed\n"; exit 1 }
 }
-send "!$\r"
+send "!\$\r"
 expect {
     -re "[\r\n]+bar: command not found[\r\n]+vush> " {}
     timeout { send_user "bang last word failed\n"; exit 1 }

--- a/tests/test_base_arith.expect
+++ b/tests/test_base_arith.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "echo $((16#ff + 2#10))\r"
+send "echo \$((16#ff + 2#10))\r"
 expect {
     -re "[\r\n]+257[\r\n]+vush> " {}
     timeout { send_user "base arithmetic failed\n"; exit 1 }

--- a/tests/test_break.expect
+++ b/tests/test_break.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "for x in a b c; do echo $x; break; done\r"
+send "for x in a b c; do echo \$x; break; done\r"
 expect {
     -re "a[\r\n]+vush> " {}
     timeout { send_user "break failed\n"; exit 1 }

--- a/tests/test_cmdsub.expect
+++ b/tests/test_cmdsub.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "echo $(echo hi)\r"
+send "echo \$(echo hi)\r"
 expect {
     -re "[\r\n]+hi[\r\n]+vush> " {}
     timeout { send_user "command substitution failed\n"; exit 1 }

--- a/tests/test_colon.expect
+++ b/tests/test_colon.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send ":\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user ": status mismatch\n"; exit 1 }

--- a/tests/test_command_p.expect
+++ b/tests/test_command_p.expect
@@ -10,14 +10,14 @@ expect {
     timeout { send_user "command without -p failed\n"; exit 1 }
 }
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+127[\r\n]+vush> " {}
     timeout { send_user "status mismatch\n"; exit 1 }
 }
 send "command -p true\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "command -p status mismatch\n"; exit 1 }

--- a/tests/test_command_pv.expect
+++ b/tests/test_command_pv.expect
@@ -9,7 +9,7 @@ expect {
     -re "[\r\n]+.*/ls[\r\n]+vush> " {}
     timeout { send_user "command -pv output mismatch\n"; exit 1 }
 }
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "command -pv status mismatch\n"; exit 1 }

--- a/tests/test_cond.expect
+++ b/tests/test_cond.expect
@@ -6,19 +6,19 @@ expect "vush> "
 send "x=foo\r"
 expect "vush> "
 
-send "[[ $x == foo ]]; echo \$?\r"
+send "[[ \$x == foo ]]; echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "equality failed\n"; exit 1 }
 }
 
-send "[[ $x == f* ]]; echo \$?\r"
+send "[[ \$x == f* ]]; echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "pattern match failed\n"; exit 1 }
 }
 
-send "[[ $x == b* ]]; echo \$?\r"
+send "[[ \$x == b* ]]; echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "pattern negative failed\n"; exit 1 }

--- a/tests/test_continue.expect
+++ b/tests/test_continue.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "for x in a b c; do if test $x = b; then continue; fi; echo $x; done\r"
+send "for x in a b c; do if test \$x = b; then continue; fi; echo \$x; done\r"
 expect {
     -re "a[\r\n]+c[\r\n]+vush> " {}
     timeout { send_user "continue failed\n"; exit 1 }

--- a/tests/test_env.expect
+++ b/tests/test_env.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "echo $HOME\r"
+send "echo \$HOME\r"
 expect {
     -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
     timeout { send_user "HOME output mismatch\n"; exit 1 }

--- a/tests/test_eval.expect
+++ b/tests/test_eval.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "export cmd='echo hi'\r"
 expect "vush> "
-send "eval $cmd there\r"
+send "eval \$cmd there\r"
 expect {
     -re "[\r\n]+hi there[\r\n]+vush> " {}
     timeout { send_user "eval failed\n"; exit 1 }

--- a/tests/test_export.expect
+++ b/tests/test_export.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "export FOO=bar\r"
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "export output mismatch\n"; exit 1 }

--- a/tests/test_export_n.expect
+++ b/tests/test_export_n.expect
@@ -16,7 +16,7 @@ expect {
     -re "\r\nvush> " {}
     timeout { send_user "export -n failed\n"; exit 1 }
 }
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "export -n removed variable\n"; exit 1 }

--- a/tests/test_export_n_unexport.expect
+++ b/tests/test_export_n_unexport.expect
@@ -16,7 +16,7 @@ expect {
     -re "\r\nvush> " {}
     timeout { send_user "export -n failed\n"; exit 1 }
 }
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "export -n removed variable\n"; exit 1 }

--- a/tests/test_false_builtin.expect
+++ b/tests/test_false_builtin.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "false\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "false builtin status mismatch\n"; exit 1 }

--- a/tests/test_for.expect
+++ b/tests/test_for.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "for x in a b c; do echo $x; done\r"
+send "for x in a b c; do echo \$x; done\r"
 expect {
     -re "a[\r\n]+b[\r\n]+c[\r\n]+vush> " {}
     timeout { send_user "for output mismatch\n"; exit 1 }

--- a/tests/test_for_arith.expect
+++ b/tests/test_for_arith.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "for ((i=0; i<3; i++)); do echo $i; done\r"
+send "for ((i=0; i<3; i++)); do echo \$i; done\r"
 expect {
     -re "0[\r\n]+1[\r\n]+2[\r\n]+vush> " {}
     timeout { send_user "arith for output mismatch\n"; exit 1 }

--- a/tests/test_function.expect
+++ b/tests/test_function.expect
@@ -13,7 +13,7 @@ send "bar() { return 7; }\r"
 expect "vush> "
 send "bar\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+7[\r\n]+vush> " {}
     timeout { send_user "return status failed\n"; exit 1 }

--- a/tests/test_function_keyword.expect
+++ b/tests/test_function_keyword.expect
@@ -13,7 +13,7 @@ send "function kv() { return 5; }\r"
 expect "vush> "
 send "kv\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+5[\r\n]+vush> " {}
     timeout { send_user "function keyword return failed\n"; exit 1 }

--- a/tests/test_kill_s.expect
+++ b/tests/test_kill_s.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "sleep 5 &\r"
 expect "vush> "
-send "echo $!\r"
+send "echo \$!\r"
 expect {
     -re "\r\n([0-9]+)\r\nvush> " { set pid $expect_out(1,string) }
     timeout { send_user "$! expansion failed\n"; exit 1 }

--- a/tests/test_local.expect
+++ b/tests/test_local.expect
@@ -2,12 +2,12 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "foo() { local x=inner; echo $x; }; x=outer; foo; echo $x\r"
+send "foo() { local x=inner; echo \$x; }; x=outer; foo; echo \$x\r"
 expect {
     -re "inner[\r\n]+outer[\r\n]+vush> " {}
     timeout { send_user "local var restore failed\n"; exit 1 }
 }
-send "bar() { local y; y=work; }; bar; echo ${y:-unset}\r"
+send "bar() { local y; y=work; }; bar; echo \${y:-unset}\r"
 expect {
     -re "unset[\r\n]+vush> " {}
     timeout { send_user "local unset failed\n"; exit 1 }

--- a/tests/test_negate.expect
+++ b/tests/test_negate.expect
@@ -5,7 +5,7 @@ expect "vush> "
 # simple command negation
 send "! false\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "negate command status mismatch\n"; exit 1 }
@@ -13,7 +13,7 @@ expect {
 # pipeline negation
 send "! true | false\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "negate pipeline status mismatch\n"; exit 1 }

--- a/tests/test_noclobber.expect
+++ b/tests/test_noclobber.expect
@@ -8,7 +8,7 @@ send "set -o noclobber\r"
 expect "vush> "
 send "echo hi >nc.tmp\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "noclobber status mismatch\n"; exit 1 }

--- a/tests/test_param_error.expect
+++ b/tests/test_param_error.expect
@@ -4,20 +4,20 @@ spawn ../vush
 expect "vush> "
 send "unset FOO\r"
 expect "vush> "
-send "echo ${FOO:?oops}\r"
+send "echo \${FOO:?oops}\r"
 expect {
     -re "oops" {}
     timeout { send_user "error message missing\n"; exit 1 }
 }
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "status mismatch\n"; exit 1 }
 }
 send "FOO=val\r"
 expect "vush> "
-send "echo ${FOO?}\r"
+send "echo \${FOO?}\r"
 expect {
     -re "[\r\n]+val[\r\n]+vush> " {}
     timeout { send_user "no value output\n"; exit 1 }

--- a/tests/test_param_expand.expect
+++ b/tests/test_param_expand.expect
@@ -4,53 +4,53 @@ spawn ../vush
 expect "vush> "
 send "unset FOO\r"
 expect "vush> "
-send "echo ${FOO:-bar}\r"
+send "echo \${FOO:-bar}\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "dash default failed\n"; exit 1 }
 }
-send "echo ${FOO:=baz}\r"
+send "echo \${FOO:=baz}\r"
 expect {
     -re "[\r\n]+baz[\r\n]+vush> " {}
     timeout { send_user "assign default failed\n"; exit 1 }
 }
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+baz[\r\n]+vush> " {}
     timeout { send_user "assign not stored\n"; exit 1 }
 }
-send "echo ${FOO:+alt}\r"
+send "echo \${FOO:+alt}\r"
 expect {
     -re "[\r\n]+alt[\r\n]+vush> " {}
     timeout { send_user "plus alt failed\n"; exit 1 }
 }
-send "echo ${FOO#b*}\r"
+send "echo \${FOO#b*}\r"
 expect {
     -re "[\r\n]+az[\r\n]+vush> " {}
     timeout { send_user "prefix removal failed\n"; exit 1 }
 }
-send "echo ${FOO%z}\r"
+send "echo \${FOO%z}\r"
 expect {
     -re "[\r\n]+ba[\r\n]+vush> " {}
     timeout { send_user "suffix removal failed\n"; exit 1 }
 }
 send "FOO=abcabc\r"
 expect "vush> "
-send "echo ${FOO#a*c}\r"
+send "echo \${FOO#a*c}\r"
 expect {
     -re "[\r\n]+abc[\r\n]+vush> " {}
     timeout { send_user "double prefix setup failed\n"; exit 1 }
 }
-send "echo ${FOO##a*c}\r"
+send "echo \${FOO##a*c}\r"
 expect "vush> "
-send "echo ${FOO%a*c}\r"
+send "echo \${FOO%a*c}\r"
 expect {
     -re "[\r\n]+abc[\r\n]+vush> " {}
     timeout { send_user "double suffix setup failed\n"; exit 1 }
 }
-send "echo ${FOO%%a*c}\r"
+send "echo \${FOO%%a*c}\r"
 expect "vush> "
-send "echo ${#FOO}\r"
+send "echo \${#FOO}\r"
 expect {
     -re "[\r\n]+6[\r\n]+vush> " {}
     timeout { send_user "length failed\n"; exit 1 }

--- a/tests/test_param_replace.expect
+++ b/tests/test_param_replace.expect
@@ -5,25 +5,25 @@ expect "vush> "
 send "FOO=hello\r"
 expect "vush> "
 # replace first occurrence
-send "echo ${FOO/l/x}\r"
+send "echo \${FOO/l/x}\r"
 expect {
     -re "[\r\n]+hexlo[\r\n]+vush> " {}
     timeout { send_user "single replace failed\n"; exit 1 }
 }
 # global replacement
-send "echo ${FOO//l/x}\r"
+send "echo \${FOO//l/x}\r"
 expect {
     -re "[\r\n]+hexxo[\r\n]+vush> " {}
     timeout { send_user "global replace failed\n"; exit 1 }
 }
 # wildcard pattern
-send "echo ${FOO/l*/Z}\r"
+send "echo \${FOO/l*/Z}\r"
 expect {
     -re "[\r\n]+heZ[\r\n]+vush> " {}
     timeout { send_user "wildcard replace failed\n"; exit 1 }
 }
 # no match
-send "echo ${FOO/z/0}\r"
+send "echo \${FOO/z/0}\r"
 expect {
     -re "[\r\n]+hello[\r\n]+vush> " {}
     timeout { send_user "no match failed\n"; exit 1 }

--- a/tests/test_param_substring.expect
+++ b/tests/test_param_substring.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "VAR=abcdef\r"
 expect "vush> "
-send "echo ${VAR:3}\r"
+send "echo \${VAR:3}\r"
 expect {
     -re "[\r\n]+def[\r\n]+vush> " {}
     timeout { send_user "offset failed\n"; exit 1 }
 }
-send "echo ${VAR:3:2}\r"
+send "echo \${VAR:3:2}\r"
 expect {
     -re "[\r\n]+de[\r\n]+vush> " {}
     timeout { send_user "offset length failed\n"; exit 1 }

--- a/tests/test_pid_params.expect
+++ b/tests/test_pid_params.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 # Test $$ expansion
 set pid [exp_pid]
-send "echo $$\r"
+send "echo \$\$\r"
 expect {
     -re "[\r\n]+$pid[\r\n]+vush> " {}
     timeout { send_user "\$\$ expansion failed\n"; exit 1 }
@@ -12,7 +12,7 @@ expect {
 # Test $! expansion
 send "sleep 1 &\r"
 expect "vush> "
-send "echo $!\r"
+send "echo \$!\r"
 expect {
     -re "[\r\n]+([0-9]+)[\r\n]+vush> " { set bg $expect_out(1,string) }
     timeout { send_user "\$! expansion failed\n"; exit 1 }
@@ -24,7 +24,7 @@ expect {
 }
 send "set -e -u\r"
 expect "vush> "
-send "echo $-\r"
+send "echo \$-\r"
 expect {
     -re "[\r\n]+eu[\r\n]+vush> " {}
     timeout { send_user "\$- expansion failed\n"; exit 1 }

--- a/tests/test_pipefail.expect
+++ b/tests/test_pipefail.expect
@@ -6,7 +6,7 @@ send "set -o pipefail\r"
 expect "vush> "
 send "false | true\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "pipefail status mismatch\n"; exit 1 }

--- a/tests/test_printf.expect
+++ b/tests/test_printf.expect
@@ -7,7 +7,7 @@ expect {
     -re "[\r\n]+foo 0005 ff[\r\n]+vush> " {}
     timeout { send_user "printf output mismatch\n"; exit 1 }
 }
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "printf status mismatch\n"; exit 1 }

--- a/tests/test_process_sub.expect
+++ b/tests/test_process_sub.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "diff <(echo a) <(echo a)\r"
+send "diff <\$(echo a) <\$(echo a)\r"
 expect {
     -re "[\r\n]+vush> " {}
     timeout { send_user "process substitution failed\n"; exit 1 }

--- a/tests/test_ps1_cmdsub.expect
+++ b/tests/test_ps1_cmdsub.expect
@@ -4,7 +4,7 @@ set start $env(PWD)
 set parent [file dirname $start]
 spawn ../vush
 expect "vush> "
-send "export PS1='$(pwd)> '\r"
+send "export PS1='\$(pwd)> '\r"
 expect "$start> "
 send "cd ..\r"
 expect "$parent> "

--- a/tests/test_read.expect
+++ b/tests/test_read.expect
@@ -5,7 +5,7 @@ expect "vush> "
 send "read first rest\r"
 send "one two three\r"
 expect "vush> "
-send "echo $first:$rest\r"
+send "echo \$first:\$rest\r"
 expect {
     -re "[\r\n]+one:two three[\r\n]+vush> " {}
     timeout { send_user "read builtin failed\n"; exit 1 }

--- a/tests/test_read_eof.expect
+++ b/tests/test_read_eof.expect
@@ -5,7 +5,7 @@ expect "vush> "
 send "read foo\r"
 send \004
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "read EOF status failed\n"; exit 1 }

--- a/tests/test_readonly.expect
+++ b/tests/test_readonly.expect
@@ -10,7 +10,7 @@ expect {
     timeout { send_user "missing readonly error\n"; exit 1 }
 }
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "readonly value modified\n"; exit 1 }
@@ -21,7 +21,7 @@ expect {
     timeout { send_user "unset allowed\n"; exit 1 }
 }
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+bar[\r\n]+vush> " {}
     timeout { send_user "readonly unset changed value\n"; exit 1 }

--- a/tests/test_select.expect
+++ b/tests/test_select.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "select x in foo bar; do echo $x; break; done\r"
+send "select x in foo bar; do echo \$x; break; done\r"
 expect {
     -re "1\\) foo[\r\n]+2\\) bar[\r\n]+\\? " {}
     timeout { send_user "select menu failed\n"; exit 1 }

--- a/tests/test_set_options.expect
+++ b/tests/test_set_options.expect
@@ -5,14 +5,14 @@ spawn ../vush
 expect "vush> "
 send "set -u\r"
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "UNDEF: unbound variable" { }
     -re "FOO: unbound variable" { }
     timeout { send_user "nounset message missing\n"; exit 1 }
 }
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "nounset status mismatch\n"; exit 1 }

--- a/tests/test_set_positional.expect
+++ b/tests/test_set_positional.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "set -- foo bar\r"
 expect "vush> "
-send "echo \"$1,$2,$#\"\r"
+send "echo \\\"\$1,\$2,\$#\\\"\r"
 expect {
     -re "[\r\n]+foo,bar,2[\r\n]+vush> " {}
     timeout { send_user "set positional failed\n"; exit 1 }

--- a/tests/test_status.expect
+++ b/tests/test_status.expect
@@ -4,14 +4,14 @@ spawn ../vush
 expect "vush> "
 send "false\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "false status mismatch\n"; exit 1 }
 }
 send "true\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "true status mismatch\n"; exit 1 }

--- a/tests/test_true_builtin.expect
+++ b/tests/test_true_builtin.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "true\r"
 expect "vush> "
-send "echo $?\r"
+send "echo \$?\r"
 expect {
     -re "[\r\n]+0[\r\n]+vush> " {}
     timeout { send_user "true builtin status mismatch\n"; exit 1 }

--- a/tests/test_unmatched.expect
+++ b/tests/test_unmatched.expect
@@ -14,7 +14,7 @@ expect {
     timeout { send_user "missing single quote error\n"; exit 1 }
 }
 expect "vush> "
-send "echo $(echo hi\r"
+send "echo \$(echo hi\r"
 expect {
     -re "syntax error: unmatched '\)'" {}
     timeout { send_user "missing command substitution error\n"; exit 1 }

--- a/tests/test_unset.expect
+++ b/tests/test_unset.expect
@@ -6,7 +6,7 @@ send "export FOO=bar\r"
 expect "vush> "
 send "unset FOO\r"
 expect "vush> "
-send "echo $FOO\r"
+send "echo \$FOO\r"
 expect {
     -re "[\r\n]+vush> " {}
     timeout { send_user "unset failed\n"; exit 1 }

--- a/tests/test_until.expect
+++ b/tests/test_until.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "j=2; until test $j -eq 0; do echo $j; j=$(expr $j - 1); done\r"
+send "j=2; until test \$j -eq 0; do echo \$j; j=\$(expr \$j - 1); done\r"
 expect {
     -re "2[\r\n]+1[\r\n]+vush> " {}
     timeout { send_user "until output mismatch\n"; exit 1 }

--- a/tests/test_var_brace.expect
+++ b/tests/test_var_brace.expect
@@ -2,17 +2,17 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "echo ${HOME}\r"
+send "echo \${HOME}\r"
 expect {
     -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
     timeout { send_user "brace expansion failed\n"; exit 1 }
 }
-send "echo \"${HOME}\"\r"
+send "echo \\\"\${HOME}\\\"\r"
 expect {
     -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
     timeout { send_user "quoted brace expansion failed\n"; exit 1 }
 }
-send "echo '${HOME}'\r"
+send "echo '\${HOME}'\r"
 expect {
     -re "[\r\n]+\${HOME}[\r\n]+vush> " {}
     timeout { send_user "single quote brace mismatch\n"; exit 1 }

--- a/tests/test_while.expect
+++ b/tests/test_while.expect
@@ -2,7 +2,7 @@
 set timeout 5
 spawn ../vush
 expect "vush> "
-send "export i=0; while test $i -lt 3; do echo $i; export i=$(expr $i + 1); done\r"
+send "export i=0; while test \$i -lt 3; do echo \$i; export i=\$(expr \$i + 1); done\r"
 expect {
     -re "0[\r\n]+1[\r\n]+2[\r\n]+vush> " {}
     timeout { send_user "while output mismatch\n"; exit 1 }


### PR DESCRIPTION
## Summary
- escape `$` and bracket characters in tests so TCL doesn't substitute them
- keep TCL variables like `$dir` unescaped

## Testing
- `make test` *(fails: invalid command name errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bbaf2e3548324858979a9d8904b06