### PR TITLE
Fix for-shellvar test by clearing function persistence

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,6 +8,7 @@ fi
 
 TMP_HOME=$(mktemp -d)
 export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
 trap 'rm -rf "$TMP_HOME"' EXIT
 
 failed=0


### PR DESCRIPTION
## Summary
- avoid persisted shell functions during tests

## Testing
- `HOME=$(mktemp -d) VUSH_FUNCFILE=/dev/null expect -f tests/test_for_shellvar.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f86a6ad248324a7194179fc06c753