### PR TITLE
Fix nounset status handling in builtins

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -29,6 +29,7 @@
 #include "lexer.h"
 
 extern int last_status;
+extern int param_error;
 
 int loop_break = 0;
 int loop_continue = 0;
@@ -461,6 +462,7 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
     if (!pipeline)
         return 0;
 
+    param_error = 0;
     if (opt_xtrace && line) {
         const char *ps4 = getenv("PS4");
         if (!ps4) ps4 = "+ ";
@@ -468,6 +470,8 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
     }
 
     if (apply_temp_assignments(pipeline, background, line)) {
+        if (param_error)
+            last_status = 1;
         cleanup_proc_subs();
         return last_status;
     }
@@ -481,6 +485,8 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
         return last_status;
     }
     int r = spawn_pipeline_segments(pipeline, background, line);
+    if (param_error)
+        last_status = 1;
     cleanup_proc_subs();
     return r;
 }

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -17,6 +17,7 @@
 #include "parser.h" /* for MAX_LINE */
 
 extern int last_status;
+extern int param_error;
 
 /* Execute CMD via popen and return its stdout output as a newly
  * allocated string with any trailing newline removed. */
@@ -206,6 +207,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
             if (opt_nounset) {
                 fprintf(stderr, "%s: unbound variable\n", name);
                 last_status = 1;
+                param_error = 1;
             }
             val = "";
         }
@@ -221,6 +223,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
             else
                 fprintf(stderr, "%s: parameter null or not set\n", name);
             last_status = 1;
+            param_error = 1;
             free(wexp);
             return strdup("");
         }
@@ -231,6 +234,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
             if (opt_nounset) {
                 fprintf(stderr, "%s: unbound variable\n", name);
                 last_status = 1;
+                param_error = 1;
             }
             val = "";
         }
@@ -331,6 +335,7 @@ static char *expand_length(const char *name) {
         if (opt_nounset) {
             fprintf(stderr, "%s: unbound variable\n", name);
             last_status = 1;
+            param_error = 1;
         }
         val = "";
     }
@@ -485,6 +490,7 @@ static char *expand_special(const char *token) {
                 if (opt_nounset) {
                     fprintf(stderr, "%ld: unbound variable\n", idx);
                     last_status = 1;
+                    param_error = 1;
                 }
                 val = "";
             }
@@ -502,6 +508,7 @@ static char *expand_plain_var(const char *name) {
         if (opt_nounset) {
             fprintf(stderr, "%s: unbound variable\n", name);
             last_status = 1;
+            param_error = 1;
         }
         val = "";
     }

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ extern char *exit_trap_cmd;
 void trap_handler(int sig);
 void run_exit_trap(void);
 int last_status = 0;
+int param_error = 0;
 int script_argc = 0;
 char **script_argv = NULL;
 int opt_errexit = 0;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -77,6 +77,7 @@ tests="
     test_dash_c_quotes.expect
     test_echo_options.expect
     test_set_options.expect
+    test_nounset.expect
     test_heredoc.expect
     test_herestring.expect
     test_heredoc_unterminated.expect

--- a/tests/test_nounset.expect
+++ b/tests/test_nounset.expect
@@ -1,0 +1,31 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "set -u\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "printf %s \$BAR\r"
+expect {
+    -re "BAR: unbound variable" {}
+    timeout { send_user "nounset printf message missing\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "nounset printf status mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- keep `$?` at 1 when parameter expansion fails
- track parameter expansion errors in `param_error`
- reset status after builtins run
- test regression for nounset behavior

## Testing
- `./test_nounset.expect`
- `expect -f tests/test_set_options.expect` *(fails: eof timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684e61f430c08324b55878cdf521ad23