### PR TITLE
Use script-relative path for expect tests

### DIFF
--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_alias_flags.expect
+++ b/tests/test_alias_flags.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_alias_persist.expect
+++ b/tests/test_alias_persist.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set dir [exec mktemp -d]
 set env(HOME) $dir
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -17,7 +17,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_andor.expect
+++ b/tests/test_andor.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_array.expect
+++ b/tests/test_array.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_assign.expect
+++ b/tests/test_assign.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_assign_redir.expect
+++ b/tests/test_assign_redir.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_badcmd.expect
+++ b/tests/test_badcmd.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_badcmd_noninteractive.expect
+++ b/tests/test_badcmd_noninteractive.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush -c {idontexist}
+spawn [file dirname [info script]]/../vush -c {idontexist}
 expect {
     -re "idontexist: command not found\r?\n" {}
     timeout { send_user "missing command not found message\n"; exit 1 }

--- a/tests/test_bang_history.expect
+++ b/tests/test_bang_history.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_bang_numeric.expect
+++ b/tests/test_bang_numeric.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_bang_words.expect
+++ b/tests/test_bang_words.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_base_arith.expect
+++ b/tests/test_base_arith.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_basic_cmd.expect
+++ b/tests/test_basic_cmd.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_bg.expect
+++ b/tests/test_bg.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_bg_default.expect
+++ b/tests/test_bg_default.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_brace_expand.expect
+++ b/tests/test_brace_expand.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_brace_group.expect
+++ b/tests/test_brace_group.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_break.expect
+++ b/tests/test_break.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_case.expect
+++ b/tests/test_case.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cd_P.expect
+++ b/tests/test_cd_P.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
 file symlink "$dir/real" "$dir/link"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cd_dash.expect
+++ b/tests/test_cd_dash.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cdpath.expect
+++ b/tests/test_cdpath.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/a"
 set env(CDPATH) $dir
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cmdsub.expect
+++ b/tests/test_cmdsub.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cmdsub_regress.expect
+++ b/tests/test_cmdsub_regress.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_colon.expect
+++ b/tests/test_colon.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command.expect
+++ b/tests/test_command.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_V.expect
+++ b/tests/test_command_V.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_p.expect
+++ b/tests/test_command_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_pV.expect
+++ b/tests/test_command_pV.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_pv.expect
+++ b/tests/test_command_pv.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_v.expect
+++ b/tests/test_command_v.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_command_v_path_long.expect
+++ b/tests/test_command_v_path_long.expect
@@ -12,7 +12,7 @@ puts $f "echo longcmd"
 close $f
 exec chmod +x "$long/foo"
 set env(PATH) "$long:/bin"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_comments.expect
+++ b/tests/test_comments.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_completion.expect
+++ b/tests/test_completion.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_completion_path.expect
+++ b/tests/test_completion_path.expect
@@ -7,7 +7,7 @@ puts $f "echo pathcomplete"
 close $f
 exec chmod +x "$dir/foo"
 set env(PATH) "$dir:$env(PATH)"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_cond.expect
+++ b/tests/test_cond.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_continue.expect
+++ b/tests/test_continue.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_custom_aliasfile.expect
+++ b/tests/test_custom_aliasfile.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set env(VUSH_ALIASFILE) "$dir/aliases"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -18,7 +18,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 set env(HOME) $dir
 set env(VUSH_ALIASFILE) "$dir/aliases"
 expect {

--- a/tests/test_custom_histfile.expect
+++ b/tests/test_custom_histfile.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set env(VUSH_HISTFILE) "$dir/histfile"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -18,7 +18,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 set env(HOME) $dir
 set env(VUSH_HISTFILE) "$dir/histfile"
 expect {

--- a/tests/test_dash_c.expect
+++ b/tests/test_dash_c.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush -c {echo hi}
+spawn [file dirname [info script]]/../vush -c {echo hi}
 expect {
     -re "hi\r?\n" {}
     timeout { send_user "-c output mismatch\n"; exit 1 }

--- a/tests/test_dash_c_quotes.expect
+++ b/tests/test_dash_c_quotes.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush -c "echo hi"
+spawn [file dirname [info script]]/../vush -c "echo hi"
 expect {
     -re "hi\r?\n" {}
     timeout { send_user "-c quoted output mismatch\n"; exit 1 }

--- a/tests/test_dirs.expect
+++ b/tests/test_dirs.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_echo_options.expect
+++ b/tests/test_echo_options.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush -c {echo -n hi}
+spawn [file dirname [info script]]/../vush -c {echo -n hi}
 expect {
     "hi" {}
     timeout { send_user "echo -n output mismatch\n"; exit 1 }
@@ -9,7 +9,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush -c {echo -e hi}
+spawn [file dirname [info script]]/../vush -c {echo -e hi}
 expect {
     -re "hi\r?\n" {}
     timeout { send_user "echo -e output mismatch\n"; exit 1 }

--- a/tests/test_env.expect
+++ b/tests/test_env.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_envfile.expect
+++ b/tests/test_envfile.expect
@@ -6,7 +6,7 @@ puts $f "echo envstart"
 close $f
 set env(HOME) $dir
 set env(ENV) "$dir/envfile"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     -re "\[\r\n\]+envstart\[\r\n\]+vush> " {}
     timeout { send_user "ENV file not executed\n"; exec rm -rf $dir; exit 1 }

--- a/tests/test_err_redir.expect
+++ b/tests/test_err_redir.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_eval.expect
+++ b/tests/test_eval.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_exec_builtin.expect
+++ b/tests/test_exec_builtin.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_exit_trap.expect
+++ b/tests/test_exit_trap.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export.expect
+++ b/tests/test_export.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export_n.expect
+++ b/tests/test_export_n.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export_n_unexport.expect
+++ b/tests/test_export_n_unexport.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export_p.expect
+++ b/tests/test_export_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export_p_listing.expect
+++ b/tests/test_export_p_listing.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_export_ps1.expect
+++ b/tests/test_export_ps1.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_false_builtin.expect
+++ b/tests/test_false_builtin.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_fc.expect
+++ b/tests/test_fc.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_fd_dup.expect
+++ b/tests/test_fd_dup.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_fg.expect
+++ b/tests/test_fg.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_fg_default.expect
+++ b/tests/test_fg_default.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_for.expect
+++ b/tests/test_for.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_for_arith.expect
+++ b/tests/test_for_arith.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_forward_search.expect
+++ b/tests/test_forward_search.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_func_scope.expect
+++ b/tests/test_func_scope.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_function.expect
+++ b/tests/test_function.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_function_keyword.expect
+++ b/tests/test_function_keyword.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_getopts.expect
+++ b/tests/test_getopts.expect
@@ -4,7 +4,7 @@ set script [exec mktemp]
 set f [open $script "w"]
 puts $f "while getopts \"ab:\" o; do echo \"$o:$OPTARG\"; done; echo index:$OPTIND"
 close $f
-spawn ../vush $script -a -b foo rest
+spawn [file dirname [info script]]/../vush $script -a -b foo rest
 expect {
     -re "a:\[\r\n\]+b:foo\[\r\n\]+index:4\[\r\n\]+" {}
     timeout { send_user "getopts parsing failed\n"; exec rm $script; exit 1 }
@@ -13,7 +13,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush $script -z
+spawn [file dirname [info script]]/../vush $script -z
 expect {
     -re "getopts: illegal option -- z\[\r\n\]+\?:\[\r\n\]+index:2\[\r\n\]+" {}
     timeout { send_user "invalid option not handled\n"; exec rm $script; exit 1 }
@@ -22,7 +22,7 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-spawn ../vush $script -b
+spawn [file dirname [info script]]/../vush $script -b
 expect {
     -re "getopts: option requires an argument -- b\[\r\n\]+\?:\[\r\n\]+index:2\[\r\n\]+" {}
     timeout { send_user "missing argument not detected\n"; exec rm $script; exit 1 }

--- a/tests/test_glob.expect
+++ b/tests/test_glob.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_hash.expect
+++ b/tests/test_hash.expect
@@ -7,7 +7,7 @@ puts $f "echo hashed1"
 close $f
 exec chmod +x "$dir/foo"
 set env(PATH) "$dir:$env(PATH)"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_heredoc.expect
+++ b/tests/test_heredoc.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_heredoc_dash.expect
+++ b/tests/test_heredoc_dash.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_heredoc_tabs.expect
+++ b/tests/test_heredoc_tabs.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_heredoc_unterminated.expect
+++ b/tests/test_heredoc_unterminated.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_herestring.expect
+++ b/tests/test_herestring.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_history.expect
+++ b/tests/test_history.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_history_clear.expect
+++ b/tests/test_history_clear.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_history_delete.expect
+++ b/tests/test_history_delete.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_history_limit.expect
+++ b/tests/test_history_limit.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set env(VUSH_HISTSIZE) 3
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_if.expect
+++ b/tests/test_if.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_jobs.expect
+++ b/tests/test_jobs.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_jobs_l.expect
+++ b/tests/test_jobs_l.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_jobs_p.expect
+++ b/tests/test_jobs_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_kill.expect
+++ b/tests/test_kill.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_kill_l.expect
+++ b/tests/test_kill_l.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_kill_l_num.expect
+++ b/tests/test_kill_l_num.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_kill_s.expect
+++ b/tests/test_kill_s.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_line_cont.expect
+++ b/tests/test_line_cont.expect
@@ -5,7 +5,7 @@ set f [open $script "w"]
 puts $f {echo one \}
 puts $f {two}
 close $f
-spawn ../vush $script
+spawn [file dirname [info script]]/../vush $script
 expect {
     -re "one two\r?\n" {}
     timeout { send_user "line continuation failed\n"; exec rm $script; exit 1 }

--- a/tests/test_lineedit.expect
+++ b/tests/test_lineedit.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_local.expect
+++ b/tests/test_local.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_local_shadow.expect
+++ b/tests/test_local_shadow.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_ls_l.expect
+++ b/tests/test_ls_l.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_negate.expect
+++ b/tests/test_negate.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_noclobber.expect
+++ b/tests/test_noclobber.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_param_error.expect
+++ b/tests/test_param_error.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_param_expand.expect
+++ b/tests/test_param_expand.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_param_inline.expect
+++ b/tests/test_param_inline.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_param_replace.expect
+++ b/tests/test_param_replace.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_param_substring.expect
+++ b/tests/test_param_substring.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_path_long.expect
+++ b/tests/test_path_long.expect
@@ -12,7 +12,7 @@ puts $f "echo longpath"
 close $f
 exec chmod +x "$long/foo"
 set env(PATH) "$long:/bin"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pid_params.expect
+++ b/tests/test_pid_params.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pipe.expect
+++ b/tests/test_pipe.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pipefail.expect
+++ b/tests/test_pipefail.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_printf.expect
+++ b/tests/test_printf.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_printf_escapes.expect
+++ b/tests/test_printf_escapes.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_process_sub.expect
+++ b/tests/test_process_sub.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_ps1.expect
+++ b/tests/test_ps1.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_ps1_cmdsub.expect
+++ b/tests/test_ps1_cmdsub.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set start $env(PWD)
 set parent [file dirname $start]
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pushd.expect
+++ b/tests/test_pushd.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pwd.expect
+++ b/tests/test_pwd.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_pwd_options.expect
+++ b/tests/test_pwd_options.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
 file symlink "$dir/real" "$dir/link"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_read.expect
+++ b/tests/test_read.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_read_eof.expect
+++ b/tests/test_read_eof.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_readonly.expect
+++ b/tests/test_readonly.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_readonly_p.expect
+++ b/tests/test_readonly_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_redir.expect
+++ b/tests/test_redir.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_reverse_search.expect
+++ b/tests/test_reverse_search.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_script.expect
+++ b/tests/test_script.expect
@@ -4,7 +4,7 @@ set script [exec mktemp]
 set f [open $script "w"]
 puts $f "echo from_script"
 close $f
-spawn ../vush $script
+spawn [file dirname [info script]]/../vush $script
 expect {
     -re "from_script\r?\n" {}
     timeout { send_user "script output mismatch\n"; exec rm $script; exit 1 }

--- a/tests/test_script_args.expect
+++ b/tests/test_script_args.expect
@@ -6,7 +6,7 @@ puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 puts $f "shift"
 puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 close $f
-spawn ../vush $script foo bar
+spawn [file dirname [info script]]/../vush $script foo bar
 expect {
     -re "$script,foo,bar,2,foo bar\r?\n" {}
     timeout { send_user "arg expansion failed\n"; exec rm $script; exit 1 }

--- a/tests/test_select.expect
+++ b/tests/test_select.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_sequence.expect
+++ b/tests/test_sequence.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_set_list.expect
+++ b/tests/test_set_list.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_set_options.expect
+++ b/tests/test_set_options.expect
@@ -1,7 +1,7 @@
 #!/usr/bin/env expect
 set timeout 5
 # nounset option
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -33,7 +33,7 @@ expect {
 }
 
 # errexit option
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -50,7 +50,7 @@ expect {
 }
 
 # xtrace option
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_set_positional.expect
+++ b/tests/test_set_positional.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_source.expect
+++ b/tests/test_source.expect
@@ -4,7 +4,7 @@ set script [exec mktemp]
 set f [open $script "w"]
 puts $f "echo sourced"
 close $f
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_source_args.expect
+++ b/tests/test_source_args.expect
@@ -6,7 +6,7 @@ puts $f "echo \"$0,$1,$2,$#,$@\""
 puts $f "shift"
 puts $f "echo \"$0,$1,$2,$#,$@\""
 close $f
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_status.expect
+++ b/tests/test_status.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_subshell.expect
+++ b/tests/test_subshell.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_test.expect
+++ b/tests/test_test.expect
@@ -3,7 +3,7 @@ set timeout 5
 set dir [exec mktemp -d]
 set file "$dir/file"
 exec touch $file
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_test_bool.expect
+++ b/tests/test_test_bool.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -4,7 +4,7 @@ set user "tildeuser"
 set home "/tmp/vush_$user"
 exec mkdir -p $home
 exec sh -c "echo \"$user:x:12345:12345::$home:/bin/false\" >> /etc/passwd"
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_time.expect
+++ b/tests/test_time.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_time_p.expect
+++ b/tests/test_time_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_times.expect
+++ b/tests/test_times.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_trap.expect
+++ b/tests/test_trap.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_trap_l.expect
+++ b/tests/test_trap_l.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_trap_no_args.expect
+++ b/tests/test_trap_no_args.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_trap_p.expect
+++ b/tests/test_trap_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_true_builtin.expect
+++ b/tests/test_true_builtin.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_type.expect
+++ b/tests/test_type.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_ulimit.expect
+++ b/tests/test_ulimit.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_umask.expect
+++ b/tests/test_umask.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_umask_symbolic.expect
+++ b/tests/test_umask_symbolic.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_unalias_a.expect
+++ b/tests/test_unalias_a.expect
@@ -2,7 +2,7 @@
 set dir [exec mktemp -d]
 set env(HOME) $dir
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_unmatched.expect
+++ b/tests/test_unmatched.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_unset.expect
+++ b/tests/test_unset.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_unset_function.expect
+++ b/tests/test_unset_function.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_until.expect
+++ b/tests/test_until.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_var_brace.expect
+++ b/tests/test_var_brace.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_version.expect
+++ b/tests/test_version.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush --version
+spawn [file dirname [info script]]/../vush --version
 expect {
     -re "vush 0\.1\.0\r?\n" {}
     timeout { send_user "version output mismatch\n"; exit 1 }

--- a/tests/test_vushrc.expect
+++ b/tests/test_vushrc.expect
@@ -5,7 +5,7 @@ set f [open "$dir/.vushrc" "w"]
 puts $f "echo rcstart"
 close $f
 set env(HOME) $dir
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     -re "\[\r\n\]+rcstart\[\r\n\]+vush> " {}
     timeout { send_user "rc file not executed\n"; exec rm -rf $dir; exit 1 }

--- a/tests/test_wait.expect
+++ b/tests/test_wait.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }

--- a/tests/test_while.expect
+++ b/tests/test_while.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn ../vush
+spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }


### PR DESCRIPTION
## Summary
- ensure every test uses the `vush` binary relative to the test file

## Testing
- `./tests/test_pushd.expect`
- `./tests/test_cd_dash.expect`
- `./tests/test_dirs.expect`
- `(cd tests && ./test_pushd.expect)`
- `(cd tests && ./test_cd_dash.expect)`
- `(cd tests && ./test_dirs.expect)`

------
https://chatgpt.com/codex/tasks/task_e_684e463dbec08324a6e3f5ebf9c29d61