### PR TITLE
Fix double free when expanding combined stdout/stderr redirections

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -87,9 +87,30 @@ static void expand_segment(PipelineSegment *seg) {
         }
     }
 
-    if (seg->in_file) { char *n = expand_var(seg->in_file); free(seg->in_file); seg->in_file = n; }
-    if (seg->out_file) { char *n = expand_var(seg->out_file); free(seg->out_file); seg->out_file = n; }
-    if (seg->err_file) { char *n = expand_var(seg->err_file); free(seg->err_file); seg->err_file = n; }
+    if (seg->in_file) {
+        char *n = expand_var(seg->in_file);
+        free(seg->in_file);
+        seg->in_file = n;
+    }
+
+    if (seg->out_file && seg->err_file && seg->out_file == seg->err_file) {
+        char *n = expand_var(seg->out_file);
+        free(seg->out_file);
+        seg->out_file = n;
+        seg->err_file = seg->out_file;
+    } else {
+        if (seg->out_file) {
+            char *n = expand_var(seg->out_file);
+            free(seg->out_file);
+            seg->out_file = n;
+        }
+
+        if (seg->err_file) {
+            char *n = expand_var(seg->err_file);
+            free(seg->err_file);
+            seg->err_file = n;
+        }
+    }
 }
 
 static void expand_pipeline(PipelineSegment *pipeline) {


### PR DESCRIPTION
## Summary
- avoid double free when `&>` or `>&` uses the same pointer for out/err file
- add logic in `expand_segment` to only free combined file once

## Testing
- `./test_err_redir.expect`
- `./test_fd_dup.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e18446974832485bf8976e1c7d375