### PR TITLE
Refactor builtin usage handling

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -11,6 +11,7 @@
  */
 #define _GNU_SOURCE
 #include "builtins.h"
+#include "util.h"
 #include "parser.h" /* for MAX_LINE */
 #include <stdio.h>
 #include <stdlib.h>
@@ -269,7 +270,7 @@ int builtin_alias(char **args)
     for (int i = 1; args[i]; i++) {
         char *eq = strchr(args[i], '=');
         if (!eq) {
-            fprintf(stderr, "usage: alias name=value\n");
+            usage_error("alias name=value");
             continue;
         }
         *eq = '\0';
@@ -294,14 +295,12 @@ int builtin_unalias(char **args)
         if (strcmp(args[i], "-a") == 0) {
             all = 1;
         } else {
-            fprintf(stderr, "usage: unalias [-a] name\n");
-            return 1;
+            return usage_error("unalias [-a] name");
         }
     }
 
     if (all && args[i]) {
-        fprintf(stderr, "usage: unalias [-a] name\n");
-        return 1;
+        return usage_error("unalias [-a] name");
     }
 
     if (all) {
@@ -310,8 +309,7 @@ int builtin_unalias(char **args)
     }
 
     if (!args[i]) {
-        fprintf(stderr, "usage: unalias [-a] name\n");
-        return 1;
+        return usage_error("unalias [-a] name");
     }
 
     for (; args[i]; i++)

--- a/src/builtins_core.c
+++ b/src/builtins_core.c
@@ -7,6 +7,7 @@
 #include "builtins.h"
 #include "vars.h"
 #include "history.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -23,8 +24,7 @@ int builtin_exit(char **args) {
         errno = 0;
         long val = strtol(args[1], &end, 10);
         if (*end != '\0' || errno != 0) {
-            fprintf(stderr, "usage: exit [STATUS]\n");
-            return 1;
+            return usage_error("exit [STATUS]");
         }
         status = (int)val;
     }

--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -97,8 +97,7 @@ static void execute_source_file(FILE *input)
  * environment. Additional arguments become script parameters. */
 int builtin_source(char **args) {
     if (!args[1]) {
-        fprintf(stderr, "usage: source file [args...]\n");
-        return 1;
+        return usage_error("source file [args...]");
     }
 
     FILE *prev_input = parse_input;
@@ -181,8 +180,7 @@ int builtin_eval(char **args) {
 /* Replace the current shell with the specified program using execvp. */
 int builtin_exec(char **args) {
     if (!args[1]) {
-        fprintf(stderr, "usage: exec command [args...]\n");
-        return 1;
+        return usage_error("exec command [args...]");
     }
     execvp(args[1], &args[1]);
     perror(args[1]);
@@ -206,8 +204,7 @@ int builtin_command(char **args) {
     }
 
     if (!args[i]) {
-        fprintf(stderr, "usage: command [-p|-v|-V] name [args...]\n");
-        return 1;
+        return usage_error("command [-p|-v|-V] name [args...]");
     }
 
     if (opt_v || opt_V) {

--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -187,8 +187,7 @@ int builtin_cd(char **args) {
  */
 int builtin_pushd(char **args) {
     if (!args[1]) {
-        fprintf(stderr, "usage: pushd dir\n");
-        return 1;
+        return usage_error("pushd dir");
     }
     char prev[PATH_MAX];
     if (!getcwd(prev, sizeof(prev))) {
@@ -250,8 +249,7 @@ int builtin_popd(char **args) {
  */
 int builtin_dirs(char **args) {
     if (args[1]) {
-        fprintf(stderr, "usage: dirs\n");
-        return 1;
+        return usage_error("dirs");
     }
     dirstack_print();
     return 1;
@@ -271,14 +269,12 @@ int builtin_pwd(char **args) {
         } else if (args[idx][1] == 'L') {
             idx++;
         } else {
-            fprintf(stderr, "usage: pwd [-L|-P]\n");
-            return 1;
+            return usage_error("pwd [-L|-P]");
         }
     }
 
     if (args[idx]) {
-        fprintf(stderr, "usage: pwd [-L|-P]\n");
-        return 1;
+        return usage_error("pwd [-L|-P]");
     }
 
     if (physical || !getenv("PWD")) {

--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -2,6 +2,7 @@
 #include "builtins.h"
 #include "vars.h"
 #include "scriptargs.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -136,10 +137,9 @@ static int getopts_next_option(const char *optstr, int silent, int *ind, char *o
 int builtin_getopts(char **args) {
     int ind = read_optind();
     if (!args[1] || !args[2]) {
-        fprintf(stderr, "usage: getopts optstring var\n");
         last_status = 1;
         write_optind(ind);
-        return 1;
+        return usage_error("getopts optstring var");
     }
 
     const char *optstr = args[1];

--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -34,8 +34,7 @@ int builtin_history(char **args)
             delete_history_entry((int)id);
             return 1;
         } else {
-            fprintf(stderr, "usage: history [-c|-d NUMBER]\n");
-            return 1;
+            return usage_error("history [-c|-d NUMBER]");
         }
     }
     print_history();
@@ -83,9 +82,7 @@ int builtin_fc(char **args)
             editor = args[i+1];
             i++;
         } else {
-            fprintf(stderr,
-                    "usage: fc [-lnr] [-e editor] [first [last]] | fc -s [old=new] [command]\n");
-            return 1;
+            return usage_error("fc [-lnr] [-e editor] [first [last]] | fc -s [old=new] [command]");
         }
     }
 

--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -11,6 +11,7 @@
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "jobs.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -95,8 +96,7 @@ int builtin_jobs(char **args) {
         } else if (strcmp(args[idx], "-p") == 0) {
             mode = 2;
         } else {
-            fprintf(stderr, "usage: jobs [-l|-p] [ID...]\n");
-            return 1;
+            return usage_error("jobs [-l|-p] [ID...]");
         }
     }
 
@@ -157,8 +157,7 @@ int builtin_kill(char **args) {
         } else if (strcmp(args[idx], "-s") == 0) {
             idx++;
             if (!args[idx]) {
-                fprintf(stderr, "usage: kill [-s SIGNAL|-SIGNAL] [-l] ID|PID...\n");
-                return 1;
+                return usage_error("kill [-s SIGNAL|-SIGNAL] [-l] ID|PID...");
             }
             sig = sig_from_name(args[idx]);
             if (sig <= 0 || sig >= NSIG) {
@@ -195,8 +194,7 @@ int builtin_kill(char **args) {
     }
 
     if (!args[idx]) {
-        fprintf(stderr, "usage: kill [-s SIGNAL|-SIGNAL] [-l] ID|PID...\n");
-        return 1;
+        return usage_error("kill [-s SIGNAL|-SIGNAL] [-l] ID|PID...");
     }
 
     int wait_ids[64];
@@ -256,8 +254,7 @@ int builtin_wait(char **args) {
         char *end;
         long val = strtol(args[i], &end, 10);
         if (*end != '\0') {
-            fprintf(stderr, "usage: wait [ID|PID]...\n");
-            return 1;
+            return usage_error("wait [ID|PID]...");
         }
         pid_t pid = get_job_pid((int)val);
         int status;

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -11,6 +11,7 @@
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "hash.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -90,8 +91,7 @@ int builtin_help(char **args) {
 /* Show how each argument would be resolved: alias, function, builtin or file. */
 int builtin_type(char **args) {
     if (!args[1]) {
-        fprintf(stderr, "usage: type name...\n");
-        return 1;
+        return usage_error("type name...");
     }
     for (int i = 1; args[i]; i++) {
         const char *alias = get_alias(args[i]);

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -2,6 +2,7 @@
 #include "builtins.h"
 #include "parser.h"
 #include "vars.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -110,9 +111,8 @@ int builtin_read(char **args) {
     const char *array_name = NULL;
     int idx;
     if (parse_read_options(args, &raw, &array_name, &idx) != 0) {
-        fprintf(stderr, "usage: read [-r] [-a NAME] [NAME...]\n");
         last_status = 1;
-        return 1;
+        return usage_error("read [-r] [-a NAME] [NAME...]");
     }
 
     char line[MAX_LINE];

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -2,6 +2,7 @@
 #include "builtins.h"
 #include "execute.h"
 #include "trap.h"
+#include "util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -94,8 +95,7 @@ int builtin_trap(char **args)
 
     if (strcmp(args[1], "-p") == 0) {
         if (args[2]) {
-            fprintf(stderr, "usage: trap -p\n");
-            return 1;
+            return usage_error("trap -p");
         }
         print_traps();
         last_status = 0;
@@ -104,8 +104,7 @@ int builtin_trap(char **args)
 
     if (strcmp(args[1], "-l") == 0) {
         if (args[2]) {
-            fprintf(stderr, "usage: trap -l\n");
-            return 1;
+            return usage_error("trap -l");
         }
         list_signals();
         last_status = 0;
@@ -151,8 +150,7 @@ int builtin_break(char **args)
         errno = 0;
         long val = strtol(args[1], &end, 10);
         if (*end != '\0' || errno != 0 || val <= 0) {
-            fprintf(stderr, "usage: break [N]\n");
-            return 1;
+            return usage_error("break [N]");
         }
         n = (int)val;
     }
@@ -171,8 +169,7 @@ int builtin_continue(char **args)
         errno = 0;
         long val = strtol(args[1], &end, 10);
         if (*end != '\0' || errno != 0 || val <= 0) {
-            fprintf(stderr, "usage: continue [N]\n");
-            return 1;
+            return usage_error("continue [N]");
         }
         n = (int)val;
     }

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -6,6 +6,7 @@
  */
 #define _GNU_SOURCE
 #include "builtins.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,8 +115,7 @@ int builtin_umask(char **args)
     }
 
     if (args[idx+1]) {
-        fprintf(stderr, "usage: umask [-S] [mode]\n");
-        return 1;
+        return usage_error("umask [-S] [mode]");
     }
 
     errno = 0;
@@ -175,19 +175,16 @@ int builtin_ulimit(char **args)
                 }
             }
             if (!found) {
-                fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
-                return 1;
+                return usage_error("ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]");
             }
         } else {
-            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
-            return 1;
+            return usage_error("ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]");
         }
     }
 
     if (show_all) {
         if (args[i]) {
-            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
-            return 1;
+            return usage_error("ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]");
         }
         struct rlimit rl;
         for (int m = 0; map[m].opt; m++) {
@@ -222,8 +219,7 @@ int builtin_ulimit(char **args)
     }
 
     if (args[i+1]) {
-        fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
-        return 1;
+        return usage_error("ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]");
     }
 
     errno = 0;

--- a/src/builtins_time.c
+++ b/src/builtins_time.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include "builtins.h"
+#include "util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,8 +25,7 @@ int builtin_time(char **args)
     }
 
     if (!args[idx]) {
-        fprintf(stderr, "usage: time [-p] command [args...]\n");
-        return 1;
+        return usage_error("time [-p] command [args...]");
     }
 
     struct timespec start, end;
@@ -73,9 +73,8 @@ int builtin_time(char **args)
 int builtin_times(char **args)
 {
     if (args[1]) {
-        fprintf(stderr, "usage: times\n");
         last_status = 1;
-        return 1;
+        return usage_error("times");
     }
 
     struct tms t;

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -17,6 +17,7 @@
 #include "arith.h"
 #include "vars.h"
 #include "options.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,8 +40,7 @@ int builtin_shift(char **args) {
         errno = 0;
         long val = strtol(args[1], &end, 10);
         if (*end != '\0' || errno != 0 || val < 0) {
-            fprintf(stderr, "usage: shift [n]\n");
-            return 1;
+            return usage_error("shift [n]");
         }
         n = (int)val;
     }
@@ -243,8 +243,7 @@ int builtin_unset(char **args) {
         remove_func = remove_vars = 1;
     }
     if (!args[i]) {
-        fprintf(stderr, "usage: unset [-f|-v] NAME...\n");
-        return 1;
+        return usage_error("unset [-f|-v] NAME...");
     }
     for (; args[i]; i++) {
         char *name = args[i];
@@ -310,8 +309,7 @@ static void list_exports(void)
  */
 int builtin_export(char **args) {
     if (!args[1]) {
-        fprintf(stderr, "usage: export [-p|-n NAME] NAME[=VALUE]...\n");
-        return 1;
+        return usage_error("export [-p|-n NAME] NAME[=VALUE]...");
     }
 
     if (strcmp(args[1], "-p") == 0 && !args[2]) {
@@ -358,8 +356,7 @@ int builtin_readonly(char **args) {
         if (strcmp(args[i], "-p") == 0) {
             pflag = 1;
         } else {
-            fprintf(stderr, "usage: readonly [-p] NAME[=VALUE]...\n");
-            return 1;
+            return usage_error("readonly [-p] NAME[=VALUE]...");
         }
     }
 
@@ -369,8 +366,7 @@ int builtin_readonly(char **args) {
     }
 
     if (!args[i]) {
-        fprintf(stderr, "usage: readonly [-p] NAME[=VALUE]...\n");
-        return 1;
+        return usage_error("readonly [-p] NAME[=VALUE]...");
     }
 
     for (; args[i]; i++) {

--- a/src/util.c
+++ b/src/util.c
@@ -56,3 +56,8 @@ int open_redirect(const char *path, int append, int force) {
         flags |= O_EXCL;
     return open(path, flags, 0644);
 }
+
+int usage_error(const char *msg) {
+    fprintf(stderr, "usage: %s\n", msg);
+    return 1;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -14,4 +14,6 @@ char *read_logical_line(FILE *f, char *buf, size_t size);
  * FORCE overrides the noclobber option when set.
  * Returns a file descriptor or -1 on failure. */
 int open_redirect(const char *path, int append, int force);
+/* Print a usage message MSG to stderr and return 1. */
+int usage_error(const char *msg);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- add `usage_error` helper in util
- use `usage_error` across builtins for usage messages

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f92f4d9708324b71303386b908456