### PR TITLE
Fix getopts variable update

### DIFF
--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -105,6 +105,7 @@ static int getopts_next_option(const char *optstr, int silent, int *ind, char *o
             } else {
                 write_optarg("");
             }
+            getopts_pos = NULL;
             return OPT_MISSING;
         }
     } else {

--- a/tests/test_getopts.expect
+++ b/tests/test_getopts.expect
@@ -31,4 +31,13 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+spawn [file dirname [info script]]/../vush $script -b foo
+expect {
+    -re "b:foo\[\r\n\]+index:3\[\r\n\]+" {}
+    timeout { send_user "argument with space failed\n"; exec rm $script; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
 exec rm $script


### PR DESCRIPTION
## Summary
- reset cached pointer after missing argument
- extend getopts test for `-b foo` case

## Testing
- `make`
- `expect -f tests/test_getopts.expect` *(fails: spawn id exp7 not open)*

------
https://chatgpt.com/codex/tasks/task_e_684f47d014c4832491765d5c3387b2da