### PR TITLE
Fix symlink creation in expect tests

### DIFF
--- a/tests/test_cd_P.expect
+++ b/tests/test_cd_P.expect
@@ -2,14 +2,14 @@
 set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
-file symlink "$dir/real" "$dir/link"
+file link -symbolic "$dir/link" "$dir/real"
 spawn ../vush
 expect "vush> "
 send "cd -P $dir/link\r"
 expect "vush> "
 send "pwd\r"
 expect {
-    -re "[\r\n]+$dir/real[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/real\[\r\n\]+vush> " {}
     timeout { send_user "cd -P failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_pwd_options.expect
+++ b/tests/test_pwd_options.expect
@@ -2,19 +2,19 @@
 set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
-file symlink "$dir/real" "$dir/link"
+file link -symbolic "$dir/link" "$dir/real"
 spawn ../vush
 expect "vush> "
 send "cd $dir/link\r"
 expect "vush> "
 send "pwd -L\r"
 expect {
-    -re "[\r\n]+$dir/link[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/link\[\r\n\]+vush> " {}
     timeout { send_user "pwd -L failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "pwd -P\r"
 expect {
-    -re "[\r\n]+$dir/real[\r\n]+vush> " {}
+    -re "\[\r\n\]+$dir/real\[\r\n\]+vush> " {}
     timeout { send_user "pwd -P failed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- use `file link -symbolic` for creating symlinks in expect tests
- escape square brackets so patterns are parsed correctly

## Testing
- `./test_cd_P.expect`
- `./test_pwd_options.expect`


------
https://chatgpt.com/codex/tasks/task_e_684bc11bb3e883249be42ad850283214