### PR TITLE
Ensure alias redefinition replaces duplicates

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -96,7 +96,6 @@ const char *get_alias(const char *name)
 /* Create or update an alias.  Returns 0 on success, -1 on allocation failure. */
 static int set_alias(const char *name, const char *value)
 {
-    remove_all_aliases(name);
     struct alias_entry *new_alias = malloc(sizeof(struct alias_entry));
     if (!new_alias) {
         perror("malloc");
@@ -213,6 +212,7 @@ int builtin_alias(char **args)
             continue;
         }
         *eq = '\0';
+        remove_all_aliases(args[i]);
         if (set_alias(args[i], eq + 1) < 0) {
             *eq = '=';
             fprintf(stderr, "alias: failed to set %s\n", args[i]);


### PR DESCRIPTION
## Summary
- update builtin_alias so redefining an alias removes previous entries
- stop `set_alias` from deleting existing aliases

## Testing
- `make`
- `./tests/test_alias_flags.expect` *(fails: "alias assignment failed")*

------
https://chatgpt.com/codex/tasks/task_e_684e38d815e483249d049ae0735fc1bc