### PR TITLE
Fix token parsing of carriage returns

### DIFF
--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -144,7 +144,7 @@ static void handle_backslash_escape(char **p, char buf[], int *len,
 /* Return non-zero when character C terminates an unquoted token. */
 static int is_end_unquoted(int c) {
     return c == ' ' || c == '\t' || c == '|' || c == '<' ||
-           c == '>' || c == '&' || c == ';';
+           c == '>' || c == '&' || c == ';' || c == '\r' || c == '\n';
 }
 
 /* Return non-zero when character C terminates a double quoted token. */


### PR DESCRIPTION
## Summary
- handle `\r` and `\n` characters when tokenizing unquoted words

## Testing
- `cd tests && ./test_array.expect` *(fails: prompt timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684f498d66508324924a7f772abf731d