### PR TITLE
Fix quoting in getopts expect script

### DIFF
--- a/tests/test_getopts.expect
+++ b/tests/test_getopts.expect
@@ -2,7 +2,7 @@
 set timeout 5
 set script [exec mktemp]
 set f [open $script "w"]
-puts $f "while getopts \"ab:\" o; do echo \"$o:$OPTARG\"; done; echo index:$OPTIND"
+puts $f {while getopts "ab:" o; do echo "$o:$OPTARG"; done; echo index:$OPTIND}
 close $f
 spawn [file dirname [info script]]/../vush $script -a -b foo rest
 expect {


### PR DESCRIPTION
## Summary
- escape `$o` and `$OPTARG` when writing the script in `test_getopts.expect`

## Testing
- `expect tests/test_getopts.expect` *(fails: `spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_684f17c8e0108324a29c6a174ce37bd2