### PR TITLE
Fix calloc failure handling

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -614,8 +614,11 @@ static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
     for (PipelineSegment *tmp = pipeline; tmp; tmp = tmp->next)
         seg_count++;
     pid_t *pids = calloc(seg_count, sizeof(pid_t));
-    if (!pids)
+    if (!pids) {
+        perror("calloc");
+        last_status = 1;
         return 1;
+    }
 
     int spawned = 0;
     int in_fd = -1;

--- a/tests/calloc_fail.c
+++ b/tests/calloc_fail.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+
+static void *(*real_calloc)(size_t, size_t) = NULL;
+static long count = 0;
+
+void *calloc(size_t nmemb, size_t size) {
+    if (!real_calloc)
+        real_calloc = dlsym(RTLD_NEXT, "calloc");
+    count++;
+    char *env = getenv("CALLOC_FAIL_AT");
+    if (env && atol(env) == count) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_calloc(nmemb, size);
+}
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -174,6 +174,7 @@ tests="
     test_path_long.expect
     test_command_v_path_long.expect
     test_dquote_escape.expect
+    test_calloc_fail.expect
 "
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_calloc_fail.expect
+++ b/tests/test_calloc_fail.expect
@@ -1,0 +1,23 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [file dirname [info script]]
+set src "$dir/calloc_fail.c"
+set lib "$dir/calloc_fail.so"
+# compile failing calloc library
+exec cc -shared -fPIC $src -o $lib
+set env(LD_PRELOAD) $lib
+set env(CALLOC_FAIL_AT) 3
+spawn $dir/../vush -c {true}
+expect {
+    -re "calloc: Cannot allocate memory\r?\n" {}
+    timeout { send_user "missing calloc error\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+set code [lindex [wait] 3]
+if { $code != 1 } {
+    send_user "exit status mismatch\n"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- ensure `spawn_pipeline_segments` sets `last_status` and prints an error when allocation fails
- add a small `calloc_fail.c` helper used by a new test
- add an expect script `test_calloc_fail.expect` that verifies last_status on calloc failure
- run the new test through `run_tests.sh`

## Testing
- `make -s`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f892829748324b4340794775e09b1