### PR TITLE
Fix alias expansion with many entries

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -118,8 +118,15 @@ static int set_alias(const char *name, const char *value)
         free(new_alias);
         return -1;
     }
-    new_alias->next = aliases;
-    aliases = new_alias;
+    new_alias->next = NULL;
+    if (!aliases) {
+        aliases = new_alias;
+    } else {
+        struct alias_entry *tail = aliases;
+        while (tail->next)
+            tail = tail->next;
+        tail->next = new_alias;
+    }
     return 0;
 }
 

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -155,6 +155,7 @@ static int expand_aliases_in_segment(PipelineSegment *seg, int *argc, char *tok)
     char *tokens[MAX_TOKENS];
     int count = 0;
     char visited[MAX_ALIAS_DEPTH][MAX_LINE];
+    memset(visited, 0, sizeof(visited));
 
     if (collect_alias_tokens(orig, tokens, &count, visited, 0) == -1) {
         free(orig);

--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -56,7 +56,7 @@ expect {
 }
 
 # Create many aliases to ensure dynamic allocation works
-for {set i 0} {$i < 40} {incr i} {
+for {set i 0} {$i < 45} {incr i} {
     send "alias a$i='echo hi$i'\r"
     expect {
         "vush> " {}
@@ -65,12 +65,12 @@ for {set i 0} {$i < 40} {incr i} {
 }
 send "alias\r"
 expect {
-    -re "a39='echo hi39'" {}
+    -re "a44='echo hi44'" {}
     timeout { send_user "alias storage failed\n"; exit 1 }
 }
-send "a39 world\r"
+send "a44 world\r"
 expect {
-    -re "\[\r\n\]+hi39 world\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+hi44 world\[\r\n\]+vush> " {}
     timeout { send_user "alias expanded failed\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- handle alias list growth in `set_alias`
- clear alias recursion stack before expansion
- extend alias test to cover >32 entries

## Testing
- `make`
- `./test_alias.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f86b05f2083249720fc2f88988b2a