### PR TITLE
Fix redirection close logic

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -401,10 +401,16 @@ void setup_redirections(PipelineSegment *seg) {
         }
     }
 
-    if (seg->close_out)
+    if (seg->close_out) {
         close(seg->out_fd);
-    else if (seg->dup_out != -1)
+        if (seg->out_fd == STDERR_FILENO)
+            seg->close_err = 0;
+        if (seg->dup_err == seg->out_fd)
+            seg->dup_err = -1;
+    } else if (seg->dup_out != -1) {
         dup2(seg->dup_out, seg->out_fd);
+    }
+
     if (seg->close_err)
         close(STDERR_FILENO);
     else if (seg->dup_err != -1)


### PR DESCRIPTION
## Summary
- prevent closing STDERR twice when stdout and stderr share a file descriptor

## Testing
- `expect -f tests/test_err_redir.expect`
- `expect -f tests/test_fd_dup.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e1be779d883249e7513f28e38e2a9