### PR TITLE
Initialize PWD from getcwd when unset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -474,6 +474,12 @@ int main(int argc, char **argv) {
     /* Always expose the running shell as $SHELL */
     setenv("SHELL", argv[0], 1);
 
+    if (!getenv("PWD")) {
+        char cwd[PATH_MAX];
+        if (getcwd(cwd, sizeof(cwd)))
+            setenv("PWD", cwd, 1);
+    }
+
     parent_pid = getppid();
 
     if (argc > 1) {


### PR DESCRIPTION
## Summary
- ensure PWD is initialized when missing
- run pushd, dirs and cd - tests

## Testing
- `make`
- `./tests/test_pushd.expect`
- `./tests/test_dirs.expect`
- `./tests/test_cd_dash.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e40f63f448324a533596abf953b12