### PR TITLE
Fix PS1 export expect test

### DIFF
--- a/tests/test_export_ps1.expect
+++ b/tests/test_export_ps1.expect
@@ -3,6 +3,10 @@ set timeout 5
 spawn ../vush
 expect "vush> "
 send "export PS1='custom> '\r"
-expect "custom> "
+expect ""
+expect {
+    -re "\r\ncustom> " {}
+    timeout { send_user "prompt not updated\n"; exit 1 }
+}
 send "exit\r"
 expect eof


### PR DESCRIPTION
## Summary
- update `test_export_ps1.expect` to clear buffer before the prompt appears
- anchor prompt check to a newline and handle timeout with non-zero exit

## Testing
- `./test_export_ps1.expect && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_684c4950eee88324b131d1eed7c94bcd