### PR TITLE
Fix history numbering after loading

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -169,6 +169,15 @@ void load_history(void) {
         add_history_entry(line, 0);
     }
     fclose(f);
+
+    /*
+     * If the history file contained more entries than allowed by
+     * max_history older commands may have been dropped while loading.
+     * Renumber the remaining entries so identifiers start at 1 for
+     * the current session and next_id reflects the new list.
+     */
+    if (head)
+        renumber_history();
 }
 
 /*


### PR DESCRIPTION
## Summary
- renumber history after `load_history()` so numbering always starts at 1 for the session

## Testing
- `make -j4`
- `tests/test_history.expect` *(fails: expect not installed)*
- `tests/test_history_delete.expect` *(fails: expect not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e2647cd488324aed32f57e5339d47