### PR TITLE
Document history renumbering

### DIFF
--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -30,6 +30,7 @@ int builtin_history(char **args)
                 fprintf(stderr, "history: invalid entry\n");
                 return 1;
             }
+            /* remove the entry and renumber remaining history items */
             delete_history_entry((int)id);
             return 1;
         } else {


### PR DESCRIPTION
## Summary
- clarify that history deletion renumbers IDs

## Testing
- `./test_history_delete.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e166d172c83248177d79504cd451a