### PR TITLE
Fix arithmetic test quoting

### DIFF
--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -5,7 +5,7 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$((1+2))\r"
+send {echo $((1+2))\r}
 expect {
     -re "\[\r\n\]+3\[\r\n\]+vush> " {}
     timeout { send_user "basic arithmetic failed\n"; exit 1 }
@@ -15,12 +15,12 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$((X*2))\r"
+send {echo $((X*2))\r}
 expect {
     -re "\[\r\n\]+8\[\r\n\]+vush> " {}
     timeout { send_user "variable expansion failed\n"; exit 1 }
 }
-send "X=\$((X+3))\r"
+send {X=$((X+3))\r}
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }


### PR DESCRIPTION
## Summary
- quote arithmetic expansions in `tests/test_arith.expect` with braces

## Testing
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e575d4e9c8324b77ca2993d1899bb