### PR TITLE
Isolate HOME during expect tests

### DIFF
--- a/tests/test_alias_flags.expect
+++ b/tests/test_alias_flags.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -39,3 +41,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir

--- a/tests/test_command.expect
+++ b/tests/test_command.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -20,3 +22,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir

--- a/tests/test_command_V.expect
+++ b/tests/test_command_V.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -20,3 +22,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir

--- a/tests/test_command_v.expect
+++ b/tests/test_command_v.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -20,3 +22,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir

--- a/tests/test_type.expect
+++ b/tests/test_type.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -20,3 +22,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir

--- a/tests/test_unalias_a.expect
+++ b/tests/test_unalias_a.expect
@@ -1,4 +1,6 @@
 #!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
 set timeout 5
 spawn ../vush
 expect {
@@ -25,3 +27,4 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- isolate HOME in several expect tests
- ensure temporary HOME setup is present in `run_tests.sh`

## Testing
- `make -j$(nproc)`
- `cd tests && ./run_tests.sh` *(fails partway due to manual interrupt but verifies `echo` in new session)*

------
https://chatgpt.com/codex/tasks/task_e_684c763f047c8324b1e937a5e60cf9f4