### PR TITLE
Fix quoting in expect regex

### DIFF
--- a/tests/test_bg_default.expect
+++ b/tests/test_bg_default.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "bg\r"
 expect {
-    -re "\\[vush\\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
+    -re {\[vush\] job [0-9]+ finished[\r\n]+vush> } {}
     timeout { send_user "bg output mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- use curly braces for regex pattern in test_bg_default.expect

## Testing
- `./test_bg_default.expect`

------
https://chatgpt.com/codex/tasks/task_e_684e575f8afc8324a27bd2bd24081020