### PR TITLE
Fix PID params test stability

### DIFF
--- a/tests/test_pid_params.expect
+++ b/tests/test_pid_params.expect
@@ -13,7 +13,7 @@ expect {
     timeout { send_user "\$\$ expansion failed\n"; exit 1 }
 }
 # Test $! expansion
-send "sleep 1 &\r"
+send "sleep 3 &\r"
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -25,7 +25,7 @@ expect {
 }
 send "jobs\r"
 expect {
-    -re "\[1\] $bg sleep 1 &\[\r\n\]+vush> " {}
+    -re "\[1\] $bg sleep 3 &[\r\n\]+vush> " {}
     timeout { send_user "jobs pid mismatch\n"; exit 1 }
 }
 send "set -e -u\r"


### PR DESCRIPTION
## Summary
- keep background job alive longer in `test_pid_params.expect`

## Testing
- `expect -f tests/test_pid_params.expect` *(fails: `$- expansion failed`)*

------
https://chatgpt.com/codex/tasks/task_e_684f39bdd1948324bee5240bcea3c2e0