### PR TITLE
Add secondary env var fallback in make_user_path

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -33,7 +33,7 @@ static void remove_all_aliases(const char *name);
 /* Return the path of the alias file or NULL if $HOME is not set. */
 static char *aliasfile_path(void)
 {
-    return make_user_path("VUSH_ALIASFILE", ".vush_aliases");
+    return make_user_path("VUSH_ALIASFILE", NULL, ".vush_aliases");
 }
 
 /* Write the current alias list to the file returned by aliasfile_path(). */

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -42,7 +42,7 @@ FuncEntry *find_function(const char *name)
  */
 static char *funcfile_path(void)
 {
-    return make_user_path("VUSH_FUNCFILE", ".vush_funcs");
+    return make_user_path("VUSH_FUNCFILE", NULL, ".vush_funcs");
 }
 
 /*

--- a/src/history.c
+++ b/src/history.c
@@ -55,12 +55,7 @@ static void renumber_history(void)
  * be constructed.
  */
 static char *histfile_path(void) {
-    const char *env = getenv("VUSH_HISTFILE");
-    if (!env || !*env)
-        env = getenv("HISTFILE");
-    if (env && *env)
-        return strdup(env);
-    return make_user_path(NULL, ".vush_history");
+    return make_user_path("VUSH_HISTFILE", "HISTFILE", ".vush_history");
 }
 
 /* Rewrite the entire history file from the in-memory list. */

--- a/src/startup.c
+++ b/src/startup.c
@@ -64,7 +64,7 @@ int process_rc_file(const char *path, FILE *input)
 /* Load ~/.vushrc if it exists. */
 int process_startup_file(FILE *input)
 {
-    char *rcpath = make_user_path(NULL, ".vushrc");
+    char *rcpath = make_user_path(NULL, NULL, ".vushrc");
     if (!rcpath)
         return 0;
     int r = process_rc_file(rcpath, input);

--- a/src/util.c
+++ b/src/util.c
@@ -59,9 +59,15 @@ int open_redirect(const char *path, int append, int force) {
     return open(path, flags, 0644);
 }
 
-char *make_user_path(const char *env_var, const char *default_name) {
+char *make_user_path(const char *env_var, const char *secondary,
+                     const char *default_name) {
     if (env_var) {
         const char *val = getenv(env_var);
+        if (val && *val)
+            return strdup(val);
+    }
+    if (secondary) {
+        const char *val = getenv(secondary);
         if (val && *val)
             return strdup(val);
     }

--- a/src/util.h
+++ b/src/util.h
@@ -14,7 +14,9 @@ char *read_logical_line(FILE *f, char *buf, size_t size);
  * FORCE overrides the noclobber option when set.
  * Returns a file descriptor or -1 on failure. */
 int open_redirect(const char *path, int append, int force);
-/* Construct a path using ENV_VAR if set, otherwise "$HOME/DEFAULT_NAME".
- * The returned string must be freed by the caller. */
-char *make_user_path(const char *env_var, const char *default_name);
+/* Construct a path using ENV_VAR if set, otherwise SECONDARY if set,
+ * falling back to "$HOME/DEFAULT_NAME". NULL is returned when HOME is not
+ * set. The returned string must be freed by the caller. */
+char *make_user_path(const char *env_var, const char *secondary,
+                     const char *default_name);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- expand `make_user_path` to accept a secondary environment variable
- adjust helper declarations and update call sites
- simplify history file path logic using new helper

## Testing
- `./test_custom_histfile.expect`
- `./test_history.expect`
- `./test_history_clear.expect`
- `./test_history_limit.expect`
- `HOME=/tmp/testhome ./test_history_delete.expect`
- `HOME=/tmp/testhome ./test_alias_persist.expect`
- `HOME=/tmp/testhome ./test_function.expect`

------
https://chatgpt.com/codex/tasks/task_e_684f9654a5a88324a49be959f52468d7