### PR TITLE
Add alias update regression test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -49,6 +49,7 @@ tests="
     test_glob.expect
     test_alias.expect
     test_alias_flags.expect
+    test_alias_update.expect
     test_alias_persist.expect
     test_unalias_a.expect
     test_status.expect

--- a/tests/test_alias_update.expect
+++ b/tests/test_alias_update.expect
@@ -1,0 +1,35 @@
+#!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias hi='echo first'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias hi='echo second'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias hi\r"
+expect {
+    -re "\[\r\n\]+hi='echo second'\[\r\n\]+vush> " {}
+    timeout { send_user "alias updated value not printed\n"; exit 1 }
+}
+send "alias -p\r"
+expect {
+    -re "alias hi='echo second'" {}
+    timeout { send_user "alias -p updated value missing\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- add regression test for updating alias
- include new test in automated suite

## Testing
- `./tests/test_alias_update.expect`
- `make test` *(fails: `expect: spawn id exp4 not open` in `test_line_cont.expect`)*

------
https://chatgpt.com/codex/tasks/task_e_684e61e382388324bf132abc6a6ff7fe