### PR TITLE
Fix escaping in source args test

### DIFF
--- a/tests/test_source_args.expect
+++ b/tests/test_source_args.expect
@@ -2,9 +2,9 @@
 set timeout 5
 set script [exec mktemp]
 set f [open $script "w"]
-puts $f "echo \"$0,$1,$2,$#,$@\""
+puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 puts $f "shift"
-puts $f "echo \"$0,$1,$2,$#,$@\""
+puts $f "echo \"\$0,\$1,\$2,\$#,\$@\""
 close $f
 spawn [file dirname [info script]]/../vush
 expect {


### PR DESCRIPTION
## Summary
- correct variable escaping in test_source_args.expect

## Testing
- `make`
- `expect -f tests/test_source_args.expect` *(fails: source args failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f63988b788324825881ce257fc1dc