### PR TITLE
Fix expect regex quoting

### DIFF
--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -6,12 +6,12 @@ send "alias ll='echo hi'\r"
 expect "vush> "
 send "alias\r"
 expect {
-    -re "[\r\n]+ll='echo hi'[\r\n]+vush> " {}
+    -re "\[\r\n\]+ll='echo hi'\[\r\n\]+vush> " {}
     timeout { send_user "alias listing failed\n"; exit 1 }
 }
 send "ll there\r"
 expect {
-    -re "[\r\n]+hi there[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi there\[\r\n\]+vush> " {}
     timeout { send_user "alias use failed\n"; exit 1 }
 }
 send "unalias ll\r"
@@ -26,7 +26,7 @@ send "alias second=first\r"
 expect "vush> "
 send "second test\r"
 expect {
-    -re "[\r\n]+nested test[\r\n]+vush> " {}
+    -re "\[\r\n\]+nested test\[\r\n\]+vush> " {}
     timeout { send_user "nested alias failed\n"; exit 1 }
 }
 send "unalias first second\r"
@@ -44,7 +44,7 @@ expect {
 }
 send "a39 world\r"
 expect {
-    -re "[\r\n]+hi39 world[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi39 world\[\r\n\]+vush> " {}
     timeout { send_user "alias expanded failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_alias_flags.expect
+++ b/tests/test_alias_flags.expect
@@ -7,7 +7,7 @@ expect "vush> "
 # print single alias
 send "alias hi\r"
 expect {
-    -re "[\r\n]+hi='echo hello'[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi='echo hello'\[\r\n\]+vush> " {}
     timeout { send_user "alias single failed\n"; exit 1 }
 }
 # list aliases with -p
@@ -22,7 +22,7 @@ expect "vush> "
 # verify change
 send "alias hi\r"
 expect {
-    -re "[\r\n]+hi='echo bye'[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi='echo bye'\[\r\n\]+vush> " {}
     timeout { send_user "alias assignment failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_alias_persist.expect
+++ b/tests/test_alias_persist.expect
@@ -12,7 +12,7 @@ spawn ../vush
 expect "vush> "
 send "hi world\r"
 expect {
-    -re "[\r\n]+persisted world[\r\n]+vush> " {}
+    -re "\[\r\n\]+persisted world\[\r\n\]+vush> " {}
     timeout { send_user "alias not persisted\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -4,35 +4,35 @@ spawn ../vush
 expect "vush> "
 send "echo $((1+2))\r"
 expect {
-    -re "[\r\n]+3[\r\n]+vush> " {}
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
     timeout { send_user "basic arithmetic failed\n"; exit 1 }
 }
 send "X=4\r"
 expect "vush> "
 send "echo $((X*2))\r"
 expect {
-    -re "[\r\n]+8[\r\n]+vush> " {}
+    -re "\[\r\n\]+8\[\r\n\]+vush> " {}
     timeout { send_user "variable expansion failed\n"; exit 1 }
 }
 send "X=$((X+3))\r"
 expect "vush> "
 send "echo $X\r"
 expect {
-    -re "[\r\n]+11[\r\n]+vush> " {}
+    -re "\[\r\n\]+11\[\r\n\]+vush> " {}
     timeout { send_user "assignment arithmetic failed\n"; exit 1 }
 }
 send "let 5\r"
 expect "vush> "
 send "echo $?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "let success failed\n"; exit 1 }
 }
 send "let 0\r"
 expect "vush> "
 send "echo $?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "let failure failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_array.expect
+++ b/tests/test_array.expect
@@ -6,19 +6,19 @@ send "nums=(one two three)\r"
 expect "vush> "
 send "echo \${nums\[1\]}\r"
 expect {
-    -re "[\r\n]+two[\r\n]+vush> " {}
+    -re "\[\r\n\]+two\[\r\n\]+vush> " {}
     timeout { send_user "subscript failed\n"; exit 1 }
 }
 send "for n in \${nums\[@\]}; do echo \$n; done\r"
 expect {
-    -re "one[\r\n]+two[\r\n]+three[\r\n]+vush> " {}
+    -re "one\[\r\n\]+two\[\r\n\]+three\[\r\n\]+vush> " {}
     timeout { send_user "iteration failed\n"; exit 1 }
 }
 send "unset nums[1]\r"
 expect "vush> "
 send "for n in \${nums\[@\]}; do echo \$n; done\r"
 expect {
-    -re "one[\r\n]+three[\r\n]+vush> " {}
+    -re "one\[\r\n\]+three\[\r\n\]+vush> " {}
     timeout { send_user "unset index failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_assign.expect
+++ b/tests/test_assign.expect
@@ -4,19 +4,19 @@ spawn ../vush
 expect "vush> "
 send "FOO=bar echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "assignment failed\n"; exit 1 }
 }
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "variable persisted\n"; exit 1 }
 }
 send "FOO=bar\r"
 expect "vush> "
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "persistent assignment failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_badcmd.expect
+++ b/tests/test_badcmd.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "idontexist\r"
 expect {
-    -re "[\r\n]+idontexist: command not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+idontexist: command not found\[\r\n\]+vush> " {}
     timeout { send_user "missing command not found message\n"; exit 1 }
 }
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+127[\r\n]+vush> " {}
+    -re "\[\r\n\]+127\[\r\n\]+vush> " {}
     timeout { send_user "status code mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bang_history.expect
+++ b/tests/test_bang_history.expect
@@ -4,27 +4,27 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo first failed\n"; exit 1 }
 }
 send "!!\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "bang repeat failed\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "echo second failed\n"; exit 1 }
 }
 send "!ec\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "bang prefix failed\n"; exit 1 }
 }
 send "!nope\r"
 expect {
-    -re "history: event not found: nope[\r\n]+vush> " {}
+    -re "history: event not found: nope\[\r\n\]+vush> " {}
     timeout { send_user "missing event not found\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bang_numeric.expect
+++ b/tests/test_bang_numeric.expect
@@ -4,22 +4,22 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo first failed\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "echo second failed\n"; exit 1 }
 }
 send "!1\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "bang number failed\n"; exit 1 }
 }
 send "!-2\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "bang negative number failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bang_words.expect
+++ b/tests/test_bang_words.expect
@@ -4,22 +4,22 @@ spawn ../vush
 expect "vush> "
 send "echo foo bar\r"
 expect {
-    -re "[\r\n]+foo bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo bar\[\r\n\]+vush> " {}
     timeout { send_user "echo foo bar failed\n"; exit 1 }
 }
 send "!\$\r"
 expect {
-    -re "[\r\n]+bar: command not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar: command not found\[\r\n\]+vush> " {}
     timeout { send_user "bang last word failed\n"; exit 1 }
 }
 send "echo one two\r"
 expect {
-    -re "[\r\n]+one two[\r\n]+vush> " {}
+    -re "\[\r\n\]+one two\[\r\n\]+vush> " {}
     timeout { send_user "echo one two failed\n"; exit 1 }
 }
 send "!*\r"
 expect {
-    -re "[\r\n]+one: command not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+one: command not found\[\r\n\]+vush> " {}
     timeout { send_user "bang all words failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_base_arith.expect
+++ b/tests/test_base_arith.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo \$((16#ff + 2#10))\r"
 expect {
-    -re "[\r\n]+257[\r\n]+vush> " {}
+    -re "\[\r\n\]+257\[\r\n\]+vush> " {}
     timeout { send_user "base arithmetic failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_basic_cmd.expect
+++ b/tests/test_basic_cmd.expect
@@ -5,7 +5,7 @@ expect "vush> "
 # run a basic command and ensure output is printed
 send "echo hi\r"
 expect {
-    -re "[\r\n]+hi[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
     timeout { send_user "basic command output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bg.expect
+++ b/tests/test_bg.expect
@@ -8,7 +8,7 @@ send "kill -SIGSTOP 1\r"
 expect "vush> "
 send "bg 1\r"
 expect {
-    -re "\[vush\] job [0-9]+ finished[\r\n]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
     timeout { send_user "bg output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bg_default.expect
+++ b/tests/test_bg_default.expect
@@ -8,7 +8,7 @@ send "kill -SIGSTOP 1\r"
 expect "vush> "
 send "bg\r"
 expect {
-    -re "\\[vush\\] job [0-9]+ finished[\r\n]+vush> " {}
+    -re "\\[vush\\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
     timeout { send_user "bg output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_brace_expand.expect
+++ b/tests/test_brace_expand.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "echo a{b,c}\r"
 expect {
-    -re "[\r\n]+ab ac[\r\n]+vush> " {}
+    -re "\[\r\n\]+ab ac\[\r\n\]+vush> " {}
     timeout { send_user "brace expansion failed\n"; exit 1 }
 }
 send "echo {1..3}\r"
 expect {
-    -re "[\r\n]+1 2 3[\r\n]+vush> " {}
+    -re "\[\r\n\]+1 2 3\[\r\n\]+vush> " {}
     timeout { send_user "numeric brace expansion failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_brace_group.expect
+++ b/tests/test_brace_group.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "{ cd /tmp; pwd; }\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "brace group output mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "brace group didn't change directory\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_break.expect
+++ b/tests/test_break.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "for x in a b c; do echo \$x; break; done\r"
 expect {
-    -re "a[\r\n]+vush> " {}
+    -re "a\[\r\n\]+vush> " {}
     timeout { send_user "break failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_case.expect
+++ b/tests/test_case.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "case foo in f*) echo match ;; esac\r"
 expect {
-    -re "match[\r\n]+vush> " {}
+    -re "match\[\r\n\]+vush> " {}
     timeout { send_user "case match failed\n"; exit 1 }
 }
 send "case 1 in 1) echo one ;& 2) echo two ;; esac\r"
 expect {
-    -re "one[\r\n]+two[\r\n]+vush> " {}
+    -re "one\[\r\n\]+two\[\r\n\]+vush> " {}
     timeout { send_user "case fallthrough failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_cd_P.expect
+++ b/tests/test_cd_P.expect
@@ -9,7 +9,7 @@ send "cd -P $dir/link\r"
 expect "vush> "
 send "pwd\r"
 expect {
-    -re "[\r\n]+$dir/real[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/real\[\r\n\]+vush> " {}
     timeout { send_user "cd -P failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_cd_dash.expect
+++ b/tests/test_cd_dash.expect
@@ -6,22 +6,22 @@ send "cd /tmp\r"
 expect "vush> "
 send "cd -\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "cd - output mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "cd - didn't switch\n"; exit 1 }
 }
 send "cd -\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "cd - toggle mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "cd - didn't toggle back\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_cdpath.expect
+++ b/tests/test_cdpath.expect
@@ -7,12 +7,12 @@ spawn ../vush
 expect "vush> "
 send "cd a\r"
 expect {
-    -re "[\r\n]+$dir/a[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/a\[\r\n\]+vush> " {}
     timeout { send_user "cdpath not used\n"; exec rm -rf $dir; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+$dir/a[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/a\[\r\n\]+vush> " {}
     timeout { send_user "cdpath didn't cd\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_cmdsub.expect
+++ b/tests/test_cmdsub.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo \$(echo hi)\r"
 expect {
-    -re "[\r\n]+hi[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
     timeout { send_user "command substitution failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_colon.expect
+++ b/tests/test_colon.expect
@@ -6,7 +6,7 @@ send ":\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user ": status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command.expect
+++ b/tests/test_command.expect
@@ -6,7 +6,7 @@ send "alias echo=echo_alias\r"
 expect "vush> "
 send "command echo hi\r"
 expect {
-    -re "[\r\n]+hi[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
     timeout { send_user "command builtin failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_V.expect
+++ b/tests/test_command_V.expect
@@ -6,7 +6,7 @@ send "alias ll='echo hi'\r"
 expect "vush> "
 send "command -V ll cd ls nosuch\r"
 expect {
-    -re "[\r\n]+ll is an alias for 'echo hi'[\r\n]+cd is a builtin[\r\n]+ls is .*/ls[\r\n]+nosuch not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+ll is an alias for 'echo hi'\[\r\n\]+cd is a builtin\[\r\n\]+ls is .*/ls\[\r\n\]+nosuch not found\[\r\n\]+vush> " {}
     timeout { send_user "command -V output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_p.expect
+++ b/tests/test_command_p.expect
@@ -6,20 +6,20 @@ send "export PATH=/tmp\r"
 expect "vush> "
 send "command true\r"
 expect {
-    -re "[\r\n]+true:.*\r?\n" {}
+    -re "\[\r\n\]+true:.*\r?\n" {}
     timeout { send_user "command without -p failed\n"; exit 1 }
 }
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+127[\r\n]+vush> " {}
+    -re "\[\r\n\]+127\[\r\n\]+vush> " {}
     timeout { send_user "status mismatch\n"; exit 1 }
 }
 send "command -p true\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "command -p status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_pV.expect
+++ b/tests/test_command_pV.expect
@@ -6,7 +6,7 @@ send "export PATH=/tmp\r"
 expect "vush> "
 send "command -pV ls nosuch\r"
 expect {
-    -re "[\r\n]+ls is .*/ls[\r\n]+nosuch not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+ls is .*/ls\[\r\n\]+nosuch not found\[\r\n\]+vush> " {}
     timeout { send_user "command -pV output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_pv.expect
+++ b/tests/test_command_pv.expect
@@ -6,12 +6,12 @@ send "export PATH=/tmp\r"
 expect "vush> "
 send "command -pv ls\r"
 expect {
-    -re "[\r\n]+.*/ls[\r\n]+vush> " {}
+    -re "\[\r\n\]+.*/ls\[\r\n\]+vush> " {}
     timeout { send_user "command -pv output mismatch\n"; exit 1 }
 }
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "command -pv status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_v.expect
+++ b/tests/test_command_v.expect
@@ -6,7 +6,7 @@ send "alias ll='echo hi'\r"
 expect "vush> "
 send "command -v ll cd ls\r"
 expect {
-    -re "[\r\n]+alias ll='echo hi'[\r\n]+cd[\r\n]+.*/ls[\r\n]+vush> " {}
+    -re "\[\r\n\]+alias ll='echo hi'\[\r\n\]+cd\[\r\n\]+.*/ls\[\r\n\]+vush> " {}
     timeout { send_user "command -v output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_command_v_path_long.expect
+++ b/tests/test_command_v_path_long.expect
@@ -16,7 +16,7 @@ spawn ../vush
 expect "vush> "
 send "command -v foo\r"
 expect {
-    -re "[\r\n]+$long/foo[\r\n]+vush> " {}
+    -re "\[\r\n\]+$long/foo\[\r\n\]+vush> " {}
     timeout { send_user "long PATH command -v failed\n"; exec rm -rf $base; exit 1 }
 }
 send "exit\r"

--- a/tests/test_comments.expect
+++ b/tests/test_comments.expect
@@ -6,7 +6,7 @@ send "# foo\r"
 expect "vush> "
 send "echo bar # comment\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "comment parsing failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_completion.expect
+++ b/tests/test_completion.expect
@@ -5,7 +5,7 @@ expect "vush> "
 # complete unique builtin 'pwd'
 send "pw\t\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "pwd completion failed\n"; exit 1 }
 }
 # list multiple completions for prefix 'ex'

--- a/tests/test_completion_path.expect
+++ b/tests/test_completion_path.expect
@@ -11,7 +11,7 @@ spawn ../vush
 expect "vush> "
 send "fo\t\r"
 expect {
-    -re "[\r\n]+pathcomplete[\r\n]+vush> " {}
+    -re "\[\r\n\]+pathcomplete\[\r\n\]+vush> " {}
     timeout { send_user "PATH completion failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_cond.expect
+++ b/tests/test_cond.expect
@@ -8,19 +8,19 @@ expect "vush> "
 
 send "[[ \$x == foo ]]; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "equality failed\n"; exit 1 }
 }
 
 send "[[ \$x == f* ]]; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "pattern match failed\n"; exit 1 }
 }
 
 send "[[ \$x == b* ]]; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "pattern negative failed\n"; exit 1 }
 }
 

--- a/tests/test_continue.expect
+++ b/tests/test_continue.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "for x in a b c; do if test \$x = b; then continue; fi; echo \$x; done\r"
 expect {
-    -re "a[\r\n]+c[\r\n]+vush> " {}
+    -re "a\[\r\n\]+c\[\r\n\]+vush> " {}
     timeout { send_user "continue failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_custom_aliasfile.expect
+++ b/tests/test_custom_aliasfile.expect
@@ -15,7 +15,7 @@ set env(VUSH_ALIASFILE) "$dir/aliases"
 expect "vush> "
 send "hi world\r"
 expect {
-    -re "[\r\n]+custom world[\r\n]+vush> " {}
+    -re "\[\r\n\]+custom world\[\r\n\]+vush> " {}
     timeout { send_user "alias not loaded\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_custom_histfile.expect
+++ b/tests/test_custom_histfile.expect
@@ -7,7 +7,7 @@ spawn ../vush
 expect "vush> "
 send "echo persist\r"
 expect {
-    -re "[\r\n]+persist[\r\n]+vush> " {}
+    -re "\[\r\n\]+persist\[\r\n\]+vush> " {}
     timeout { send_user "echo failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"
@@ -18,7 +18,7 @@ set env(VUSH_HISTFILE) "$dir/histfile"
 expect "vush> "
 send "history\r"
 expect {
-    -re "1 echo persist[\r\n]+2 history[\r\n]+vush> " {}
+    -re "1 echo persist\[\r\n\]+2 history\[\r\n\]+vush> " {}
     timeout { send_user "history not loaded\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_dirs.expect
+++ b/tests/test_dirs.expect
@@ -4,17 +4,17 @@ spawn ../vush
 expect "vush> "
 send "pushd /tmp\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "pushd output mismatch\n"; exit 1 }
 }
 send "dirs\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "dirs output mismatch\n"; exit 1 }
 }
 send "popd\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "popd output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_env.expect
+++ b/tests/test_env.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo \$HOME\r"
 expect {
-    -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(HOME)\[\r\n\]+vush> " {}
     timeout { send_user "HOME output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_envfile.expect
+++ b/tests/test_envfile.expect
@@ -8,7 +8,7 @@ set env(HOME) $dir
 set env(ENV) "$dir/envfile"
 spawn ../vush
 expect {
-    -re "[\r\n]+envstart[\r\n]+vush> " {}
+    -re "\[\r\n\]+envstart\[\r\n\]+vush> " {}
     timeout { send_user "ENV file not executed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_err_redir.expect
+++ b/tests/test_err_redir.expect
@@ -6,7 +6,7 @@ send "echo error 2>err.tmp\r"
 expect "vush> "
 send "ls err.tmp\r"
 expect {
-    -re "[\r\n]+err.tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+err.tmp\[\r\n\]+vush> " {}
     timeout { send_user "stderr redirection failed\n"; exit 1 }
 }
 send "ls nonexistent &>both.tmp\r"

--- a/tests/test_eval.expect
+++ b/tests/test_eval.expect
@@ -6,7 +6,7 @@ send "export cmd='echo hi'\r"
 expect "vush> "
 send "eval \$cmd there\r"
 expect {
-    -re "[\r\n]+hi there[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi there\[\r\n\]+vush> " {}
     timeout { send_user "eval failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_exec_builtin.expect
+++ b/tests/test_exec_builtin.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "exec /bin/echo hi\r"
 expect {
-    -re "[\r\n]+hi\r?\n" {}
+    -re "\[\r\n\]+hi\r?\n" {}
     timeout { send_user "exec builtin failed\n"; exit 1 }
 }
 expect eof

--- a/tests/test_exit_trap.expect
+++ b/tests/test_exit_trap.expect
@@ -6,7 +6,7 @@ send "trap 'echo exiting' EXIT\r"
 expect "vush> "
 send "exit\r"
 expect {
-    -re "[\r\n]+exiting[\r\n]+" {}
+    -re "\[\r\n\]+exiting\[\r\n\]+" {}
     timeout { send_user "EXIT trap output mismatch\n"; exit 1 }
 }
 expect eof

--- a/tests/test_export.expect
+++ b/tests/test_export.expect
@@ -6,7 +6,7 @@ send "export FOO=bar\r"
 expect "vush> "
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "export output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_export_n.expect
+++ b/tests/test_export_n.expect
@@ -18,7 +18,7 @@ expect {
 }
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "export -n removed variable\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_export_n_unexport.expect
+++ b/tests/test_export_n_unexport.expect
@@ -18,7 +18,7 @@ expect {
 }
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "export -n removed variable\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_false_builtin.expect
+++ b/tests/test_false_builtin.expect
@@ -6,7 +6,7 @@ send "false\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "false builtin status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_fc.expect
+++ b/tests/test_fc.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "echo hi\r"
 expect {
-    -re "[\r\n]+hi[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
     timeout { send_user "echo output mismatch\n"; exit 1 }
 }
 send "fc -l -1\r"
 expect {
-    -re "1 echo hi[\r\n]+vush> " {}
+    -re "1 echo hi\[\r\n\]+vush> " {}
     timeout { send_user "fc output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_fd_dup.expect
+++ b/tests/test_fd_dup.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo test 2>&1\r"
 expect {
-    -re "[\r\n]+test[\r\n]+vush> " {}
+    -re "\[\r\n\]+test\[\r\n\]+vush> " {}
     timeout { send_user "2>&1 failed\n"; exit 1 }
 }
 send "ls nonexistent >&dup.tmp\r"

--- a/tests/test_for.expect
+++ b/tests/test_for.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "for x in a b c; do echo \$x; done\r"
 expect {
-    -re "a[\r\n]+b[\r\n]+c[\r\n]+vush> " {}
+    -re "a\[\r\n\]+b\[\r\n\]+c\[\r\n\]+vush> " {}
     timeout { send_user "for output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_for_arith.expect
+++ b/tests/test_for_arith.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "for ((i=0; i<3; i++)); do echo \$i; done\r"
 expect {
-    -re "0[\r\n]+1[\r\n]+2[\r\n]+vush> " {}
+    -re "0\[\r\n\]+1\[\r\n\]+2\[\r\n\]+vush> " {}
     timeout { send_user "arith for output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_forward_search.expect
+++ b/tests/test_forward_search.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo first failed\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "echo second failed\n"; exit 1 }
 }
 # Use forward search to recall 'echo second'
@@ -18,7 +18,7 @@ send "echo"
 send "\023"
 send "\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "forward search failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_function.expect
+++ b/tests/test_function.expect
@@ -6,7 +6,7 @@ send "foo() { echo hi \$1; }\r"
 expect "vush> "
 send "foo there\r"
 expect {
-    -re "[\r\n]+hi there[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi there\[\r\n\]+vush> " {}
     timeout { send_user "function output failed\n"; exit 1 }
 }
 send "bar() { return 7; }\r"
@@ -15,7 +15,7 @@ send "bar\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+7[\r\n]+vush> " {}
+    -re "\[\r\n\]+7\[\r\n\]+vush> " {}
     timeout { send_user "return status failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_function_keyword.expect
+++ b/tests/test_function_keyword.expect
@@ -6,7 +6,7 @@ send "function kwtest { echo hi \$1; }\r"
 expect "vush> "
 send "kwtest there\r"
 expect {
-    -re "[\r\n]+hi there[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi there\[\r\n\]+vush> " {}
     timeout { send_user "function keyword output failed\n"; exit 1 }
 }
 send "function kv() { return 5; }\r"
@@ -15,7 +15,7 @@ send "kv\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+5[\r\n]+vush> " {}
+    -re "\[\r\n\]+5\[\r\n\]+vush> " {}
     timeout { send_user "function keyword return failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_getopts.expect
+++ b/tests/test_getopts.expect
@@ -6,19 +6,19 @@ puts $f "while getopts \"ab:\" o; do echo \"$o:$OPTARG\"; done; echo index:$OPTI
 close $f
 spawn ../vush $script -a -b foo rest
 expect {
-    -re "a:[\r\n]+b:foo[\r\n]+index:4[\r\n]+" {}
+    -re "a:\[\r\n\]+b:foo\[\r\n\]+index:4\[\r\n\]+" {}
     timeout { send_user "getopts parsing failed\n"; exec rm $script; exit 1 }
 }
 expect eof
 spawn ../vush $script -z
 expect {
-    -re "getopts: illegal option -- z[\r\n]+\?:[\r\n]+index:2[\r\n]+" {}
+    -re "getopts: illegal option -- z\[\r\n\]+\?:\[\r\n\]+index:2\[\r\n\]+" {}
     timeout { send_user "invalid option not handled\n"; exec rm $script; exit 1 }
 }
 expect eof
 spawn ../vush $script -b
 expect {
-    -re "getopts: option requires an argument -- b[\r\n]+\?:[\r\n]+index:2[\r\n]+" {}
+    -re "getopts: option requires an argument -- b\[\r\n\]+\?:\[\r\n\]+index:2\[\r\n\]+" {}
     timeout { send_user "missing argument not detected\n"; exec rm $script; exit 1 }
 }
 expect eof

--- a/tests/test_glob.expect
+++ b/tests/test_glob.expect
@@ -6,7 +6,7 @@ send "touch g1.c g2.c\r"
 expect "vush> "
 send "echo *.c\r"
 expect {
-    -re "[\r\n]+g1.c g2.c[\r\n]+vush> " {}
+    -re "\[\r\n\]+g1.c g2.c\[\r\n\]+vush> " {}
     timeout { send_user "glob expansion failed\n"; exit 1 }
 }
 send "rm g1.c g2.c\r"

--- a/tests/test_hash.expect
+++ b/tests/test_hash.expect
@@ -11,7 +11,7 @@ spawn ../vush
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+hashed1[\r\n]+vush> " {}
+    -re "\[\r\n\]+hashed1\[\r\n\]+vush> " {}
     timeout { send_user "first run failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "hash foo\r"
@@ -19,14 +19,14 @@ expect "vush> "
 exec mv "$dir/foo" "$dir/foo2"
 send "foo\r"
 expect {
-    -re "[\r\n]+hashed1[\r\n]+vush> " {}
+    -re "\[\r\n\]+hashed1\[\r\n\]+vush> " {}
     timeout { send_user "hash not used\n"; exec rm -rf $dir; exit 1 }
 }
 send "hash -r\r"
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+foo: command not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo: command not found\[\r\n\]+vush> " {}
     timeout { send_user "hash -r failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_heredoc.expect
+++ b/tests/test_heredoc.expect
@@ -7,7 +7,7 @@ send "hello\r"
 send "world\r"
 send "EOF\r"
 expect {
-    -re "[\r\n]+hello[\r\n]+world[\r\n]+vush> " {}
+    -re "\[\r\n\]+hello\[\r\n\]+world\[\r\n\]+vush> " {}
     timeout { send_user "heredoc output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_heredoc_dash.expect
+++ b/tests/test_heredoc_dash.expect
@@ -6,7 +6,7 @@ send "cat <<-EOF\r"
 send "\tfoo\r"
 send "EOF\r"
 expect {
-    -re "[\r\n]+foo[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo\[\r\n\]+vush> " {}
     timeout { send_user "heredoc <<- failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_heredoc_tabs.expect
+++ b/tests/test_heredoc_tabs.expect
@@ -6,7 +6,7 @@ send "cat <<EOF\r"
 send "\tfoo\r"
 send "EOF\r"
 expect {
-    -re "[\r\n]+\tfoo[\r\n]+vush> " {}
+    -re "\[\r\n\]+\tfoo\[\r\n\]+vush> " {}
     timeout { send_user "heredoc tab preservation failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_herestring.expect
+++ b/tests/test_herestring.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "cat <<<\"hello\"\r"
 expect {
-    -re "[\r\n]+hello[\r\n]+vush> " {}
+    -re "\[\r\n\]+hello\[\r\n\]+vush> " {}
     timeout { send_user "here-string failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_history.expect
+++ b/tests/test_history.expect
@@ -4,17 +4,17 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo output mismatch\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "second output mismatch\n"; exit 1 }
 }
 send "history\r"
 expect {
-    -re "1 echo first[\r\n]+2 echo second[\r\n]+3 history[\r\n]+vush> " {}
+    -re "1 echo first\[\r\n\]+2 echo second\[\r\n\]+3 history\[\r\n\]+vush> " {}
     timeout { send_user "history output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_history_clear.expect
+++ b/tests/test_history_clear.expect
@@ -6,7 +6,7 @@ send "history -c\r"
 expect "vush> "
 send "history\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "history not cleared\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_history_delete.expect
+++ b/tests/test_history_delete.expect
@@ -4,24 +4,24 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo first failed\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "echo second failed\n"; exit 1 }
 }
 send "history\r"
 expect {
-    -re "1 echo first[\r\n]+2 echo second[\r\n]+3 history[\r\n]+vush> " {}
+    -re "1 echo first\[\r\n\]+2 echo second\[\r\n\]+3 history\[\r\n\]+vush> " {}
     timeout { send_user "history list failed\n"; exit 1 }
 }
 send "history -d 2\r"
 expect "vush> "
 send "history\r"
 expect {
-    -re "1 echo first[\r\n]+3 history[\r\n]+4 history -d 2[\r\n]+5 history[\r\n]+vush> " {}
+    -re "1 echo first\[\r\n\]+3 history\[\r\n\]+4 history -d 2\[\r\n\]+5 history\[\r\n\]+vush> " {}
     timeout { send_user "history delete failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_history_limit.expect
+++ b/tests/test_history_limit.expect
@@ -7,27 +7,27 @@ spawn ../vush
 expect "vush> "
 send "echo one\r"
 expect {
-    -re "[\r\n]+one[\r\n]+vush> " {}
+    -re "\[\r\n\]+one\[\r\n\]+vush> " {}
     timeout { send_user "echo one failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "echo two\r"
 expect {
-    -re "[\r\n]+two[\r\n]+vush> " {}
+    -re "\[\r\n\]+two\[\r\n\]+vush> " {}
     timeout { send_user "echo two failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "echo three\r"
 expect {
-    -re "[\r\n]+three[\r\n]+vush> " {}
+    -re "\[\r\n\]+three\[\r\n\]+vush> " {}
     timeout { send_user "echo three failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "echo four\r"
 expect {
-    -re "[\r\n]+four[\r\n]+vush> " {}
+    -re "\[\r\n\]+four\[\r\n\]+vush> " {}
     timeout { send_user "echo four failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "history\r"
 expect {
-    -re "3 echo three[\r\n]+4 echo four[\r\n]+5 history[\r\n]+vush> " {}
+    -re "3 echo three\[\r\n\]+4 echo four\[\r\n\]+5 history\[\r\n\]+vush> " {}
     timeout { send_user "history limit mismatch\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_if.expect
+++ b/tests/test_if.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "if test 1 -eq 1; then echo ok; else echo fail; fi\r"
 expect {
-    -re "ok[\r\n]+vush> " {}
+    -re "ok\[\r\n\]+vush> " {}
     timeout { send_user "if output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_jobs.expect
+++ b/tests/test_jobs.expect
@@ -6,12 +6,12 @@ send "sleep 5 &\r"
 expect "vush> "
 send "jobs\r"
 expect {
-    -re "\[1\] [0-9]+ sleep 5 &[\r\n]+vush> " {}
+    -re "\[1\] \[0-9\]+ sleep 5 &\[\r\n\]+vush> " {}
     timeout { send_user "jobs output mismatch\n"; exit 1 }
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_jobs_l.expect
+++ b/tests/test_jobs_l.expect
@@ -6,12 +6,12 @@ send "sleep 5 &\r"
 expect "vush> "
 send "jobs -l\r"
 expect {
-    -re "\[1\] [0-9]+ Running sleep 5 &[\r\n]+vush> " {}
+    -re "\[1\] \[0-9\]+ Running sleep 5 &\[\r\n\]+vush> " {}
     timeout { send_user "jobs -l output mismatch\n"; exit 1 }
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_jobs_p.expect
+++ b/tests/test_jobs_p.expect
@@ -6,12 +6,12 @@ send "sleep 5 &\r"
 expect "vush> "
 send "jobs -p\r"
 expect {
-    -re "[0-9]+\r\nvush> " {}
+    -re "\[0-9\]+\r\nvush> " {}
     timeout { send_user "jobs -p output mismatch\n"; exit 1 }
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_kill.expect
+++ b/tests/test_kill.expect
@@ -6,7 +6,7 @@ send "sleep 5 &\r"
 expect "vush> "
 send "kill 1\r"
 expect {
-    -re "\[vush\] job [0-9]+ finished[\r\n]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "jobs\r"

--- a/tests/test_kill_s.expect
+++ b/tests/test_kill_s.expect
@@ -6,12 +6,12 @@ send "sleep 5 &\r"
 expect "vush> "
 send "echo \$!\r"
 expect {
-    -re "\r\n([0-9]+)\r\nvush> " { set pid $expect_out(1,string) }
+    -re "\r\n(\[0-9\]+)\r\nvush> " { set pid $expect_out(1,string) }
     timeout { send_user "$! expansion failed\n"; exit 1 }
 }
 send "kill -s TERM $pid\r"
 expect {
-    -re "\[vush\] job [0-9]+ finished\r\nvush> " {}
+    -re "\[vush\] job \[0-9\]+ finished\r\nvush> " {}
     timeout { send_user "kill -s output mismatch\n"; exit 1 }
 }
 send "jobs\r"

--- a/tests/test_lineedit.expect
+++ b/tests/test_lineedit.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "echo foo\r"
 expect {
-    -re "[\r\n]+foo[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo\[\r\n\]+vush> " {}
     timeout { send_user "echo foo failed\n"; exit 1 }
 }
 send "echo bar\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "echo bar failed\n"; exit 1 }
 }
 # Recall 'echo foo' using up arrow twice
@@ -17,21 +17,21 @@ send "\033[A"
 send "\033[A"
 send "\r"
 expect {
-    -re "[\r\n]+foo[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo\[\r\n\]+vush> " {}
     timeout { send_user "history recall up failed\n"; exit 1 }
 }
 # Recall 'echo bar' using down arrow
 send "\033[B"
 send "\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "history recall down failed\n"; exit 1 }
 }
 send "echo one two"
 send "\027"
 send "three\r"
 expect {
-    -re "[\r\n]+one three[\r\n]+vush> " {}
+    -re "\[\r\n\]+one three\[\r\n\]+vush> " {}
     timeout { send_user "Ctrl-W failed\n"; exit 1 }
 }
 send "echo foo bar"
@@ -41,14 +41,14 @@ send "\033[D"
 send "\013"
 send "baz\r"
 expect {
-    -re "[\r\n]+foo baz[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo baz\[\r\n\]+vush> " {}
     timeout { send_user "Ctrl-K failed\n"; exit 1 }
 }
 send "echo clear"
 send "\014"
 send "\r"
 expect {
-    -re "[\r\n]+clear[\r\n]+vush> " {}
+    -re "\[\r\n\]+clear\[\r\n\]+vush> " {}
     timeout { send_user "Ctrl-L failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_local.expect
+++ b/tests/test_local.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "foo() { local x=inner; echo \$x; }; x=outer; foo; echo \$x\r"
 expect {
-    -re "inner[\r\n]+outer[\r\n]+vush> " {}
+    -re "inner\[\r\n\]+outer\[\r\n\]+vush> " {}
     timeout { send_user "local var restore failed\n"; exit 1 }
 }
 send "bar() { local y; y=work; }; bar; echo \${y:-unset}\r"
 expect {
-    -re "unset[\r\n]+vush> " {}
+    -re "unset\[\r\n\]+vush> " {}
     timeout { send_user "local unset failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_ls_l.expect
+++ b/tests/test_ls_l.expect
@@ -5,7 +5,7 @@ expect "vush> "
 # run ls -l on a repository file and check that the filename appears
 send "ls -l run_tests.sh\r"
 expect {
-    -re "[\r\n]+.*run_tests.sh[\r\n]+vush> " {}
+    -re "\[\r\n\]+.*run_tests.sh\[\r\n\]+vush> " {}
     timeout { send_user "ls -l output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_negate.expect
+++ b/tests/test_negate.expect
@@ -7,7 +7,7 @@ send "! false\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "negate command status mismatch\n"; exit 1 }
 }
 # pipeline negation
@@ -15,7 +15,7 @@ send "! true | false\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "negate pipeline status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_noclobber.expect
+++ b/tests/test_noclobber.expect
@@ -10,12 +10,12 @@ send "echo hi >nc.tmp\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "noclobber status mismatch\n"; exit 1 }
 }
 send "cat nc.tmp\r"
 expect {
-    -re "[\r\n]+orig[\r\n]+vush> " {}
+    -re "\[\r\n\]+orig\[\r\n\]+vush> " {}
     timeout { send_user "noclobber overwrite\n"; exit 1 }
 }
 send "rm nc.tmp\r"

--- a/tests/test_param_error.expect
+++ b/tests/test_param_error.expect
@@ -12,14 +12,14 @@ expect {
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "status mismatch\n"; exit 1 }
 }
 send "FOO=val\r"
 expect "vush> "
 send "echo \${FOO?}\r"
 expect {
-    -re "[\r\n]+val[\r\n]+vush> " {}
+    -re "\[\r\n\]+val\[\r\n\]+vush> " {}
     timeout { send_user "no value output\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_param_expand.expect
+++ b/tests/test_param_expand.expect
@@ -6,53 +6,53 @@ send "unset FOO\r"
 expect "vush> "
 send "echo \${FOO:-bar}\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "dash default failed\n"; exit 1 }
 }
 send "echo \${FOO:=baz}\r"
 expect {
-    -re "[\r\n]+baz[\r\n]+vush> " {}
+    -re "\[\r\n\]+baz\[\r\n\]+vush> " {}
     timeout { send_user "assign default failed\n"; exit 1 }
 }
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+baz[\r\n]+vush> " {}
+    -re "\[\r\n\]+baz\[\r\n\]+vush> " {}
     timeout { send_user "assign not stored\n"; exit 1 }
 }
 send "echo \${FOO:+alt}\r"
 expect {
-    -re "[\r\n]+alt[\r\n]+vush> " {}
+    -re "\[\r\n\]+alt\[\r\n\]+vush> " {}
     timeout { send_user "plus alt failed\n"; exit 1 }
 }
 send "echo \${FOO#b*}\r"
 expect {
-    -re "[\r\n]+az[\r\n]+vush> " {}
+    -re "\[\r\n\]+az\[\r\n\]+vush> " {}
     timeout { send_user "prefix removal failed\n"; exit 1 }
 }
 send "echo \${FOO%z}\r"
 expect {
-    -re "[\r\n]+ba[\r\n]+vush> " {}
+    -re "\[\r\n\]+ba\[\r\n\]+vush> " {}
     timeout { send_user "suffix removal failed\n"; exit 1 }
 }
 send "FOO=abcabc\r"
 expect "vush> "
 send "echo \${FOO#a*c}\r"
 expect {
-    -re "[\r\n]+abc[\r\n]+vush> " {}
+    -re "\[\r\n\]+abc\[\r\n\]+vush> " {}
     timeout { send_user "double prefix setup failed\n"; exit 1 }
 }
 send "echo \${FOO##a*c}\r"
 expect "vush> "
 send "echo \${FOO%a*c}\r"
 expect {
-    -re "[\r\n]+abc[\r\n]+vush> " {}
+    -re "\[\r\n\]+abc\[\r\n\]+vush> " {}
     timeout { send_user "double suffix setup failed\n"; exit 1 }
 }
 send "echo \${FOO%%a*c}\r"
 expect "vush> "
 send "echo \${#FOO}\r"
 expect {
-    -re "[\r\n]+6[\r\n]+vush> " {}
+    -re "\[\r\n\]+6\[\r\n\]+vush> " {}
     timeout { send_user "length failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_param_replace.expect
+++ b/tests/test_param_replace.expect
@@ -7,25 +7,25 @@ expect "vush> "
 # replace first occurrence
 send "echo \${FOO/l/x}\r"
 expect {
-    -re "[\r\n]+hexlo[\r\n]+vush> " {}
+    -re "\[\r\n\]+hexlo\[\r\n\]+vush> " {}
     timeout { send_user "single replace failed\n"; exit 1 }
 }
 # global replacement
 send "echo \${FOO//l/x}\r"
 expect {
-    -re "[\r\n]+hexxo[\r\n]+vush> " {}
+    -re "\[\r\n\]+hexxo\[\r\n\]+vush> " {}
     timeout { send_user "global replace failed\n"; exit 1 }
 }
 # wildcard pattern
 send "echo \${FOO/l*/Z}\r"
 expect {
-    -re "[\r\n]+heZ[\r\n]+vush> " {}
+    -re "\[\r\n\]+heZ\[\r\n\]+vush> " {}
     timeout { send_user "wildcard replace failed\n"; exit 1 }
 }
 # no match
 send "echo \${FOO/z/0}\r"
 expect {
-    -re "[\r\n]+hello[\r\n]+vush> " {}
+    -re "\[\r\n\]+hello\[\r\n\]+vush> " {}
     timeout { send_user "no match failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_param_substring.expect
+++ b/tests/test_param_substring.expect
@@ -6,12 +6,12 @@ send "VAR=abcdef\r"
 expect "vush> "
 send "echo \${VAR:3}\r"
 expect {
-    -re "[\r\n]+def[\r\n]+vush> " {}
+    -re "\[\r\n\]+def\[\r\n\]+vush> " {}
     timeout { send_user "offset failed\n"; exit 1 }
 }
 send "echo \${VAR:3:2}\r"
 expect {
-    -re "[\r\n]+de[\r\n]+vush> " {}
+    -re "\[\r\n\]+de\[\r\n\]+vush> " {}
     timeout { send_user "offset length failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_path_blank.expect
+++ b/tests/test_path_blank.expect
@@ -13,7 +13,7 @@ spawn $scriptdir/../vush
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+blankpath[\r\n]+vush> " {}
+    -re "\[\r\n\]+blankpath\[\r\n\]+vush> " {}
     timeout { send_user "blank PATH entry failed\n"; cd $scriptdir; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_path_long.expect
+++ b/tests/test_path_long.expect
@@ -16,7 +16,7 @@ spawn ../vush
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+longpath[\r\n]+vush> " {}
+    -re "\[\r\n\]+longpath\[\r\n\]+vush> " {}
     timeout { send_user "long PATH failed\n"; exec rm -rf $base; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pid_params.expect
+++ b/tests/test_pid_params.expect
@@ -6,7 +6,7 @@ expect "vush> "
 set pid [exp_pid]
 send "echo \$\$\r"
 expect {
-    -re "[\r\n]+$pid[\r\n]+vush> " {}
+    -re "\[\r\n\]+$pid\[\r\n\]+vush> " {}
     timeout { send_user "\$\$ expansion failed\n"; exit 1 }
 }
 # Test $! expansion
@@ -14,19 +14,19 @@ send "sleep 1 &\r"
 expect "vush> "
 send "echo \$!\r"
 expect {
-    -re "[\r\n]+([0-9]+)[\r\n]+vush> " { set bg $expect_out(1,string) }
+    -re "\[\r\n\]+(\[0-9\]+)\[\r\n\]+vush> " { set bg $expect_out(1,string) }
     timeout { send_user "\$! expansion failed\n"; exit 1 }
 }
 send "jobs\r"
 expect {
-    -re "\[1\] $bg sleep 1 &[\r\n]+vush> " {}
+    -re "\[1\] $bg sleep 1 &\[\r\n\]+vush> " {}
     timeout { send_user "jobs pid mismatch\n"; exit 1 }
 }
 send "set -e -u\r"
 expect "vush> "
 send "echo \$-\r"
 expect {
-    -re "[\r\n]+eu[\r\n]+vush> " {}
+    -re "\[\r\n\]+eu\[\r\n\]+vush> " {}
     timeout { send_user "\$- expansion failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pipe.expect
+++ b/tests/test_pipe.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo foo | grep foo\r"
 expect {
-    -re "[\r\n]+foo[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo\[\r\n\]+vush> " {}
     timeout { send_user "pipeline output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pipefail.expect
+++ b/tests/test_pipefail.expect
@@ -8,7 +8,7 @@ send "false | true\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "pipefail status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_printf.expect
+++ b/tests/test_printf.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "printf \"%s %04d %x\\n\" foo 5 255\r"
 expect {
-    -re "[\r\n]+foo 0005 ff[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo 0005 ff\[\r\n\]+vush> " {}
     timeout { send_user "printf output mismatch\n"; exit 1 }
 }
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "printf status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_printf_escapes.expect
+++ b/tests/test_printf_escapes.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "printf \"hi\\nthere\\041\\n\"\r"
 expect {
-    -re "[\r\n]+hi\r\nthere![\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\r\nthere!\[\r\n\]+vush> " {}
     timeout { send_user "printf escapes mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_process_sub.expect
+++ b/tests/test_process_sub.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "diff <\$(echo a) <\$(echo a)\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "process substitution failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_ps1_cmdsub.expect
+++ b/tests/test_ps1_cmdsub.expect
@@ -10,7 +10,7 @@ send "cd ..\r"
 expect "$parent> "
 send "cd -\r"
 expect {
-    -re "[\r\n]+$start[\r\n]+$start> " {}
+    -re "\[\r\n\]+$start\[\r\n\]+$start> " {}
     timeout { send_user "prompt not updated after cd -\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pushd.expect
+++ b/tests/test_pushd.expect
@@ -4,22 +4,22 @@ spawn ../vush
 expect "vush> "
 send "pushd /tmp\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "pushd output mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "pushd didn't cd\n"; exit 1 }
 }
 send "popd\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "popd output mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "popd didn't cd back\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pwd.expect
+++ b/tests/test_pwd.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "pwd\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "pwd output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pwd_options.expect
+++ b/tests/test_pwd_options.expect
@@ -9,12 +9,12 @@ send "cd $dir/link\r"
 expect "vush> "
 send "pwd -L\r"
 expect {
-    -re "[\r\n]+$dir/link[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/link\[\r\n\]+vush> " {}
     timeout { send_user "pwd -L failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "pwd -P\r"
 expect {
-    -re "[\r\n]+$dir/real[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/real\[\r\n\]+vush> " {}
     timeout { send_user "pwd -P failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_read.expect
+++ b/tests/test_read.expect
@@ -7,7 +7,7 @@ send "one two three\r"
 expect "vush> "
 send "echo \$first:\$rest\r"
 expect {
-    -re "[\r\n]+one:two three[\r\n]+vush> " {}
+    -re "\[\r\n\]+one:two three\[\r\n\]+vush> " {}
     timeout { send_user "read builtin failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_read_eof.expect
+++ b/tests/test_read_eof.expect
@@ -7,7 +7,7 @@ send \004
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "read EOF status failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_readonly.expect
+++ b/tests/test_readonly.expect
@@ -12,7 +12,7 @@ expect {
 expect "vush> "
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "readonly value modified\n"; exit 1 }
 }
 send "unset FOO\r"
@@ -23,7 +23,7 @@ expect {
 expect "vush> "
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
     timeout { send_user "readonly unset changed value\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_redir.expect
+++ b/tests/test_redir.expect
@@ -6,7 +6,7 @@ send "echo test >redir.tmp\r"
 expect "vush> "
 send "cat redir.tmp\r"
 expect {
-    -re "[\r\n]+test[\r\n]+vush> " {}
+    -re "\[\r\n\]+test\[\r\n\]+vush> " {}
     timeout { send_user "redirection failed\n"; exit 1 }
 }
 send "rm redir.tmp\r"

--- a/tests/test_reverse_search.expect
+++ b/tests/test_reverse_search.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "echo first\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "echo first failed\n"; exit 1 }
 }
 send "echo second\r"
 expect {
-    -re "[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "echo second failed\n"; exit 1 }
 }
 # Use reverse search to recall 'echo first'
@@ -17,7 +17,7 @@ send "\022"
 send "fir"
 send "\r"
 expect {
-    -re "[\r\n]+first[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+vush> " {}
     timeout { send_user "reverse search failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_select.expect
+++ b/tests/test_select.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "select x in foo bar; do echo \$x; break; done\r"
 expect {
-    -re "1\\) foo[\r\n]+2\\) bar[\r\n]+\\? " {}
+    -re "1\\) foo\[\r\n\]+2\\) bar\[\r\n\]+\\? " {}
     timeout { send_user "select menu failed\n"; exit 1 }
 }
 send "2\r"
 expect {
-    -re "bar[\r\n]+vush> " {}
+    -re "bar\[\r\n\]+vush> " {}
     timeout { send_user "select output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_sequence.expect
+++ b/tests/test_sequence.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "echo first; echo second\r"
 expect {
-    -re "[\r\n]+first[\r\n]+second[\r\n]+vush> " {}
+    -re "\[\r\n\]+first\[\r\n\]+second\[\r\n\]+vush> " {}
     timeout { send_user "sequence output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_set_options.expect
+++ b/tests/test_set_options.expect
@@ -14,7 +14,7 @@ expect {
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "nounset status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_set_positional.expect
+++ b/tests/test_set_positional.expect
@@ -6,7 +6,7 @@ send "set -- foo bar\r"
 expect "vush> "
 send "echo \\\"\$1,\$2,\$#\\\"\r"
 expect {
-    -re "[\r\n]+foo,bar,2[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo,bar,2\[\r\n\]+vush> " {}
     timeout { send_user "set positional failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_source.expect
+++ b/tests/test_source.expect
@@ -8,12 +8,12 @@ spawn ../vush
 expect "vush> "
 send "source $script\r"
 expect {
-    -re "[\r\n]+sourced[\r\n]+vush> " {}
+    -re "\[\r\n\]+sourced\[\r\n\]+vush> " {}
     timeout { send_user "source builtin failed\n"; exec rm $script; exit 1 }
 }
 send ". $script\r"
 expect {
-    -re "[\r\n]+sourced[\r\n]+vush> " {}
+    -re "\[\r\n\]+sourced\[\r\n\]+vush> " {}
     timeout { send_user "dot alias failed\n"; exec rm $script; exit 1 }
 }
 send "exit\r"

--- a/tests/test_source_args.expect
+++ b/tests/test_source_args.expect
@@ -10,7 +10,7 @@ spawn ../vush
 expect "vush> "
 send "source $script foo bar\r"
 expect {
-    -re "[\r\n]+$script,foo,bar,2,foo bar[\r\n]+vush> " {}
+    -re "\[\r\n\]+$script,foo,bar,2,foo bar\[\r\n\]+vush> " {}
     timeout { send_user "source args failed\n"; exec rm $script; exit 1 }
 }
 send "exit\r"

--- a/tests/test_status.expect
+++ b/tests/test_status.expect
@@ -6,14 +6,14 @@ send "false\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "false status mismatch\n"; exit 1 }
 }
 send "true\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "true status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_subshell.expect
+++ b/tests/test_subshell.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "(cd /tmp; pwd)\r"
 expect {
-    -re "[\r\n]+/tmp[\r\n]+vush> " {}
+    -re "\[\r\n\]+/tmp\[\r\n\]+vush> " {}
     timeout { send_user "subshell output mismatch\n"; exit 1 }
 }
 send "pwd\r"
 expect {
-    -re "[\r\n]+$env(PWD)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
     timeout { send_user "subshell changed directory\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_test.expect
+++ b/tests/test_test.expect
@@ -8,43 +8,43 @@ expect "vush> "
 
 send "test -e $file; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-e failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -f $file; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-f failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -d $dir; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-d failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -d $file; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "-d on file failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -r $file; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-r failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -w $file; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-w failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -x $file; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "-x false failed\n"; exec rm -rf $dir; exit 1 }
 }
 
@@ -53,13 +53,13 @@ expect "vush> "
 
 send "test -x $file; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "-x true failed\n"; exec rm -rf $dir; exit 1 }
 }
 
 send "test -e $dir/nope; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "-e nonexistent failed\n"; exec rm -rf $dir; exit 1 }
 }
 

--- a/tests/test_test_bool.expect
+++ b/tests/test_test_bool.expect
@@ -6,34 +6,34 @@ expect "vush> "
 # ! operator
 send "test ! 1 -eq 2; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "negation failed\n"; exit 1 }
 }
 
 # -a operator
 send "test 1 -eq 1 -a 2 -eq 3; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "and failed\n"; exit 1 }
 }
 
 # -o operator
 send "test 1 -eq 1 -o 2 -eq 3; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "or failed\n"; exit 1 }
 }
 
 # precedence ! and -a before -o
 send "test 0 -eq 1 -o 1 -eq 1 -a 2 -eq 2; echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "precedence failed\n"; exit 1 }
 }
 
 send "test ! 1 -eq 1 -o 1 -eq 1 -a 0 -eq 1; echo \$?\r"
 expect {
-    -re "[\r\n]+1[\r\n]+vush> " {}
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "complex precedence failed\n"; exit 1 }
 }
 

--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -10,7 +10,7 @@ send "cd ~$user\r"
 expect "vush> "
 send "pwd\r"
 expect {
-    -re "[\r\n]+$home[\r\n]+vush> " {}
+    -re "\[\r\n\]+$home\[\r\n\]+vush> " {}
     timeout { send_user "tilde expansion failed\n"; exec sed -i '/$user:x:12345/d' /etc/passwd; exec rm -rf $home; exit 1 }
 }
 send "exit\r"

--- a/tests/test_time.expect
+++ b/tests/test_time.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "time sleep 0.1\r"
 expect {
-    -re "real [0-9]+\.[0-9]+ sec\r?\n" {}
+    -re "real \[0-9\]+\.\[0-9\]+ sec\r?\n" {}
     timeout { send_user "time output mismatch\n"; exit 1 }
 }
 expect "vush> "

--- a/tests/test_time_p.expect
+++ b/tests/test_time_p.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "time -p sleep 0.1\r"
 expect {
-    -re "real [0-9]+\.[0-9]+\r?\nuser [0-9]+\.[0-9]+\r?\nsys [0-9]+\.[0-9]+\r?\n" {}
+    -re "real \[0-9\]+\.\[0-9\]+\r?\nuser \[0-9\]+\.\[0-9\]+\r?\nsys \[0-9\]+\.\[0-9\]+\r?\n" {}
     timeout { send_user "time -p output mismatch\n"; exit 1 }
 }
 expect "vush> "

--- a/tests/test_times.expect
+++ b/tests/test_times.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "times\r"
 expect {
-    -re "[0-9]+\.[0-9]+ [0-9]+\.[0-9]+\r?\n[0-9]+\.[0-9]+ [0-9]+\.[0-9]+\r?\n" {}
+    -re "\[0-9\]+\.\[0-9\]+ \[0-9\]+\.\[0-9\]+\r?\n\[0-9\]+\.\[0-9\]+ \[0-9\]+\.\[0-9\]+\r?\n" {}
     timeout { send_user "times output mismatch\n"; exit 1 }
 }
 expect "vush> "

--- a/tests/test_trap.expect
+++ b/tests/test_trap.expect
@@ -7,7 +7,7 @@ expect "vush> "
 set pid [exp_pid]
 exec kill -INT $pid
 expect {
-    -re "[\r\n]+trapped[\r\n]+vush> " {}
+    -re "\[\r\n\]+trapped\[\r\n\]+vush> " {}
     timeout { send_user "trap output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_trap_no_args.expect
+++ b/tests/test_trap_no_args.expect
@@ -6,7 +6,7 @@ send "trap 'echo hi' INT\r"
 expect "vush> "
 send "trap\r"
 expect {
-    -re "[\r\n]+trap 'echo hi' INT[\r\n]+vush> " {}
+    -re "\[\r\n\]+trap 'echo hi' INT\[\r\n\]+vush> " {}
     timeout { send_user "trap no args output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_trap_p.expect
+++ b/tests/test_trap_p.expect
@@ -6,7 +6,7 @@ send "trap 'echo hi' INT\r"
 expect "vush> "
 send "trap -p\r"
 expect {
-    -re "[\r\n]+trap 'echo hi' INT[\r\n]+vush> " {}
+    -re "\[\r\n\]+trap 'echo hi' INT\[\r\n\]+vush> " {}
     timeout { send_user "trap -p output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_true_builtin.expect
+++ b/tests/test_true_builtin.expect
@@ -6,7 +6,7 @@ send "true\r"
 expect "vush> "
 send "echo \$?\r"
 expect {
-    -re "[\r\n]+0[\r\n]+vush> " {}
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "true builtin status mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_type.expect
+++ b/tests/test_type.expect
@@ -6,7 +6,7 @@ send "alias ll='echo hi'\r"
 expect "vush> "
 send "type ll cd ls nosuch\r"
 expect {
-    -re "[\r\n]+ll is an alias for 'echo hi'[\r\n]+cd is a builtin[\r\n]+ls is .*/ls[\r\n]+nosuch not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+ll is an alias for 'echo hi'\[\r\n\]+cd is a builtin\[\r\n\]+ls is .*/ls\[\r\n\]+nosuch not found\[\r\n\]+vush> " {}
     timeout { send_user "type output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_ulimit.expect
+++ b/tests/test_ulimit.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "ulimit -a\r"
 expect {
-    -re "\r\n-c (?:unlimited|[0-9]+)\r?\n-d (?:unlimited|[0-9]+)\r?\n-f (?:unlimited|[0-9]+)\r?\n-n (?:unlimited|[0-9]+)\r?\n-s (?:unlimited|[0-9]+)\r?\n-t (?:unlimited|[0-9]+)\r?\n-v (?:unlimited|[0-9]+)\r?\nvush> " {}
+    -re "\r\n-c (?:unlimited|\[0-9\]+)\r?\n-d (?:unlimited|\[0-9\]+)\r?\n-f (?:unlimited|\[0-9\]+)\r?\n-n (?:unlimited|\[0-9\]+)\r?\n-s (?:unlimited|\[0-9\]+)\r?\n-t (?:unlimited|\[0-9\]+)\r?\n-v (?:unlimited|\[0-9\]+)\r?\nvush> " {}
     timeout { send_user "ulimit -a output mismatch\n"; exit 1 }
 }
 send "ulimit -f 1234\r"

--- a/tests/test_umask.expect
+++ b/tests/test_umask.expect
@@ -4,12 +4,12 @@ spawn ../vush
 expect "vush> "
 send "umask\r"
 expect {
-    -re "[\r\n]+([0-7]{4})[\r\n]+vush> " { set old $expect_out(1,string) }
+    -re "\[\r\n\]+(\[0-7\]{4})\[\r\n\]+vush> " { set old $expect_out(1,string) }
     timeout { send_user "umask read failed\n"; exit 1 }
 }
 send "umask -S\r"
 expect {
-    -re "\r\nu=[rwx]*,g=[rwx]*,o=[rwx]*\r?\nvush> " {}
+    -re "\r\nu=\[rwx\]*,g=\[rwx\]*,o=\[rwx\]*\r?\nvush> " {}
     timeout { send_user "umask -S output mismatch\n"; exit 1 }
 }
 send "umask 077\r"
@@ -21,7 +21,7 @@ expect {
 }
 send "umask\r"
 expect {
-    -re "[\r\n]+0077[\r\n]+vush> " {}
+    -re "\[\r\n\]+0077\[\r\n\]+vush> " {}
     timeout { send_user "umask set failed\n"; exit 1 }
 }
 send "umask $old\r"

--- a/tests/test_umask_symbolic.expect
+++ b/tests/test_umask_symbolic.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "umask\r"
 expect {
-    -re "[\r\n]+([0-7]{4})[\r\n]+vush> " { set old $expect_out(1,string) }
+    -re "\[\r\n\]+(\[0-7\]{4})\[\r\n\]+vush> " { set old $expect_out(1,string) }
     timeout { send_user "umask read failed\n"; exit 1 }
 }
 send "umask u=rwx,g=rx,o=\r"
@@ -16,7 +16,7 @@ expect {
 }
 send "umask\r"
 expect {
-    -re "[\r\n]+0077[\r\n]+vush> " {}
+    -re "\[\r\n\]+0077\[\r\n\]+vush> " {}
     timeout { send_user "umask symbolic set failed\n"; exit 1 }
 }
 send "umask $old\r"

--- a/tests/test_unalias_a.expect
+++ b/tests/test_unalias_a.expect
@@ -8,7 +8,7 @@ send "unalias -a\r"
 expect "vush> "
 send "alias\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "unalias -a failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_unset.expect
+++ b/tests/test_unset.expect
@@ -8,7 +8,7 @@ send "unset FOO\r"
 expect "vush> "
 send "echo \$FOO\r"
 expect {
-    -re "[\r\n]+vush> " {}
+    -re "\[\r\n\]+vush> " {}
     timeout { send_user "unset failed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_unset_function.expect
+++ b/tests/test_unset_function.expect
@@ -6,14 +6,14 @@ send "foo() { echo hi; }\r"
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+hi[\r\n]+vush> " {}
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
     timeout { send_user "function execution failed\n"; exit 1 }
 }
 send "unset -f foo\r"
 expect "vush> "
 send "foo\r"
 expect {
-    -re "[\r\n]+foo: command not found[\r\n]+vush> " {}
+    -re "\[\r\n\]+foo: command not found\[\r\n\]+vush> " {}
     timeout { send_user "function not removed\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_until.expect
+++ b/tests/test_until.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "j=2; until test \$j -eq 0; do echo \$j; j=\$(expr \$j - 1); done\r"
 expect {
-    -re "2[\r\n]+1[\r\n]+vush> " {}
+    -re "2\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "until output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_var_brace.expect
+++ b/tests/test_var_brace.expect
@@ -4,17 +4,17 @@ spawn ../vush
 expect "vush> "
 send "echo \${HOME}\r"
 expect {
-    -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(HOME)\[\r\n\]+vush> " {}
     timeout { send_user "brace expansion failed\n"; exit 1 }
 }
 send "echo \\\"\${HOME}\\\"\r"
 expect {
-    -re "[\r\n]+$env(HOME)[\r\n]+vush> " {}
+    -re "\[\r\n\]+$env(HOME)\[\r\n\]+vush> " {}
     timeout { send_user "quoted brace expansion failed\n"; exit 1 }
 }
 send "echo '\${HOME}'\r"
 expect {
-    -re "[\r\n]+\${HOME}[\r\n]+vush> " {}
+    -re "\[\r\n\]+\${HOME}\[\r\n\]+vush> " {}
     timeout { send_user "single quote brace mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_vushrc.expect
+++ b/tests/test_vushrc.expect
@@ -7,7 +7,7 @@ close $f
 set env(HOME) $dir
 spawn ../vush
 expect {
-    -re "[\r\n]+rcstart[\r\n]+vush> " {}
+    -re "\[\r\n\]+rcstart\[\r\n\]+vush> " {}
     timeout { send_user "rc file not executed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_while.expect
+++ b/tests/test_while.expect
@@ -4,7 +4,7 @@ spawn ../vush
 expect "vush> "
 send "export i=0; while test \$i -lt 3; do echo \$i; export i=\$(expr \$i + 1); done\r"
 expect {
-    -re "0[\r\n]+1[\r\n]+2[\r\n]+vush> " {}
+    -re "0\[\r\n\]+1\[\r\n\]+2\[\r\n\]+vush> " {}
     timeout { send_user "while output mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- escape brackets in expect regexes so Tcl doesn't misparse

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c370344948324a44e40bba42abfe1