### PR TITLE
Adjust startup tests for new newline behavior

### DIFF
--- a/tests/test_envfile.expect
+++ b/tests/test_envfile.expect
@@ -8,7 +8,7 @@ set env(HOME) $dir
 set env(ENV) "$dir/envfile"
 spawn [file dirname [info script]]/../vush
 expect {
-    -re "\[\r\n\]+envstart\[\r\n\]+vush> " {}
+    -re {[\r\n]*envstart[\r\n]+vush> } {}
     timeout { send_user "ENV file not executed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"

--- a/tests/test_vushrc.expect
+++ b/tests/test_vushrc.expect
@@ -7,7 +7,7 @@ close $f
 set env(HOME) $dir
 spawn [file dirname [info script]]/../vush
 expect {
-    -re "\[\r\n\]+rcstart\[\r\n\]+vush> " {}
+    -re {[\r\n]*rcstart[\r\n]+vush> } {}
     timeout { send_user "rc file not executed\n"; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- accommodate missing newline before startup messages in tests

## Testing
- `./test_vushrc.expect`
- `./test_envfile.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f3b5ce9c88324938093b8ba36d49e