### PR TITLE
Fix command -v path lookup

### DIFF
--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -251,11 +251,12 @@ int builtin_command(char **args) {
             char *dir = strtok_r(paths, ":", &saveptr);
             int found = 0;
             while (dir) {
-                size_t len = strlen(dir) + strlen(args[i]) + 2;
+                const char *d = *dir ? dir : ".";
+                size_t len = strlen(d) + strlen(args[i]) + 2;
                 char *full = malloc(len);
                 if (!full)
                     break;
-                snprintf(full, len, "%s/%s", dir, args[i]);
+                snprintf(full, len, "%s/%s", d, args[i]);
                 if (access(full, X_OK) == 0) {
                     if (opt_V)
                         printf("%s is %s\n", args[i], full);

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -123,15 +123,16 @@ int builtin_type(char **args) {
         char *dir = strtok_r(paths, ":", &saveptr);
         int found = 0;
         while (dir) {
-            size_t len = strlen(dir) + strlen(args[i]) + 2;
+            const char *d = *dir ? dir : ".";
+            size_t len = strlen(d) + strlen(args[i]) + 2;
             char *full = malloc(len);
             if (!full)
                 break;
-            snprintf(full, len, "%s/%s", dir, args[i]);
+            snprintf(full, len, "%s/%s", d, args[i]);
             if (access(full, X_OK) == 0) {
                 printf("%s is %s\n", args[i], full);
-                free(full);
                 found = 1;
+                free(full);
                 break;
             }
             free(full);


### PR DESCRIPTION
## Summary
- handle blank PATH segments in command lookup logic
- ensure `command -v` test covers very long PATH values

## Testing
- `tests/test_path_long.expect`
- `tests/test_command_v_path_long.expect`
- `make test` *(fails: expect spawn id not open)*

------
https://chatgpt.com/codex/tasks/task_e_684f8a4b8020832482aace3e6db19015