### PR TITLE
Fix whitespace handling in arithmetic evaluator

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -188,7 +188,15 @@ static long parse_expr(const char **s) {
 long eval_arith(const char *expr) {
     const char *p = expr;
     long v = parse_expr(&p);
+    /* Skip any whitespace the parser left behind. */
     skip_ws(&p);
+    /* Historically some callers might include carriage returns
+     * or stray newlines at the end of the expression.  These
+     * should be ignored rather than treated as trailing garbage. */
+    while (*p == '\r' || *p == '\n') {
+        p++;
+        skip_ws(&p);
+    }
     if (*p != '\0') {
         /* trailing garbage indicates a syntax error; mimic zero result */
         return 0;


### PR DESCRIPTION
## Summary
- improve trailing garbage handling in `eval_arith`

## Testing
- `make`
- `expect tests/test_arith.expect` *(fails: basic arithmetic failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f7097340083248f5f1c1deffe119b