### PR TITLE
Fix newline before rc and ENV scripts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -192,6 +192,8 @@ static void process_startup_file(FILE *input)
         return;
     char rcpath[PATH_MAX];
     snprintf(rcpath, sizeof(rcpath), "%s/.vushrc", home);
+    if (access(rcpath, R_OK) == 0)
+        putchar('\n');
     process_rc_file(rcpath, input);
 }
 
@@ -545,8 +547,11 @@ int main(int argc, char **argv) {
         process_startup_file(input);
 
     const char *envfile = getenv("ENV");
-    if (envfile && *envfile)
+    if (envfile && *envfile) {
+        if (access(envfile, R_OK) == 0)
+            putchar('\n');
         process_rc_file(envfile, input);
+    }
 
     if (dash_c)
         run_command_string(dash_c);


### PR DESCRIPTION
## Summary
- print a newline before executing `~/.vushrc`
- print a newline before executing the file specified by `$ENV`

## Testing
- `expect -f tests/test_vushrc.expect`
- `expect -f tests/test_envfile.expect`


------
https://chatgpt.com/codex/tasks/task_e_684e628763548324b4287f5278e8deef