### PR TITLE
Fix combined redirection pointer handling

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -22,6 +22,7 @@ void free_pipeline(PipelineSegment *p) {
             unlink(p->in_file);
         free(p->in_file);
         free(p->out_file);
+        /* err_file may share the same allocation as out_file */
         if (p->err_file && p->err_file != p->out_file)
             free(p->err_file);
         free(p);

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -380,6 +380,9 @@ static int parse_combined_redirect(PipelineSegment *seg, char **p, char *tok) {
         seg->out_file = file;
         seg->err_file = file;
     }
+    /* Ensure err_file always mirrors out_file for combined redirection */
+    if (!seg->err_file)
+        seg->err_file = seg->out_file;
     free(tok);
     return 1;
 }


### PR DESCRIPTION
## Summary
- ensure combined redirection shares out_file and err_file pointers
- clarify free_pipeline not to double free shared redirection files

## Testing
- `make`
- `expect -f tests/test_err_redir.expect`
- `expect -f tests/test_fd_dup.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e343fdda48324af1dcdb7f93da54b