### PR TITLE
Implement errexit handling and -o options

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -110,6 +110,8 @@ int builtin_set(char **args) {
                 opt_pipefail = 1;
             else if (strcmp(args[i+1], "noclobber") == 0)
                 opt_noclobber = 1;
+            else if (strcmp(args[i+1], "errexit") == 0)
+                opt_errexit = 1;
             else {
                 fprintf(stderr, "set: unknown option %s\n", args[i+1]);
                 return 1;
@@ -149,6 +151,8 @@ int builtin_set(char **args) {
                 opt_pipefail = 0;
             else if (strcmp(args[i+1], "noclobber") == 0)
                 opt_noclobber = 0;
+            else if (strcmp(args[i+1], "errexit") == 0)
+                opt_errexit = 0;
             else {
                 fprintf(stderr, "set: unknown option %s\n", args[i+1]);
                 return 1;

--- a/src/execute.c
+++ b/src/execute.c
@@ -683,6 +683,8 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
         last_status = 1;
     free_pipeline(copy);
     cleanup_proc_subs();
+    if (opt_errexit && !background && last_status != 0)
+        exit(last_status);
     return r;
 }
 


### PR DESCRIPTION
## Summary
- support `set -o errexit` and `set +o errexit`
- exit after failed pipeline if `opt_errexit` is enabled

## Testing
- `make`
- `./tests/run_tests.sh test_set_options.expect` *(fails: couldn't compile regular expression pattern)*

------
https://chatgpt.com/codex/tasks/task_e_684f5b2455588324bb1d5edb13777320