### PR TITLE
Fix glob test by isolating with temporary directory

### DIFF
--- a/tests/test_glob.expect
+++ b/tests/test_glob.expect
@@ -1,6 +1,9 @@
 #!/usr/bin/env expect
 set timeout 5
-spawn [file dirname [info script]]/../vush
+set dir [exec mktemp -d]
+set scriptdir [file normalize [file dirname [info script]]]
+cd $dir
+spawn $scriptdir/../vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -13,15 +16,12 @@ expect {
 send "echo *.c\r"
 expect {
     -re "\[\r\n\]+g1.c g2.c\[\r\n\]+vush> " {}
-    timeout { send_user "glob expansion failed\n"; exit 1 }
-}
-send "rm g1.c g2.c\r"
-expect {
-    "vush> " {}
-    timeout { send_user "prompt timeout\n"; exit 1 }
+    timeout { send_user "glob expansion failed\n"; cd $scriptdir; exec rm -rf $dir; exit 1 }
 }
 send "exit\r"
 expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
+cd $scriptdir
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- use a temporary directory for `test_glob.expect`
- create files in the temp dir and clean them up afterwards

## Testing
- `./run_tests.sh` *(fails: many tests fail but command executed)*

------
https://chatgpt.com/codex/tasks/task_e_6850288621548324b6c65c15876e9ddf