### PR TITLE
Fix EOF handling in read builtin

### DIFF
--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -95,7 +95,9 @@ static int read_terminal_line(char *buf, size_t size) {
         do {
             n = read(STDIN_FILENO, &c, 1);
         } while (n == -1 && errno == EINTR);
-        if (n <= 0)
+        if (n == 0)
+            return 1; /* EOF */
+        if (n < 0)
             return -1;
         if (c == '\n' || c == '\r')
             break;
@@ -116,7 +118,8 @@ int builtin_read(char **args) {
     }
 
     char line[MAX_LINE];
-    if (read_terminal_line(line, sizeof(line)) < 0) {
+    int r = read_terminal_line(line, sizeof(line));
+    if (r != 0) {
         last_status = 1;
         return 1;
     }


### PR DESCRIPTION
## Summary
- handle EOF correctly in `read_terminal_line`
- ensure builtin exits with status 1 when EOF occurs

## Testing
- `make test` *(fails: `expect: spawn id exp7 not open`)*
- `HOME=$(mktemp -d) VUSH_FUNCFILE=/dev/null ./tests/test_read_eof.expect` *(fails: prompt timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685028cdf0fc8324b9440750c655ca44