### PR TITLE
Fix history recall after command execution

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -355,7 +355,6 @@ static void repl_loop(FILE *input)
             check_mail();
             const char *ps = getenv("PS1");
             char *prompt = expand_prompt(ps ? ps : "vush> ");
-            history_reset_cursor();
             jobs_at_prompt = 1;
             check_jobs();
             line = line_edit(prompt);


### PR DESCRIPTION
## Summary
- keep history cursor between prompts so down arrow restores next entry

## Testing
- `./test_lineedit.expect`
- `./test_forward_search.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e21e655388324a70809b97590b24f