### PR TITLE
Fix echo option spacing

### DIFF
--- a/src/builtins_print.c
+++ b/src/builtins_print.c
@@ -29,9 +29,10 @@ int builtin_echo(char **args)
         }
         break;
     }
+    int first_arg = i;
 
     for (; args[i]; i++) {
-        if (i > 1 && args[i-1])
+        if (i > first_arg)
             putchar(' ');
         const char *s = args[i];
         if (interpret) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -66,6 +66,7 @@ tests="
     test_custom_aliasfile.expect
     test_dash_c.expect
     test_dash_c_quotes.expect
+    test_echo_options.expect
     test_set_options.expect
     test_heredoc.expect
     test_herestring.expect

--- a/tests/test_echo_options.expect
+++ b/tests/test_echo_options.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn ../vush -c {echo -n hi}
+expect {
+    "hi" {}
+    timeout { send_user "echo -n output mismatch\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+spawn ../vush -c {echo -e hi}
+expect {
+    -re "hi\r?\n" {}
+    timeout { send_user "echo -e output mismatch\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- handle option indices properly when printing arguments in builtin echo
- test echo option handling with no leading space

## Testing
- `make`
- `cd tests && ./test_echo_options.expect`

------
https://chatgpt.com/codex/tasks/task_e_684c5919f870832496581d9ee68e932a