### PR TITLE
Handle inline variable expansion in tokenizer

### DIFF
--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "lexer.h"
 #include "parser.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -253,6 +254,23 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
             }
             /* unmatched, reset pointer for error */
             *p = (char *)start;
+        }
+        if (**p == '$' && (isalnum((unsigned char)*(*p + 1)))) {
+            char var[MAX_LINE];
+            int vlen = 0;
+            var[vlen++] = *(*p)++; /* '$' */
+            while (**p && isalnum((unsigned char)**p) && vlen < MAX_LINE - 1) {
+                var[vlen++] = **p;
+                (*p)++;
+            }
+            var[vlen] = '\0';
+            char *exp = *do_expand ? expand_var(var) : strdup(var);
+            if (!exp) return -1;
+            for (int ci = 0; exp[ci] && *len < MAX_LINE - 1; ci++)
+                buf[(*len)++] = exp[ci];
+            free(exp);
+            first = 0;
+            continue;
         }
         if (*len < MAX_LINE - 1) buf[(*len)++] = **p;
         (*p)++;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -64,6 +64,7 @@ tests="
     test_envfile.expect
     test_var_brace.expect
     test_param_expand.expect
+    test_param_inline.expect
     test_unmatched.expect
     test_jobs.expect
     test_type.expect

--- a/tests/test_param_inline.expect
+++ b/tests/test_param_inline.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn ../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "set -- foo bar\r"
+expect {
+    "vush> " {}
+    timeout { send_user "set failed\n"; exit 1 }
+}
+send "echo foo\$1bar\r"
+expect {
+    -re "\[\r\n\]+foofoobar\[\r\n\]+vush> " {}
+    timeout { send_user "inline expansion failed\n"; exit 1 }
+}
+send "echo \"\$1,\$2\"\r"
+expect {
+    -re "\[\r\n\]+foo,bar\[\r\n\]+vush> " {}
+    timeout { send_user "quoted inline expansion failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- support basic variable expansions directly in `read_simple_token`
- add tests for inline positional parameter expansion

## Testing
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c861fca1483249449aee7fdef3ee1