### PR TITLE
Fix getopts state on errors

### DIFF
--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -91,11 +91,9 @@ static int getopts_next_option(const char *optstr, int silent, int *ind, char *o
         } else {
             write_optarg("");
         }
-        if (!getopts_pos || *getopts_pos == '\0') {
-            getopts_pos = NULL;
-            *ind = current_ind + 1;
-            current_ind = 0;
-        }
+        getopts_pos = NULL;
+        *ind = current_ind + 1;
+        current_ind = 0;
         return OPT_ILLEGAL;
     }
 


### PR DESCRIPTION
## Summary
- reset getopts position when reporting illegal options
- keep OPTIND in sync for error cases

## Testing
- `make`
- `./tests/test_getopts.expect` *(fails: spawn id exp7 not open)*

------
https://chatgpt.com/codex/tasks/task_e_684f89d677548324be2727396e6bd73f