### PR TITLE
Fix history logging of exit command

### DIFF
--- a/src/builtins_core.c
+++ b/src/builtins_core.c
@@ -6,6 +6,7 @@
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "vars.h"
+#include "history.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -27,6 +28,7 @@ int builtin_exit(char **args) {
         }
         status = (int)val;
     }
+    delete_last_history_entry();
     run_exit_trap();
     free_aliases();
     free_functions();

--- a/src/history.c
+++ b/src/history.c
@@ -379,6 +379,15 @@ void delete_history_entry(int id) {
 }
 
 /*
+ * Delete the most recent history entry from memory and update the history
+ * file.  Has no effect when history is empty.
+ */
+void delete_last_history_entry(void) {
+    if (tail)
+        delete_history_entry(tail->id);
+}
+
+/*
  * Return the most recently added command or NULL if history is empty.
  */
 const char *history_last(void) {

--- a/src/history.h
+++ b/src/history.h
@@ -63,6 +63,9 @@ const char *history_get_by_id(int id);
 /* Return the OFFSET-th previous command where 1 is the last entry. */
 const char *history_get_relative(int offset);
 
+/* Remove the most recent command from history. */
+void delete_last_history_entry(void);
+
 /* Obtain the last argument of the most recent command. Caller must free. */
 char *history_last_word(void);
 


### PR DESCRIPTION
## Summary
- add `delete_last_history_entry` helper to manipulate history
- use the new helper in `builtin_exit` so `exit` isn't stored

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f3c797dc08324bffbfd3de0b41ee8