### PR TITLE
Fix until loop variable handling

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -316,6 +316,13 @@ static int apply_temp_assignments(PipelineSegment *pipeline, int background,
     if (pipeline->next)
         return 0;
 
+    /*
+     * Expand words in the pipeline before applying temporary assignments so
+     * that command substitutions and parameter expansions occur using the
+     * current environment.  This mirrors normal shell behavior where
+     * assignment values are expanded prior to being set.
+     */
+    expand_segment(pipeline);
 
     if (!pipeline->argv[0] && pipeline->assign_count > 0) {
         for (int i = 0; i < pipeline->assign_count; i++) {
@@ -500,8 +507,6 @@ static int apply_temp_assignments(PipelineSegment *pipeline, int background,
             }
         }
     }
-    expand_segment(pipeline);
-
     int handled = 0;
     int is_blt = is_builtin_command(pipeline->argv[0]);
     FuncEntry *fn = NULL;

--- a/tests/test_until.expect
+++ b/tests/test_until.expect
@@ -10,6 +10,11 @@ expect {
     -re "2\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "until output mismatch\n"; exit 1 }
 }
+send "echo \$j\r"
+expect {
+    -re "0\[\r\n\]+vush> " {}
+    timeout { send_user "until var mismatch\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- ensure temporary assignments expand before execution
- evaluate command substitutions within the shell so variables persist
- validate final variable value in until loop test

## Testing
- `expect -f tests/test_until.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f8d58ad70832491e4152c7d6dfedd