### PR TITLE
Fix parsing of ${VAR?} in brace expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -426,7 +426,7 @@ static char *expand_braced(const char *inner) {
     char name[MAX_LINE];
     int n = 0;
     const char *p = inner;
-    while (*p && *p != ':' && *p != '#' && *p != '%' && *p != '/' && n < MAX_LINE - 1)
+    while (*p && *p != ':' && *p != '#' && *p != '%' && *p != '/' && *p != '?' && n < MAX_LINE - 1)
         name[n++] = *p++;
     name[n] = '\0';
 


### PR DESCRIPTION
## Summary
- ensure `?` stops variable name collection in `expand_braced`

## Testing
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f81a8acb48324860ebf646a56830c