### PR TITLE
Fix regex to match literal plus sign

### DIFF
--- a/tests/test_set_options.expect
+++ b/tests/test_set_options.expect
@@ -62,7 +62,7 @@ expect {
 }
 send "echo hi\r"
 expect {
-    -re "\+ echo hi\r\nhi\r\nvush> " {}
+    -re {[+] echo hi\r\nhi\r\nvush> } {}
     timeout { send_user "xtrace output mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- escape `+` in `test_set_options.expect` so Tcl doesn't treat it as a quantifier

## Testing
- `expect -f test_set_options.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f62ea1b1883248472ac377e9445a2