### PR TITLE
Fix unmatched quote handling

### DIFF
--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -224,7 +224,8 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
                 (*p)++;
             }
             if (!closed && !**p) {
-                parse_need_more = 1;
+                fprintf(stderr, "syntax error: unmatched ')'\n");
+                parse_need_more = 0;
                 return -1;
             }
             if (startc == '`') {
@@ -232,7 +233,8 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
                     if (*len < MAX_LINE - 1) buf[(*len)++] = *(*p)++;
                     closed = 1;
                 } else if (!closed) {
-                    parse_need_more = 1;
+                    fprintf(stderr, "syntax error: unmatched '`'\n");
+                    parse_need_more = 0;
                     return -1;
                 }
             }
@@ -294,7 +296,8 @@ static char *parse_quoted_word(char **p, int *quoted, int *do_expand_out) {
         if (**p == quote) {
             (*p)++;
         } else if (**p == '\0') {
-            parse_need_more = 1;
+            fprintf(stderr, "syntax error: unmatched '%c'\n", quote);
+            parse_need_more = 0;
             return NULL;
         } else {
             fprintf(stderr, "syntax error: unmatched '%c'\n", quote);
@@ -308,7 +311,8 @@ static char *parse_quoted_word(char **p, int *quoted, int *do_expand_out) {
         if (**p == quote) {
             (*p)++;
         } else if (**p == '\0') {
-            parse_need_more = 1;
+            fprintf(stderr, "syntax error: unmatched '\"'\n");
+            parse_need_more = 0;
             return NULL;
         } else {
             fprintf(stderr, "syntax error: unmatched '\"'\n");

--- a/tests/test_unmatched.expect
+++ b/tests/test_unmatched.expect
@@ -25,7 +25,7 @@ expect {
 }
 send "echo \$(echo hi\r"
 expect {
-    -re "syntax error: unmatched '\)'" {}
+    -re {syntax error: unmatched '\)} {}
     timeout { send_user "missing command substitution error\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- report syntax error when line ends with open quote
- reset `parse_need_more` so prompt returns on new line
- handle unmatched command substitutions
- fix `test_unmatched.expect` regex for command substitutions

## Testing
- `make -j$(nproc)`
- `expect tests/test_unmatched.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f175800948324adc0abb36da30a69