### PR TITLE
Fix inline positional parameter expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -633,6 +633,10 @@ char *expand_var(const char *token) {
                 const char *q = p + 1;
                 if (*q == '#' || *q == '?' || *q == '*' || *q == '@' || *q == '$' || *q == '!') {
                     q++; /* special single char parameter */
+                } else if (isdigit((unsigned char)*q)) {
+                    q++;
+                    while (isdigit((unsigned char)*q))
+                        q++;
                 } else {
                     while (*q && (isalnum((unsigned char)*q) || *q == '_'))
                         q++;


### PR DESCRIPTION
## Summary
- handle digit-only parameters correctly when embedded within words
- ensure `$1` expands properly even when adjacent to literal text

## Testing
- `make`
- `expect test_param_inline.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e09f964dc8324a5e60b8e1cf475c4