### PR TITLE
Fix tilde user cleanup

### DIFF
--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -17,12 +17,12 @@ expect {
 send "pwd\r"
 expect {
     -re "\[\r\n\]+$home\[\r\n\]+vush> " {}
-    timeout { send_user "tilde expansion failed\n"; exec sed -i '/$user:x:12345/d' /etc/passwd; exec rm -rf $home; exit 1 }
+    timeout { send_user "tilde expansion failed\n"; exec sed -i "/$user:x:12345/d" /etc/passwd; exec rm -rf $home; exit 1 }
 }
 send "exit\r"
 expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-exec sed -i '/$user:x:12345/d' /etc/passwd
+exec sed -i "/$user:x:12345/d" /etc/passwd
 exec rm -rf $home


### PR DESCRIPTION
## Summary
- ensure `$user` variable expands in cleanup commands in `tests/test_tilde_user.expect`

## Testing
- `./test_tilde_user.expect`

------
https://chatgpt.com/codex/tasks/task_e_684c5b03e91083248a7eb43632698fe6