### PR TITLE
Fix numeric history expansion for negative offsets

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -729,7 +729,7 @@ char *expand_history(const char *line) {
         pref[n] = '\0';
         rest = p;
         int id = atoi(pref);
-        const char *tmp = neg ? history_get_relative(id + 1) : history_get_by_id(id);
+        const char *tmp = neg ? history_get_relative(id) : history_get_by_id(id);
         if (tmp)
             expansion = strdup(tmp);
         if (!expansion) {


### PR DESCRIPTION
## Summary
- correct history expansion logic when referencing previous commands with negative numbers

## Testing
- `tests/test_bang_numeric.expect`


------
https://chatgpt.com/codex/tasks/task_e_684f494cfa648324841710a324febd96