### PR TITLE
Fix apply_modifier trailing copy

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -321,11 +321,10 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
                 pos = vlen;
             }
         }
-        if (pos < vlen)
+        if (pos < vlen) {
             memcpy(res + out, val + pos, vlen - pos);
-        else if (!replaced)
-            ;
-        out += (pos < vlen) ? vlen - pos : 0;
+            out += vlen - pos;
+        }
         res[out] = '\0';
         free(pattern);
         char *ret = strdup(res);


### PR DESCRIPTION
## Summary
- simplify the final copy logic in `apply_modifier`

## Testing
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68502d6b966c83248324099c959c25cb