### PR TITLE
Handle backslash escapes correctly

### DIFF
--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -128,14 +128,17 @@ static char *parse_redirect_token(char **p) {
 static void handle_backslash_escape(char **p, char buf[], int *len,
                                    int *first, int *do_expand,
                                    int disable_first) {
-    (*p)++;
+    /* Append the backslash itself. */
+    if (*len < MAX_LINE - 1)
+        buf[(*len)++] = '\\';
+    (*p)++; /* move past the backslash */
     if (**p) {
+        /* Append the escaped character as-is */
         if (*len < MAX_LINE - 1)
             buf[(*len)++] = **p;
         if (*first && disable_first && (**p == '$' || **p == '`'))
             *do_expand = 0;
-        if (**p)
-            (*p)++;
+        (*p)++;
     }
     *first = 0;
 }


### PR DESCRIPTION
## Summary
- fix backslash escaping so both characters are stored
- rebuild vush
- run `test_printf.expect` and `test_printf_escapes.expect`

## Testing
- `make`
- `./tests/test_printf.expect`
- `./tests/test_printf_escapes.expect`


------
https://chatgpt.com/codex/tasks/task_e_68502a6ba7008324b2922873d3eb75d4