### PR TITLE
Handle missing env vars for cd

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -87,10 +87,14 @@ int builtin_cd(char **args) {
     if (!args[idx]) {
         target = getenv("HOME");
     } else if (strcmp(args[idx], "-") == 0) {
+        char buf[PATH_MAX];
         target = getenv("OLDPWD");
         if (!target) {
-            fprintf(stderr, "cd: OLDPWD not set\n");
-            return 1;
+            if (!getcwd(buf, sizeof(buf))) {
+                perror("getcwd");
+                return 1;
+            }
+            target = buf;
         }
         printf("%s\n", target);
     } else {

--- a/tests/test_cd_dash.expect
+++ b/tests/test_cd_dash.expect
@@ -5,6 +5,11 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
+send "unset PWD OLDPWD\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
 send "cd /tmp\r"
 expect {
     "vush> " {}


### PR DESCRIPTION
## Summary
- make `cd -` fall back to `getcwd()` when `OLDPWD` isn't set
- ensure `test_cd_dash.expect` unsets `PWD` and `OLDPWD` before testing

## Testing
- `make`
- `cd tests && ./test_cd_dash.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e43e8984c83249dfe96e5c30bacaa