### PR TITLE
Add env test for for-loop variable

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -86,6 +86,7 @@ tests="
     test_if.expect
     test_for.expect
     test_for_shellvar.expect
+    test_for_env.expect
     test_while.expect
     test_until.expect
     test_function.expect

--- a/tests/test_for_env.expect
+++ b/tests/test_for_env.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "for x in a b c; do :; done\r"
+expect {
+    "vush> " {}
+    timeout { send_user "for loop timeout\n"; exit 1 }
+}
+send "env | grep ^x=\r"
+expect {
+    -re "x=c\r?\nvush> " {}
+    timeout { send_user "env output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- add an expect script testing that `for` loop variables remain exported
- include the new script in `run_tests.sh`

## Testing
- `HOME=$(mktemp -d) expect -f test_for.expect`
- `HOME=$(mktemp -d) expect -f test_for_shellvar.expect`
- `HOME=$(mktemp -d) expect -f test_for_env.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f70fffa448324b7a9244469f3e8f0