### PR TITLE
Fix heredoc CRLF tolerance in test

### DIFF
--- a/tests/test_heredoc.expect
+++ b/tests/test_heredoc.expect
@@ -10,7 +10,7 @@ send "hello\r"
 send "world\r"
 send "EOF\r"
 expect {
-    -re "\[\r\n\]+hello\[\r\n\]+world\[\r\n\]+vush> " {}
+    -re {\r?\nhello\r?\nworld\r?\nvush> } {}
     timeout { send_user "heredoc output mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- allow optional carriage returns when matching heredoc output in `test_heredoc.expect`

## Testing
- `./test_heredoc.expect` *(fails: heredoc output mismatch)*
- `make test` *(fails: expect script errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c8fd1d4c48324a1095864a201e77c