### PR TITLE
Handle EOF while reading here-doc

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -489,6 +489,8 @@ static void repl_loop(FILE *input)
             }
 
             if (!cmds) {
+                if (feof(input))
+                    clearerr(input);
                 free_commands(cmds);
                 free(expanded);
                 break;

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -204,9 +204,10 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
     if (fd < 0) { perror("mkstemp"); free(delim); free(tok); return -1; }
     FILE *tf = fdopen(fd, "w");
     if (!tf) { perror("fdopen"); close(fd); unlink(template); free(delim); free(tok); return -1; }
+    FILE *in = parse_input ? parse_input : stdin;
     char buf[MAX_LINE];
     int found = 0;
-    while (fgets(buf, sizeof(buf), parse_input ? parse_input : stdin)) {
+    while (fgets(buf, sizeof(buf), in)) {
         size_t len = strlen(buf);
         while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
             buf[--len] = '\0';
@@ -218,6 +219,8 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
         fprintf(tf, "%s\n", line);
     }
     if (!found) {
+        if (in == stdin)
+            clearerr(stdin);
         fclose(tf);
         unlink(template);
         free(delim);


### PR DESCRIPTION
## Summary
- reset `stdin` EOF flag when here-doc input ends unexpectedly
- clear EOF in `repl_loop` so shell continues after unterminated here-doc

## Testing
- `make`
- `expect -f tests/test_heredoc_unterminated.expect` *(fails: unterminated heredoc not detected)*

------
https://chatgpt.com/codex/tasks/task_e_684f465bf1ec832485053de70828001b