### PR TITLE
Fix job completion message order

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -121,7 +121,8 @@ static int check_jobs_internal(int prefix) {
 }
 
 int check_jobs(void) {
-    return check_jobs_internal(0);
+    int prefix = jobs_at_prompt ? 2 : 1;
+    return check_jobs_internal(prefix);
 }
 
 /* SIGCHLD handler to reap finished background jobs even when


### PR DESCRIPTION
## Summary
- print job completion notices before the prompt

## Testing
- `expect -f tests/test_kill.expect` *(fails: kill output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684e61dd386083249263b49080883fab