### PR TITLE
Handle EINTR in read builtin

### DIFF
--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 extern int last_status;
 
 /* ---- helper functions for builtin_read -------------------------------- */
@@ -90,7 +91,10 @@ static int read_terminal_line(char *buf, size_t size) {
     size_t pos = 0;
     while (pos < size - 1) {
         char c;
-        ssize_t n = read(STDIN_FILENO, &c, 1);
+        ssize_t n;
+        do {
+            n = read(STDIN_FILENO, &c, 1);
+        } while (n == -1 && errno == EINTR);
         if (n <= 0)
             return -1;
         if (c == '\n' || c == '\r')

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -96,6 +96,7 @@ tests="
     test_arith_expr.expect
     test_read.expect
     test_read_eof.expect
+    test_read_signal.expect
     test_case.expect
     test_trap.expect
     test_exit_trap.expect

--- a/tests/test_read_signal.expect
+++ b/tests/test_read_signal.expect
@@ -1,0 +1,32 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "trap '' USR1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "read foo\r"
+set pid [exp_pid]
+after 100
+exec kill -USR1 $pid
+after 100
+send "hello\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$foo\r"
+expect {
+    -re "\[\r\n\]+hello\[\r\n\]+vush> " {}
+    timeout { send_user "signal read failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- retry reads if interrupted by signals
- add regression test for signal-interrupted read

## Testing
- `make`
- `./tests/test_read_signal.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f88f7b8648324a370a89de7688b83