### PR TITLE
Fix history numbering after entry deletion

### DIFF
--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -24,8 +24,13 @@ int builtin_history(char **args)
             clear_history();
             return 1;
         } else if (strcmp(args[1], "-d") == 0 && args[2] && !args[3]) {
-            int id = atoi(args[2]);
-            delete_history_entry(id);
+            char *end;
+            long id = strtol(args[2], &end, 10);
+            if (*end || id <= 0) {
+                fprintf(stderr, "history: invalid entry\n");
+                return 1;
+            }
+            delete_history_entry((int)id);
             return 1;
         } else {
             fprintf(stderr, "usage: history [-c|-d NUMBER]\n");

--- a/src/history.c
+++ b/src/history.c
@@ -38,6 +38,15 @@ static int skip_next = 0;
 static int history_size = 0;
 static int max_history = MAX_HISTORY;
 
+/* Renumber history entries sequentially starting at 1. */
+static void renumber_history(void)
+{
+    int id = 1;
+    for (HistEntry *e = head; e; e = e->next)
+        e->id = id++;
+    next_id = id;
+}
+
 /*
  * Determine the path to the history file.  ``$VUSH_HISTFILE`` takes
  * precedence over ``$HOME/.vush_history``.  Returns NULL if no path can
@@ -293,6 +302,8 @@ void delete_history_entry(int id) {
 
     free(e);
     history_size--;
+
+    renumber_history();
 
     const char *path = histfile_path();
     if (!path)

--- a/tests/test_history_delete.expect
+++ b/tests/test_history_delete.expect
@@ -27,7 +27,7 @@ expect {
 }
 send "history\r"
 expect {
-    -re "1 echo first\[\r\n\]+3 history\[\r\n\]+4 history -d 2\[\r\n\]+5 history\[\r\n\]+vush> " {}
+    -re "1 echo first\[\r\n\]+2 history\[\r\n\]+3 history -d 2\[\r\n\]+4 history\[\r\n\]+vush> " {}
     timeout { send_user "history delete failed\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- keep history numbering sequential after deleting an entry
- validate numeric arguments for `history -d`
- update test for new numbering behaviour

## Testing
- `make`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" ./tests/test_history.expect`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" ./tests/test_history_delete.expect`

------
https://chatgpt.com/codex/tasks/task_e_684df7a79b58832497e4e8da4a0e084c