### PR TITLE
Fix alias expansion with empty results

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -163,6 +163,11 @@ static int expand_aliases_in_segment(PipelineSegment *seg, int *argc, char *tok)
         return -1;
     }
 
+    if (count == 0) {
+        free(orig);
+        return 0;
+    }
+
     free(orig);
     int i = 0;
     for (; i < count && *argc < MAX_TOKENS - 1; i++) {


### PR DESCRIPTION
## Summary
- avoid treating aliases that expand to zero tokens as successful

## Testing
- `make`
- `tests/test_alias.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f841ea5c48324a78f1b6b4b8d6d78