### PR TITLE
Implement parse_int helper and refactor builtins

### DIFF
--- a/src/builtins_core.c
+++ b/src/builtins_core.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include "util.h"
 
 extern int last_status;
 
@@ -19,10 +20,8 @@ extern int last_status;
 int builtin_exit(char **args) {
     int status = last_status;
     if (args[1]) {
-        char *end;
-        errno = 0;
-        long val = strtol(args[1], &end, 10);
-        if (*end != '\0' || errno != 0) {
+        long val;
+        if (parse_int(args[1], 10, &val) < 0) {
             fprintf(stderr, "usage: exit [STATUS]\n");
             return 1;
         }

--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -24,9 +24,8 @@ int builtin_history(char **args)
             clear_history();
             return 1;
         } else if (strcmp(args[1], "-d") == 0 && args[2] && !args[3]) {
-            char *end;
-            long id = strtol(args[2], &end, 10);
-            if (*end || id <= 0) {
+            long id;
+            if (parse_int(args[2], 10, &id) < 0 || id <= 0) {
                 fprintf(stderr, "history: invalid entry\n");
                 return 1;
             }

--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -18,6 +18,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <time.h>
+#include "util.h"
 
 /* Map signal names to numbers for kill builtin */
 static const struct { const char *n; int v; } sig_map[] = {
@@ -202,9 +203,8 @@ int builtin_kill(char **args) {
     int wait_ids[64];
     int wait_count = 0;
     for (; args[idx]; idx++) {
-        char *end;
-        long val = strtol(args[idx], &end, 10);
-        if (*end != '\0') {
+        long val;
+        if (parse_int(args[idx], 10, &val) < 0) {
             fprintf(stderr, "kill: invalid id %s\n", args[idx]);
             continue;
         }
@@ -253,9 +253,8 @@ int builtin_wait(char **args) {
         return 1;
     }
     for (; args[i]; i++) {
-        char *end;
-        long val = strtol(args[i], &end, 10);
-        if (*end != '\0') {
+        long val;
+        if (parse_int(args[i], 10, &val) < 0) {
             fprintf(stderr, "usage: wait [ID|PID]...\n");
             return 1;
         }

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -9,6 +9,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <signal.h>
+#include "util.h"
 
 extern int last_status;
 void list_signals(void);
@@ -147,10 +148,8 @@ int builtin_break(char **args)
 {
     int n = 1;
     if (args[1]) {
-        char *end;
-        errno = 0;
-        long val = strtol(args[1], &end, 10);
-        if (*end != '\0' || errno != 0 || val <= 0) {
+        long val;
+        if (parse_int(args[1], 10, &val) < 0 || val <= 0) {
             fprintf(stderr, "usage: break [N]\n");
             return 1;
         }
@@ -167,10 +166,8 @@ int builtin_continue(char **args)
 {
     int n = 1;
     if (args[1]) {
-        char *end;
-        errno = 0;
-        long val = strtol(args[1], &end, 10);
-        if (*end != '\0' || errno != 0 || val <= 0) {
+        long val;
+        if (parse_int(args[1], 10, &val) < 0 || val <= 0) {
             fprintf(stderr, "usage: continue [N]\n");
             return 1;
         }

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
+#include "util.h"
 
 extern int last_status;
 
@@ -118,11 +119,9 @@ int builtin_umask(char **args)
         return 1;
     }
 
-    errno = 0;
-    char *end;
-    long val = strtol(args[idx], &end, 8);
     mode_t newmask;
-    if (*end == '\0' && errno == 0 && val >= 0 && val <= 0777) {
+    long val;
+    if (parse_int(args[idx], 8, &val) == 0 && val >= 0 && val <= 0777) {
         newmask = (mode_t)val;
     } else if (parse_symbolic_umask(args[idx], &newmask) == 0) {
         /* parsed successfully */

--- a/src/util.c
+++ b/src/util.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include "options.h"
@@ -74,4 +75,16 @@ char *make_user_path(const char *env_var, const char *default_name) {
         return NULL;
     snprintf(res, len, "%s/%s", home, default_name);
     return res;
+}
+
+int parse_int(const char *str, int base, long *out) {
+    if (!str || !*str || !out)
+        return -1;
+    char *end;
+    errno = 0;
+    long val = strtol(str, &end, base);
+    if (errno != 0 || end == str || *end != '\0')
+        return -1;
+    *out = val;
+    return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -17,4 +17,7 @@ int open_redirect(const char *path, int append, int force);
 /* Construct a path using ENV_VAR if set, otherwise "$HOME/DEFAULT_NAME".
  * The returned string must be freed by the caller. */
 char *make_user_path(const char *env_var, const char *default_name);
+/* Parse STR as an integer using BASE and store the result in OUT.
+ * Returns 0 on success or -1 on invalid or out-of-range input. */
+int parse_int(const char *str, int base, long *out);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- add `parse_int` helper in util
- use `parse_int` instead of manual `strtol` calls across builtins

## Testing
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f9668182c8324b7d0f0a85e44f364