### PR TITLE
Fix heredoc EOF error output

### DIFF
--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -263,8 +263,10 @@ static int process_here_doc(PipelineSegment *seg, char **p, char *tok, int quote
         unlink(template);
         free(delim);
         free(tok);
-        if (eof)
+        if (eof) {
             fprintf(stderr, "syntax error: here-document delimited by end-of-file\n");
+            fflush(stderr);
+        }
         else
             parse_need_more = 1;
         return -1;


### PR DESCRIPTION
## Summary
- flush error message when heredoc delimiter is missing

## Testing
- `make test` *(fails: expect spawn id not open)*

------
https://chatgpt.com/codex/tasks/task_e_684f8d5e90dc83248948ed376fecb570