### PR TITLE
Fix AND/OR test

### DIFF
--- a/tests/test_andor.expect
+++ b/tests/test_andor.expect
@@ -7,7 +7,7 @@ expect {
 }
 send "false && echo nope\r"
 expect {
-    -re "nope" { send_user "AND execution failed\n"; exit 1 }
+    -re "\r\nnope\r\n" { send_user "AND execution failed\n"; exit 1 }
     -re "vush> " {}
     timeout { send_user "command timeout\n"; exit 1 }
 }


### PR DESCRIPTION
## Summary
- adjust the `test_andor.expect` script so it ignores the typed command line

## Testing
- `./test_andor.expect`

------
https://chatgpt.com/codex/tasks/task_e_684dffcf3690832485b3c932ab45801a