### PR TITLE
Fix quoting in script args test

### DIFF
--- a/tests/test_script_args.expect
+++ b/tests/test_script_args.expect
@@ -2,9 +2,9 @@
 set timeout 5
 set script [exec mktemp]
 set f [open $script "w"]
-puts $f "echo \"$0,$1,$2,$#,$@\""
+puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 puts $f "shift"
-puts $f "echo \"$0,$1,$2,$#,$@\""
+puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 close $f
 spawn ../vush $script foo bar
 expect {


### PR DESCRIPTION
## Summary
- escape `$` characters when writing to the temporary script in `tests/test_script_args.expect`

## Testing
- `./test_script_args.expect` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_684c5bae5b1883248e2b7d39b50da17b