### PR TITLE
Replace deprecated symlink command in expect tests

### DIFF
--- a/tests/test_cd_P.expect
+++ b/tests/test_cd_P.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
-file symlink "$dir/real" "$dir/link"
+file link -symbolic "$dir/link" "$dir/real"
 spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}

--- a/tests/test_pwd_options.expect
+++ b/tests/test_pwd_options.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set dir [exec mktemp -d]
 file mkdir "$dir/real"
-file symlink "$dir/real" "$dir/link"
+file link -symbolic "$dir/link" "$dir/real"
 spawn [file dirname [info script]]/../vush
 expect {
     "vush> " {}


### PR DESCRIPTION
## Summary
- update symlink creation in `test_cd_P.expect`
- update symlink creation in `test_pwd_options.expect`

## Testing
- `expect ./tests/test_cd_P.expect`
- `expect ./tests/test_pwd_options.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e575e0b1c8324a6967f31961a9141