### PR TITLE
Show cwd in pushd/dirs output

### DIFF
--- a/src/dirstack.c
+++ b/src/dirstack.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <limits.h>
 
 typedef struct DirNode {
     char *dir;
@@ -60,6 +62,17 @@ char *dirstack_pop(void) {
  * Each entry is separated by a space and a trailing newline is added.
  */
 void dirstack_print(void) {
+    const char *pwd = getenv("PWD");
+    char cwd[PATH_MAX];
+    if (!pwd) {
+        if (getcwd(cwd, sizeof(cwd)))
+            pwd = cwd;
+        else
+            pwd = "";
+    }
+
+    printf("%s ", pwd);
+
     DirNode *n = top;
     while (n) {
         printf("%s ", n->dir);

--- a/tests/test_dirs.expect
+++ b/tests/test_dirs.expect
@@ -7,17 +7,17 @@ expect {
 }
 send "pushd /tmp\r"
 expect {
-    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+/tmp $env(PWD) \[\r\n\]+vush> " {}
     timeout { send_user "pushd output mismatch\n"; exit 1 }
 }
 send "dirs\r"
 expect {
-    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+/tmp $env(PWD) \[\r\n\]+vush> " {}
     timeout { send_user "dirs output mismatch\n"; exit 1 }
 }
 send "popd\r"
 expect {
-    -re "\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+$env(PWD) \[\r\n\]+vush> " {}
     timeout { send_user "popd output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pushd.expect
+++ b/tests/test_pushd.expect
@@ -7,7 +7,7 @@ expect {
 }
 send "pushd /tmp\r"
 expect {
-    -re "\[\r\n\]+$env(PWD)\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+/tmp $env(PWD) \[\r\n\]+vush> " {}
     timeout { send_user "pushd output mismatch\n"; exit 1 }
 }
 send "pwd\r"
@@ -17,7 +17,7 @@ expect {
 }
 send "popd\r"
 expect {
-    -re "\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+$env(PWD) \[\r\n\]+vush> " {}
     timeout { send_user "popd output mismatch\n"; exit 1 }
 }
 send "pwd\r"


### PR DESCRIPTION
## Summary
- print current directory before listing stack contents
- adjust `pushd` and `dirs` tests for new output format

## Testing
- `make`
- `./tests/test_pushd.expect`
- `./tests/test_dirs.expect`


------
https://chatgpt.com/codex/tasks/task_e_684c57d27f448324ac15f84c75675ba4