### PR TITLE
Implement async job completion

### DIFF
--- a/src/jobs.h
+++ b/src/jobs.h
@@ -10,13 +10,14 @@
 
 void add_job(pid_t pid, const char *cmd);
 void remove_job(pid_t pid);
-void check_jobs(void);
+int check_jobs(void);
 void print_jobs(int mode, int count, int *ids);
 pid_t get_job_pid(int id);
 int wait_job(int id);
 int kill_job(int id, int sig);
 int bg_job(int id);
 int get_last_job_id(void);
+void jobs_sigchld_handler(int sig);
 
 /* PID of the most recently started background job */
 extern pid_t last_bg_pid;

--- a/src/main.c
+++ b/src/main.c
@@ -521,6 +521,8 @@ int main(int argc, char **argv) {
 
     /* Ignore Ctrl-C in the shell itself */
     signal(SIGINT, SIG_IGN);
+    /* Reap background jobs asynchronously */
+    signal(SIGCHLD, jobs_sigchld_handler);
 
     load_history();
     load_aliases();


### PR DESCRIPTION
## Summary
- add SIGCHLD handler to print finished job notifications
- track job states in `check_jobs` and update for stop/continue
- install SIGCHLD handler in `main`

## Testing
- `make`
- `expect test_bg.expect` *(fails: bg output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684df9d0e2b08324ab6f44afaa043323