### PR TITLE
Add getopts error state regression test

### DIFF
--- a/tests/test_getopts.expect
+++ b/tests/test_getopts.expect
@@ -40,4 +40,13 @@ expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+spawn [file dirname [info script]]/../vush $script -z -a
+expect {
+    -re "getopts: illegal option -- z\[\r\n\]+\?:\[\r\n\]+a:\[\r\n\]+index:3\[\r\n\]+" {}
+    timeout { send_user "invalid option reset failed\n"; exec rm $script; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
 exec rm $script


### PR DESCRIPTION
## Summary
- extend `test_getopts.expect` to verify state reset after an invalid option

## Testing
- `make`
- `expect -f tests/test_getopts.expect` *(fails: spawn id exp7 not open)*

------
https://chatgpt.com/codex/tasks/task_e_684f8d393ea883249e83880ae6a2e382