### PR TITLE
Handle continue levels correctly in loops

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -645,12 +645,22 @@ static int exec_while(Command *cmd, const char *line) {
     while (1) {
         run_command_list(cmd->cond, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
         if (last_status != 0)
             break;
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
     }
     loop_depth--;
     return last_status;
@@ -666,12 +676,22 @@ static int exec_until(Command *cmd, const char *line) {
     while (1) {
         run_command_list(cmd->cond, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
         if (last_status == 0)
             break;
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
     }
     loop_depth--;
     return last_status;
@@ -691,7 +711,12 @@ static int exec_for(Command *cmd, const char *line) {
         }
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
     }
     loop_depth--;
     return last_status;
@@ -721,7 +746,12 @@ static int exec_select(Command *cmd, const char *line) {
             setenv(cmd->var, cmd->words[choice - 1], 1);
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
     }
     loop_depth--;
     return last_status;
@@ -743,7 +773,12 @@ static int exec_for_arith(Command *cmd, const char *line) {
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
         eval_arith(cmd->arith_update ? cmd->arith_update : "0");
-        if (loop_continue) { loop_continue--; continue; }
+        if (loop_continue) {
+            loop_continue--;
+            if (loop_continue)
+                break;
+            continue;
+        }
     }
     loop_depth--;
     return last_status;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -102,6 +102,7 @@ tests="
     test_brace_group.expect
     test_break.expect
     test_continue.expect
+    test_continue_n.expect
     test_test.expect
     test_cond.expect
     test_ls_l.expect

--- a/tests/test_continue_n.expect
+++ b/tests/test_continue_n.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "for i in a b; do echo \$i start; for j in 1 2; do if test \$j = 1; then continue 2; fi; echo \$i \$j; done; echo \$i end; done\r"
+expect {
+    -re "a start\r\nb start\r\nvush> " {}
+    timeout { send_user "continue 2 failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- propagate `continue N` correctly across nested loops
- add regression test for `continue 2` inside nested loops

## Testing
- `make test` *(fails: `expect` scripts report "spawn id not open")*

------
https://chatgpt.com/codex/tasks/task_e_684f45faea8c8324a0a069bd79422b47