### PR TITLE
Fix prompt expansion to retain trailing spaces

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -908,9 +908,10 @@ char *expand_prompt(const char *prompt) {
     if (!res)
         return strdup("");
 
-    /* When the token includes $(...) or backticks, perform command
-     * substitution using the normal variable expansion logic. */
-    if (do_expand && (strstr(res, "$(") || strchr(res, '`'))) {
+    /* When expansion is requested run the normal variable expansion logic.
+     * This interprets variables and command substitutions while leaving any
+     * trailing whitespace intact. */
+    if (do_expand) {
         char *out = expand_var(res);
         if (!out) {
             free(res);


### PR DESCRIPTION
## Summary
- expand prompts using `expand_var` when expansion is enabled

## Testing
- `make`
- `expect -f tests/test_ps1.expect`
- `expect -f tests/test_ps1_cmdsub.expect`


------
https://chatgpt.com/codex/tasks/task_e_684f3cb0bbb48324afed4603f9d935a5