### PR TITLE
Fix quoting of brackets in Expect scripts

### DIFF
--- a/tests/test_array.expect
+++ b/tests/test_array.expect
@@ -14,7 +14,7 @@ expect {
     -re "one\[\r\n\]+two\[\r\n\]+three\[\r\n\]+vush> " {}
     timeout { send_user "iteration failed\n"; exit 1 }
 }
-send "unset nums[1]\r"
+send "unset nums\[1\]\r"
 expect "vush> "
 send "for n in \${nums\[@\]}; do echo \$n; done\r"
 expect {

--- a/tests/test_cond.expect
+++ b/tests/test_cond.expect
@@ -6,19 +6,19 @@ expect "vush> "
 send "x=foo\r"
 expect "vush> "
 
-send "[[ \$x == foo ]]; echo \$?\r"
+send "\[\[ \$x == foo \]\]; echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "equality failed\n"; exit 1 }
 }
 
-send "[[ \$x == f* ]]; echo \$?\r"
+send "\[\[ \$x == f* \]\]; echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "pattern match failed\n"; exit 1 }
 }
 
-send "[[ \$x == b* ]]; echo \$?\r"
+send "\[\[ \$x == b* \]\]; echo \$?\r"
 expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "pattern negative failed\n"; exit 1 }

--- a/tests/test_lineedit.expect
+++ b/tests/test_lineedit.expect
@@ -13,15 +13,15 @@ expect {
     timeout { send_user "echo bar failed\n"; exit 1 }
 }
 # Recall 'echo foo' using up arrow twice
-send "\033[A"
-send "\033[A"
+send "\033\[A"
+send "\033\[A"
 send "\r"
 expect {
     -re "\[\r\n\]+foo\[\r\n\]+vush> " {}
     timeout { send_user "history recall up failed\n"; exit 1 }
 }
 # Recall 'echo bar' using down arrow
-send "\033[B"
+send "\033\[B"
 send "\r"
 expect {
     -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
@@ -35,9 +35,9 @@ expect {
     timeout { send_user "Ctrl-W failed\n"; exit 1 }
 }
 send "echo foo bar"
-send "\033[D"
-send "\033[D"
-send "\033[D"
+send "\033\[D"
+send "\033\[D"
+send "\033\[D"
 send "\013"
 send "baz\r"
 expect {


### PR DESCRIPTION
## Summary
- escape [ and ] inside double-quoted strings in tests
- fix arrow key sequences in `test_lineedit.expect`

## Testing
- `tests/run_tests.sh` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b892f4c8324807db8cda8610c62