### PR TITLE
Share signal name helpers

### DIFF
--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -16,59 +16,11 @@
 #include <string.h>
 #include <ctype.h>
 #include <signal.h>
+#include "signal_map.h"
 #include <sys/wait.h>
 #include <time.h>
 
-/* Map signal names to numbers for kill builtin */
-static const struct { const char *n; int v; } sig_map[] = {
-    {"INT", SIGINT}, {"TERM", SIGTERM}, {"HUP", SIGHUP},
-#ifdef SIGQUIT
-    {"QUIT", SIGQUIT},
-#endif
-#ifdef SIGUSR1
-    {"USR1", SIGUSR1},
-#endif
-#ifdef SIGUSR2
-    {"USR2", SIGUSR2},
-#endif
-#ifdef SIGCHLD
-    {"CHLD", SIGCHLD},
-#endif
-#ifdef SIGCONT
-    {"CONT", SIGCONT},
-#endif
-#ifdef SIGSTOP
-    {"STOP", SIGSTOP},
-#endif
-#ifdef SIGALRM
-    {"ALRM", SIGALRM},
-#endif
-    {NULL, 0}
-};
 
-static int sig_from_name(const char *name)
-{
-    if (!name || !*name)
-        return -1;
-    if (isdigit((unsigned char)name[0]))
-        return atoi(name);
-    if (strncasecmp(name, "SIG", 3) == 0)
-        name += 3;
-    for (int i = 0; sig_map[i].n; i++) {
-        if (strcasecmp(name, sig_map[i].n) == 0)
-            return sig_map[i].v;
-    }
-    return -1;
-}
-
-static const char *name_from_sig(int sig)
-{
-    for (int i = 0; sig_map[i].n; i++) {
-        if (sig_map[i].v == sig)
-            return sig_map[i].n;
-    }
-    return NULL;
-}
 
 void list_signals(void)
 {

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -9,63 +9,15 @@
 #include <ctype.h>
 #include <errno.h>
 #include <signal.h>
+#include "signal_map.h"
 
 extern int last_status;
 void list_signals(void);
 
-/* Map signal names to numbers for trap builtin. */
-static const struct { const char *n; int v; } sig_map[] = {
-    {"INT", SIGINT}, {"TERM", SIGTERM}, {"HUP", SIGHUP},
-#ifdef SIGQUIT
-    {"QUIT", SIGQUIT},
-#endif
-#ifdef SIGUSR1
-    {"USR1", SIGUSR1},
-#endif
-#ifdef SIGUSR2
-    {"USR2", SIGUSR2},
-#endif
-#ifdef SIGCHLD
-    {"CHLD", SIGCHLD},
-#endif
-#ifdef SIGCONT
-    {"CONT", SIGCONT},
-#endif
-#ifdef SIGSTOP
-    {"STOP", SIGSTOP},
-#endif
-#ifdef SIGALRM
-    {"ALRM", SIGALRM},
-#endif
-    {NULL, 0}
-};
+/* Map signal names to numbers for trap builtin is now defined in signal_map.h */
 
 char *trap_cmds[NSIG];
 char *exit_trap_cmd;
-
-static int sig_from_name(const char *name)
-{
-    if (!name || !*name)
-        return -1;
-    if (isdigit((unsigned char)name[0]))
-        return atoi(name);
-    if (strncasecmp(name, "SIG", 3) == 0)
-        name += 3;
-    for (int i = 0; sig_map[i].n; i++) {
-        if (strcasecmp(name, sig_map[i].n) == 0)
-            return sig_map[i].v;
-    }
-    return -1;
-}
-
-static const char *name_from_sig(int sig)
-{
-    for (int i = 0; sig_map[i].n; i++) {
-        if (sig_map[i].v == sig)
-            return sig_map[i].n;
-    }
-    return NULL;
-}
 
 /* Assign commands to run when specified signals are received. */
 static void print_traps(void)

--- a/src/signal_map.h
+++ b/src/signal_map.h
@@ -1,0 +1,59 @@
+#ifndef SIGNAL_MAP_H
+#define SIGNAL_MAP_H
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+static const struct { const char *n; int v; } sig_map[] = {
+    {"INT", SIGINT}, {"TERM", SIGTERM}, {"HUP", SIGHUP},
+#ifdef SIGQUIT
+    {"QUIT", SIGQUIT},
+#endif
+#ifdef SIGUSR1
+    {"USR1", SIGUSR1},
+#endif
+#ifdef SIGUSR2
+    {"USR2", SIGUSR2},
+#endif
+#ifdef SIGCHLD
+    {"CHLD", SIGCHLD},
+#endif
+#ifdef SIGCONT
+    {"CONT", SIGCONT},
+#endif
+#ifdef SIGSTOP
+    {"STOP", SIGSTOP},
+#endif
+#ifdef SIGALRM
+    {"ALRM", SIGALRM},
+#endif
+    {NULL, 0}
+};
+
+static inline int sig_from_name(const char *name)
+{
+    if (!name || !*name)
+        return -1;
+    if (isdigit((unsigned char)name[0]))
+        return atoi(name);
+    if (strncasecmp(name, "SIG", 3) == 0)
+        name += 3;
+    for (int i = 0; sig_map[i].n; i++) {
+        if (strcasecmp(name, sig_map[i].n) == 0)
+            return sig_map[i].v;
+    }
+    return -1;
+}
+
+static inline const char *name_from_sig(int sig)
+{
+    for (int i = 0; sig_map[i].n; i++) {
+        if (sig_map[i].v == sig)
+            return sig_map[i].n;
+    }
+    return NULL;
+}
+
+#endif /* SIGNAL_MAP_H */


### PR DESCRIPTION
## Summary
- factor out `sig_map` and helper functions into new `signal_map.h`
- use the shared header from `builtins_jobs.c`
- use the shared header from `builtins_signals.c`

## Testing
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f96a955148324bbcbdb7add44f57c