### PR TITLE
Fix tilde expansion for simple tokens

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -567,8 +567,11 @@ char *expand_var(const char *token) {
         return strdup("");
 
     /* Fast path for simple tokens without any expansions. */
-    if (!strchr(token, '$') && !strchr(token, '`') && token[0] != '~')
+    if (!strchr(token, '$') && !strchr(token, '`')) {
+        if (token[0] == '~')
+            return expand_tilde(token);
         return strdup(token);
+    }
 
     char *out = calloc(1, 1);
     if (!out)


### PR DESCRIPTION
## Summary
- expand tokens beginning with `~` via `expand_tilde` when no `$` or backticks
- verify `cd ~tildeuser` resolves user home directory

## Testing
- `make`
- `./tests/test_tilde_user.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e26443e648324b446bded04d23ff8