### PR TITLE
Fix alias querying with quoted expansions

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -232,7 +232,25 @@ int builtin_alias(char **args)
             *eq = '\0';
             const char *name = args[1];
             const char *val = get_alias(name);
-            int same = val && strcmp(val, eq + 1) == 0;
+
+            const char *newval = eq + 1;
+            char *buf = NULL;
+            if (val) {
+                size_t len = strlen(newval);
+                if (len >= 2 &&
+                    ((newval[0] == '\'' && newval[len - 1] == '\'') ||
+                     (newval[0] == '"' && newval[len - 1] == '"'))) {
+                    buf = strndup(newval + 1, len - 2);
+                    if (!buf) {
+                        *eq = '=';
+                        perror("strndup");
+                        return 1;
+                    }
+                    newval = buf;
+                }
+            }
+            int same = val && strcmp(val, newval) == 0;
+            free(buf);
             *eq = '=';
             if (same) {
                 printf("%s='%s'\n", name, val);

--- a/tests/test_alias_quoted_query.expect
+++ b/tests/test_alias_quoted_query.expect
@@ -1,0 +1,26 @@
+#!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias hi='echo bye'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# simulate line-editor expansion
+send "alias hi='echo bye'\r"
+expect {
+    -re "\[\r\n\]+hi='echo bye'\[\r\n\]+vush> " {}
+    timeout { send_user "quoted query failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- handle single/double quoted alias values when comparing for query
- add regression test for quoted alias query

## Testing
- `make -j$(nproc)`
- `expect -f tests/test_alias_flags.expect` *(fails: alias assignment failed)*
- `expect -f tests/test_alias_quoted_query.expect` *(fails: quoted query failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f4a490a548324be77a4fec5258f7a