### PR TITLE
Fix prompt redraw after completion

### DIFF
--- a/src/completion.c
+++ b/src/completion.c
@@ -228,10 +228,17 @@ static void apply_completion(const char *match, char *buf, int *lenp, int *posp,
         *lenp += mlen - prefix_len;
         *posp = start + mlen;
         buf[*lenp] = '\0';
-        printf("%s%s", prompt, buf);
+        int len = *lenp;
+        printf("\r%s%s", prompt, buf);
+        if (*disp_lenp > len) {
+            for (int i = len; i < *disp_lenp; i++)
+                putchar(' ');
+            printf("\r%s%s", prompt, buf);
+        }
+        for (int i = len; i > *posp; i--)
+            printf("\b");
         fflush(stdout);
-        if (*lenp > *disp_lenp)
-            *disp_lenp = *lenp;
+        *disp_lenp = len;
     }
 }
 


### PR DESCRIPTION
## Summary
- redraw the prompt from the start when applying a completion

## Testing
- `make -s`
- `tests/run_tests.sh tests/test_completion_path.expect` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f869d70dc8324af15703f6b4babfa