### PR TITLE
Print job command on completion

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -105,7 +105,9 @@ int check_jobs_internal(int prefix) {
                     else if (prefix == 2)
                         printf("\r");
                 }
-                printf("[vush] job %d finished\n", curr ? curr->id : pid);
+                printf("[vush] job %d (%s) finished\n",
+                       curr ? curr->id : pid,
+                       curr ? curr->cmd : "?");
                 printed = 1;
             }
             remove_job(pid);

--- a/tests/test_bg.expect
+++ b/tests/test_bg.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "bg 1\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 2 \&\) finished\[\r\n\]+vush> " {}
     timeout { send_user "bg output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_bg_default.expect
+++ b/tests/test_bg_default.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "bg\r"
 expect {
-    -re {\[vush\] job [0-9]+ finished[\r\n]+vush> } {}
+    -re {\[vush\] job [0-9]+ \(sleep 2 \&\) finished[\r\n]+vush> } {}
     timeout { send_user "bg output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_kill.expect
+++ b/tests/test_kill.expect
@@ -12,7 +12,7 @@ expect {
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ finished\[\r\n\]+vush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "jobs\r"

--- a/tests/test_kill_s.expect
+++ b/tests/test_kill_s.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "kill -s TERM $pid\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ finished\r\nvush> " {}
+    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\r\nvush> " {}
     timeout { send_user "kill -s output mismatch\n"; exit 1 }
 }
 send "jobs\r"


### PR DESCRIPTION
## Summary
- show the command when notifying that a job has finished
- update job control tests for the new message format

## Testing
- `make test` *(fails: `expect` scripts report EOF issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f3eeaec04832485faa22aa1f66581