### PR TITLE
Honor errexit after builtin/functions

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -428,6 +428,9 @@ static int apply_temp_assignments(PipelineSegment *pipeline, int background,
 
     free(backs);
 
+    if (handled && opt_errexit && last_status != 0)
+        exit(last_status);
+
     return handled;
 }
 
@@ -550,6 +553,8 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
             last_status = 1;
         free_pipeline(copy);
         cleanup_proc_subs();
+        if (opt_errexit && last_status != 0)
+            exit(last_status);
         return last_status;
     }
 


### PR DESCRIPTION
## Summary
- exit with `last_status` after builtins/functions when `opt_errexit` is set
- propagate `errexit` check from `run_pipeline_internal`

## Testing
- `make vush`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f4a5f2f188324ad09c3f39ad332c2