### PR TITLE
Fix alias flag test

### DIFF
--- a/tests/test_alias_flags.expect
+++ b/tests/test_alias_flags.expect
@@ -21,7 +21,7 @@ expect {
 # list aliases with -p
 send "alias -p\r"
 expect {
-    -re "alias hi='echo hello'" {}
+    -re "alias hi='echo hello'\r\nvush> " {}
     timeout { send_user "alias -p failed\n"; exit 1 }
 }
 # change alias normally


### PR DESCRIPTION
## Summary
- sync expect script after `alias -p` to avoid stale prompts

## Testing
- `expect -f tests/test_alias_flags.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f70e3fd448324b18fdcc1dcf0dca5