### PR TITLE
Fix heredoc EOF handling

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -219,13 +219,15 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
         fprintf(tf, "%s\n", line);
     }
     if (!found) {
-        if (in == stdin)
+        int eof = feof(in);
+        if (in == stdin && eof)
             clearerr(stdin);
         fclose(tf);
         unlink(template);
         free(delim);
         free(tok);
-        fprintf(stderr, "syntax error: here-document delimited by end-of-file\n");
+        if (eof)
+            fprintf(stderr, "syntax error: here-document delimited by end-of-file\n");
         return -1;
     }
     fclose(tf);


### PR DESCRIPTION
## Summary
- ensure heredoc processing reports an error when EOF occurs before the delimiter

## Testing
- `make -j$(nproc)`
- `make test` *(fails: couldn't compile regex in expect script)*

------
https://chatgpt.com/codex/tasks/task_e_684f4b3223f483249bac524eef3c88a2