### PR TITLE
Fix interactive read with carriage returns

### DIFF
--- a/src/lineedit.c
+++ b/src/lineedit.c
@@ -291,7 +291,7 @@ static char *read_raw_line(const char *prompt) {
             break;
     }
 
-    tcsetattr(STDIN_FILENO, TCSAFLUSH, &orig);
+    tcsetattr(STDIN_FILENO, TCSANOW, &orig);
 
     if (len < 0)
         return NULL;


### PR DESCRIPTION
## Summary
- handle carriage return input in `read` builtin
- restore terminal mode without flushing input so queued characters aren't lost

## Testing
- `./test_read.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f46a94cf48324919c3d63feaa57b8