### PR TITLE
Fix heredoc input handling

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -216,9 +216,11 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
     int c;
     while ((c = fgetc(in)) != EOF) {
         if (c == '\r') {
-            int n = fgetc(in);
-            if (n != '\n' && n != EOF)
-                ungetc(n, in);
+            if (!isatty(fileno(in))) {
+                int n = fgetc(in);
+                if (n != '\n' && n != EOF)
+                    ungetc(n, in);
+            }
             c = '\n';
         }
         if (c == '\n') {


### PR DESCRIPTION
## Summary
- avoid blocking when reading CR-delimited heredocs

## Testing
- `tests/test_heredoc.expect`
- `make vush`

------
https://chatgpt.com/codex/tasks/task_e_684f86b8ce588324bae3f7751b355037