### PR TITLE
Ensure job completion messages appear promptly

### DIFF
--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -218,13 +218,14 @@ int builtin_kill(char **args) {
     }
     /*
      * Repeatedly poll for completed jobs so the "job finished" notice is
-     * printed before returning.  This mirrors the behaviour of other
-     * job-control builtins and ensures the next prompt follows the message
-     * directly. Wait up to ~1s for the targeted job to exit.
+     * printed before returning.  Call check_jobs_internal(1) so the
+     * notification appears on a new line immediately, matching the
+     * behaviour of other job-control builtins. Wait up to ~1s for the
+     * targeted job to exit.
      */
     struct timespec ts = {0, 10000000}; /* 10 ms */
     for (int i = 0; i < 100; i++) {
-        int printed = check_jobs();
+        int printed = check_jobs_internal(1);
         int remaining = 0;
         for (int j = 0; j < wait_count; j++) {
             if (get_job_pid(wait_ids[j]) > 0) {

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -88,7 +88,7 @@ void remove_job(pid_t pid) {
  * prompt so that completed jobs are noticed.
  */
 /* prefix: 0=no prefix, 1=prepend newline, 2=carriage return */
-static int check_jobs_internal(int prefix) {
+int check_jobs_internal(int prefix) {
     int printed = 0;
     int status;
     pid_t pid;

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -12,6 +12,7 @@
 void add_job(pid_t pid, const char *cmd);
 void remove_job(pid_t pid);
 int check_jobs(void);
+int check_jobs_internal(int prefix);
 void print_jobs(int mode, int count, int *ids);
 pid_t get_job_pid(int id);
 int wait_job(int id);


### PR DESCRIPTION
## Summary
- expose `check_jobs_internal` and use it within `kill`
- keep background notification timing consistent

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e64c479f88324b4407dfb3ea73afd