### PR TITLE
Delay variable expansion to execution time

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -116,6 +116,8 @@ static int apply_temp_assignments(PipelineSegment *pipeline, int background,
     if (pipeline->next)
         return 0;
 
+    expand_segment(pipeline);
+
     if (!pipeline->argv[0] && pipeline->assign_count > 0) {
         for (int i = 0; i < pipeline->assign_count; i++) {
             char *eq = strchr(pipeline->assigns[i], '=');
@@ -438,12 +440,12 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
         fprintf(stderr, "%s%s\n", ps4, line);
     }
 
-    expand_pipeline(pipeline);
-
     if (apply_temp_assignments(pipeline, background, line)) {
         cleanup_proc_subs();
         return last_status;
     }
+
+    expand_pipeline(pipeline);
 
     if (!pipeline->argv[0] || pipeline->argv[0][0] == '\0') {
         fprintf(stderr, "syntax error: missing command\n");

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -259,19 +259,12 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
             *p = (char *)start;
         }
         if (**p == '$' && (isalnum((unsigned char)*(*p + 1)))) {
-            char var[MAX_LINE];
-            int vlen = 0;
-            var[vlen++] = *(*p)++; /* '$' */
-            while (**p && isalnum((unsigned char)**p) && vlen < MAX_LINE - 1) {
-                var[vlen++] = **p;
+            if (*len < MAX_LINE - 1)
+                buf[(*len)++] = *(*p)++; /* '$' */
+            while (**p && isalnum((unsigned char)**p) && *len < MAX_LINE - 1) {
+                buf[(*len)++] = **p;
                 (*p)++;
             }
-            var[vlen] = '\0';
-            char *exp = *do_expand ? expand_var(var) : strdup(var);
-            if (!exp) return -1;
-            for (int ci = 0; exp[ci] && *len < MAX_LINE - 1; ci++)
-                buf[(*len)++] = exp[ci];
-            free(exp);
             first = 0;
             continue;
         }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -29,6 +29,7 @@ tests="
     test_unset_function.expect
     test_local.expect
     test_func_scope.expect
+    test_local_shadow.expect
     test_script.expect
     test_script_args.expect
     test_comments.expect

--- a/tests/test_local_shadow.expect
+++ b/tests/test_local_shadow.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn ../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "foo() { local x=inner; echo \$x; }; x=outer; foo; echo \$x\r"
+expect {
+    -re "inner\[\r\n\]+outer\[\r\n\]+vush> " {}
+    timeout { send_user "shadow failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- stop expanding variables in `read_token`
- expand pipeline segments at execution time
- regression test for `local` variable shadowing

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684caabee35883249a165bd11fcfa3db