### PR TITLE
Fix tests script to run non-executable expect files

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -172,7 +172,12 @@ for test in $tests; do
     if [ "$test" = "test_history.expect" ]; then
         rm -f "$HOME/.vush_history"
     fi
-    if ! ./$test; then
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
         echo "FAILED: $test"
         failed=1
     else


### PR DESCRIPTION
## Summary
- allow running `.expect` tests that aren't executable by invoking `expect -f`

## Testing
- `make test` *(interrupted after a few tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e575b31f88324bc1b118012fc60ec