### PR TITLE
Fix bg job completion message timing

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -255,9 +255,11 @@ int bg_job(int id) {
             curr->state = JOB_RUNNING;
             /*
              * If the process exits right away, check for completed jobs so
-             * the message is printed before the prompt.
+             * the message is printed before the prompt. Use prefix 1 so
+             * the output appears on a new line before the shell prints the
+             * next prompt.
              */
-            check_jobs();
+            check_jobs_internal(1);
             return 0;
         }
         curr = curr->next;


### PR DESCRIPTION
## Summary
- ensure job completion messages appear on a new line before the prompt when resuming jobs with `bg`

## Testing
- `make`
- `HOME=$(mktemp -d) ./tests/test_bg.expect` *(fails: bg output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684e38d2f2b0832486cbff04c499cb96