### PR TITLE
Fix builtin_cond return logic

### DIFF
--- a/src/builtins_test.c
+++ b/src/builtins_test.c
@@ -190,8 +190,7 @@ int builtin_test(char **args) {
 int builtin_cond(char **args) {
     int count = 0;
     while (args[count]) count++;
-    char **av = args + 1;
-    count--;
+    char **av = args;
     int res = 1;
     if (count == 1) {
         res = av[0][0] ? 0 : 1;
@@ -209,5 +208,5 @@ int builtin_cond(char **args) {
         }
     }
     last_status = res;
-    return 1;
+    return res;
 }

--- a/tests/test_cond.expect
+++ b/tests/test_cond.expect
@@ -17,6 +17,12 @@ expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "equality failed\n"; exit 1 }
 }
+send "\[\[ foo == foo \]\]; echo \$?\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "literal equality failed\n"; exit 1 }
+}
+
 
 send "\[\[ \$x == f* \]\]; echo \$?\r"
 expect {


### PR DESCRIPTION
## Summary
- fix builtin_cond to parse arguments correctly and return comparison status
- add a literal equality case to test_cond.expect

## Testing
- `make test` *(fails: expect script errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f70b70fb48324addc908e2447d336