### PR TITLE
Fix job completion prompt ordering

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -103,7 +103,7 @@ static int check_jobs_internal(int prefix) {
                     if (prefix == 1)
                         printf("\n");
                     else if (prefix == 2)
-                        printf("\r\n");
+                        printf("\r");
                 }
                 printf("[vush] job %d finished\n", curr ? curr->id : pid);
                 printed = 1;
@@ -128,7 +128,7 @@ int check_jobs(void) {
  * waiting for input. Simply delegate to check_jobs(). */
 void jobs_sigchld_handler(int sig) {
     (void)sig;
-    int prefix = jobs_at_prompt ? 2 : 1;
+    int prefix = jobs_at_prompt ? 2 : 0;
     if (check_jobs_internal(prefix) && jobs_at_prompt) {
         const char *ps = getenv("PS1");
         printf("%s", ps ? ps : "vush> ");

--- a/src/main.c
+++ b/src/main.c
@@ -357,7 +357,10 @@ static void repl_loop(FILE *input)
             char *prompt = expand_prompt(ps ? ps : "vush> ");
             jobs_at_prompt = 1;
             check_jobs();
-            line = line_edit(prompt);
+            if (jobs_at_prompt)
+                line = line_edit(prompt);
+            else
+                line = line_edit("");
             jobs_at_prompt = 0;
             free(prompt);
             if (!line)


### PR DESCRIPTION
## Summary
- adjust prompt logic so SIGCHLD output doesn't cause a duplicate prompt
- avoid extra newline when printing job notifications

## Testing
- `expect -f tests/test_bg.expect` *(fails: bg output mismatch)*
- `expect -f tests/test_kill.expect` *(fails: kill output mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_684e53f614cc8324a8fadfcd92a673b3