### PR TITLE
Fix ${HOME} brace regex

### DIFF
--- a/tests/test_var_brace.expect
+++ b/tests/test_var_brace.expect
@@ -17,7 +17,7 @@ expect {
 }
 send "echo '\${HOME}'\r"
 expect {
-    -re "\[\r\n\]+\${HOME}\[\r\n\]+vush> " {}
+    -re "\r?\n\\$\\{HOME\\}\r?\nvush> " {}
     timeout { send_user "single quote brace mismatch\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- fix the regex that matches `${HOME}` with optional CRs

## Testing
- `tests/test_var_brace.expect`
- `make test` *(fails: long PATH and dquote tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f63b277d0832480f05e8135f6519a