### PR TITLE
Fix quoting in line continuation test

### DIFF
--- a/tests/test_line_cont.expect
+++ b/tests/test_line_cont.expect
@@ -2,8 +2,8 @@
 set timeout 5
 set script [exec mktemp]
 set f [open $script "w"]
-puts $f "echo one \\\"
-puts $f "two"
+puts $f {echo one \}
+puts $f {two}
 close $f
 spawn ../vush $script
 expect {


### PR DESCRIPTION
## Summary
- rewrite the line continuation expect script using brace quoting

## Testing
- `make`
- `make test` *(fails: missing close-brace errors and permission issues)*

------
https://chatgpt.com/codex/tasks/task_e_684c8c01c7688324aeaa1fe676736151