### PR TITLE
Handle builtin redirections in child process

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -38,6 +38,7 @@ tests="
     test_history_delete.expect
     test_pipe.expect
     test_redir.expect
+    test_assign_redir.expect
     test_source.expect
     test_fg.expect
     test_bg.expect

--- a/tests/test_assign_redir.expect
+++ b/tests/test_assign_redir.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn ../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "FOO=bar echo hi >redir.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "cat redir.tmp\r"
+expect {
+    -re "\[\r\n\]+hi\[\r\n\]+vush> " {}
+    timeout { send_user "redirect with assign failed\n"; exit 1 }
+}
+send "rm redir.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- detect redirection on single pipeline segments and run them via `spawn_pipeline_segments`
- pass background and line info to `apply_temp_assignments`
- add regression test for assignments with builtin redirection

## Testing
- `make`
- `./tests/test_assign_redir.expect`

------
https://chatgpt.com/codex/tasks/task_e_684c93e366cc83249bd9b5e6c8c62048