### PR TITLE
Fix job completion message and adjust tests

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -22,6 +22,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <unistd.h>
+#include <ctype.h>
 #include <time.h>
 
 typedef enum { JOB_RUNNING, JOB_STOPPED } JobState;
@@ -106,9 +107,21 @@ int check_jobs_internal(int prefix) {
                     else if (prefix == 2)
                         printf("\r");
                 }
-                printf("[vush] job %d (%s) finished\n",
+                const char *cmd = curr ? curr->cmd : "?";
+                char tmp[MAX_LINE];
+                strncpy(tmp, cmd, sizeof(tmp) - 1);
+                tmp[sizeof(tmp) - 1] = '\0';
+                size_t len = strlen(tmp);
+                while (len > 0 && isspace((unsigned char)tmp[len - 1]))
+                    tmp[--len] = '\0';
+                if (len > 0 && tmp[len - 1] == '&') {
+                    tmp[--len] = '\0';
+                    while (len > 0 && isspace((unsigned char)tmp[len - 1]))
+                        tmp[--len] = '\0';
+                }
+                printf("[vush] job %d (%s &) finished\n",
                        curr ? curr->id : pid,
-                       curr ? curr->cmd : "?");
+                       tmp);
                 printed = 1;
             }
             remove_job(pid);

--- a/tests/test_jobs.expect
+++ b/tests/test_jobs.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "kill 1\r"
 expect {
-    -re {\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n\s]+vush> } {}
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n\s]+vush> } {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_jobs_l.expect
+++ b/tests/test_jobs_l.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "kill 1\r"
 expect {
-    -re {\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n\s]+vush> } {}
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n\s]+vush> } {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_jobs_p.expect
+++ b/tests/test_jobs_p.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "exit\r"

--- a/tests/test_kill.expect
+++ b/tests/test_kill.expect
@@ -12,7 +12,7 @@ expect {
 }
 send "kill 1\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\[\r\n\]+vush> " {}
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
     timeout { send_user "kill output mismatch\n"; exit 1 }
 }
 send "jobs\r"

--- a/tests/test_kill_s.expect
+++ b/tests/test_kill_s.expect
@@ -17,8 +17,12 @@ expect {
 }
 send "kill -s TERM $pid\r"
 expect {
-    -re "\[vush\] job \[0-9\]+ \(sleep 5 \&\) finished\r\nvush> " {}
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+} {}
     timeout { send_user "kill -s output mismatch\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
 }
 send "jobs\r"
 expect {


### PR DESCRIPTION
## Summary
- show trailing ampersand in job completion messages
- include temporary trim logic to avoid duplicating ampersands
- update job-control expect scripts to match new output

## Testing
- `expect -f tests/test_bg.expect`
- `expect -f tests/test_bg_default.expect`
- `expect -f tests/test_kill.expect`
- `expect -f tests/test_kill_s.expect`
- `expect -f tests/test_jobs.expect`
- `expect -f tests/test_jobs_l.expect`
- `expect -f tests/test_jobs_p.expect`


------
https://chatgpt.com/codex/tasks/task_e_684f5b0fa9b08324bec0af1ef4f921ac