### PR TITLE
Fix history renumbering

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -191,8 +191,7 @@ void load_history(void) {
      * Renumber the remaining entries so identifiers start at 1 for
      * the current session and next_id reflects the new list.
      */
-    if (head)
-        renumber_history();
+    renumber_history();
 }
 
 /*


### PR DESCRIPTION
## Summary
- always renumber after loading history
- run tests

## Testing
- `HOME=$TMPDIR expect test_history_delete.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e38d5e1508324baf8bf876163c9e6