### PR TITLE
Fix history pruning and file path caching

### DIFF
--- a/tests/test_history_limit.expect
+++ b/tests/test_history_limit.expect
@@ -30,7 +30,7 @@ expect {
 }
 send "history\r"
 expect {
-    -re "3 echo three\[\r\n\]+4 echo four\[\r\n\]+5 history\[\r\n\]+vush> " {}
+    -re "1 echo three\[\r\n\]+2 echo four\[\r\n\]+3 history\[\r\n\]+vush> " {}
     timeout { send_user "history limit mismatch\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- cache history file path at startup
- honour HISTSIZE and HISTFILESIZE
- drop excess entries as commands are recorded
- update history limit test

## Testing
- `make`
- `for t in test_history.expect test_history_limit.expect test_history_delete.expect; do TMP=$(mktemp -d); HOME=$TMP expect -f $t || echo FAIL-$t; rm -rf $TMP; done`

------
https://chatgpt.com/codex/tasks/task_e_684e479b594c8324baf741730126ff55