### PR TITLE
Fix line cont expect backslash

### DIFF
--- a/tests/test_line_cont.expect
+++ b/tests/test_line_cont.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set script [exec mktemp]
 set f [open $script "w"]
-puts $f {echo one \}
+puts $f {echo one \\}
 puts $f {two}
 close $f
 spawn [file dirname [info script]]/../vush $script


### PR DESCRIPTION
## Summary
- ensure `test_line_cont.expect` uses escaped trailing backslash

## Testing
- `make test` *(fails: `FAILED: test_base_arith.expect` and others)*

------
https://chatgpt.com/codex/tasks/task_e_684e575da3448324a415954c20c5cdd4