### PR TITLE
Fix parameter expansion after brace parsing

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -491,7 +491,7 @@ static int start_new_segment(char **p, PipelineSegment **seg_ptr, int *argc) {
 }
 
 static char **expand_token_braces(char *tok, int quoted, int *count) {
-    if (!quoted) {
+    if (!quoted && !(tok[0] == '$' && tok[1] == '{')) {
         char **btoks = expand_braces(tok, count);
         free(tok);
         return btoks;

--- a/tests/test_param_expand.expect
+++ b/tests/test_param_expand.expect
@@ -10,6 +10,21 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
+send "echo \${FOO:+alt}\r"
+expect {
+    "vush> " {}
+    timeout { send_user "plus unset failed\n"; exit 1 }
+}
+send "echo \${FOO#b*}\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prefix unset failed\n"; exit 1 }
+}
+send "echo \${FOO%z}\r"
+expect {
+    "vush> " {}
+    timeout { send_user "suffix unset failed\n"; exit 1 }
+}
 send "echo \${FOO:-bar}\r"
 expect {
     -re "\[\r\n\]+bar\[\r\n\]+vush> " {}


### PR DESCRIPTION
## Summary
- prevent brace expansion from hijacking `${…}` expressions
- test `${VAR:+alt}`, `${VAR#pat}`, and `${VAR%pat}` when variable unset

## Testing
- `./tests/run_tests.sh tests/test_param_expand.expect` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c9d05faf88324b902a89afad6998c