### PR TITLE
Clear history before history test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -169,6 +169,9 @@ tests="
 "
 for test in $tests; do
     echo "Running $test"
+    if [ "$test" = "test_history.expect" ]; then
+        rm -f "$HOME/.vush_history"
+    fi
     if ! ./$test; then
         echo "FAILED: $test"
         failed=1


### PR DESCRIPTION
## Summary
- make sure `$HOME/.vush_history` is removed before `test_history.expect`

## Testing
- `HOME=/tmp/testsuite ./tests/test_basic_cmd.expect`
- `HOME=/tmp/testsuite ./tests/test_history.expect` *(fails without clearing history)*
- `rm /tmp/testsuite/.vush_history && HOME=/tmp/testsuite ./tests/test_history.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e4d9844c08324b34cc1307b1b5f1d