### PR TITLE
Fix job notice output ordering

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -103,7 +103,7 @@ static int check_jobs_internal(int prefix) {
                     if (prefix == 1)
                         printf("\n");
                     else if (prefix == 2)
-                        printf("\r");
+                        printf("\r\n");
                 }
                 printf("[vush] job %d finished\n", curr ? curr->id : pid);
                 printed = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -357,6 +357,7 @@ static void repl_loop(FILE *input)
             char *prompt = expand_prompt(ps ? ps : "vush> ");
             history_reset_cursor();
             jobs_at_prompt = 1;
+            check_jobs();
             line = line_edit(prompt);
             jobs_at_prompt = 0;
             free(prompt);


### PR DESCRIPTION
## Summary
- flush job completion messages before drawing the next prompt
- check for completed jobs right before line editing starts

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684e1de0dcc48324885a23668242fb5e