### PR TITLE
Add arithmetic expect test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -92,6 +92,7 @@ tests="
     test_function.expect
     test_assign.expect
     test_arith.expect
+    test_arith_expr.expect
     test_read.expect
     test_read_eof.expect
     test_case.expect

--- a/tests/test_arith_expr.expect
+++ b/tests/test_arith_expr.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send {echo $((1+2))\r}
+expect {
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
+    timeout { send_user "arithmetic expansion failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- add a simple expect script verifying arithmetic evaluation
- include new test in test list

## Testing
- `tests/run_tests.sh` *(fails: `expect` scripts error out in this environment)*
- `./tests/test_arith_expr.expect` *(fails: arithmetic expansion not observed)*

------
https://chatgpt.com/codex/tasks/task_e_684f81c55dd883248a7557f6173d5fbe