### PR TITLE
Handle EOF in here-doc

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -257,6 +257,8 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
         free(tok);
         if (eof)
             fprintf(stderr, "syntax error: here-document delimited by end-of-file\n");
+        else
+            parse_need_more = 1;
         return -1;
     }
     fclose(tf);


### PR DESCRIPTION
## Summary
- emit proper error when here-doc hits EOF

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f824ea8e483249f16b12f7c17bc69