### PR TITLE
Run glob test in temporary directory

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -180,6 +180,26 @@ tests="
 "
 for test in $tests; do
     echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
     case "$test" in
         test_history.expect|\
         test_history_clear.expect|\

--- a/tests/test_glob.expect
+++ b/tests/test_glob.expect
@@ -1,8 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
 set scriptdir [file normalize [file dirname [info script]]]
-cd $dir
 spawn $scriptdir/../vush
 expect {
     "vush> " {}
@@ -16,12 +14,10 @@ expect {
 send "echo *.c\r"
 expect {
     -re "\[\r\n\]+g1.c g2.c\[\r\n\]+vush> " {}
-    timeout { send_user "glob expansion failed\n"; cd $scriptdir; exec rm -rf $dir; exit 1 }
+    timeout { send_user "glob expansion failed\n"; exit 1 }
 }
 send "exit\r"
 expect {
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }
-cd $scriptdir
-exec rm -rf $dir


### PR DESCRIPTION
## Summary
- run `test_glob.expect` inside a temporary directory
- drop temp directory setup from the test script

## Testing
- `expect -f /workspace/vush/tests/test_glob.expect`
- `make test` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68502b664ca48324b692472d3481ff48