### PR TITLE
Add for ((init;cond;incr)) loop syntax

### DIFF
--- a/src/parser_clauses.c
+++ b/src/parser_clauses.c
@@ -275,7 +275,11 @@ static Command *parse_for_arith_clause(char **p) {
     char *init, *cond, *incr;
     if (!parse_for_arith_exprs(p, &init, &cond, &incr))
         return NULL;
-    while (**p == ' ' || **p == '\t') (*p)++;
+    while (**p == ' ' || **p == '\t' || **p == '\n') (*p)++;
+    if (**p == ';') {
+        (*p)++;
+        while (**p == ' ' || **p == '\t' || **p == '\n') (*p)++;
+    }
     int q = 0; int de = 1; char *tok = read_token(p, &q, &de);
     if (!tok || strcmp(tok, "do") != 0) { free(init); free(cond); free(incr); free(tok); return NULL; }
     free(tok);

--- a/tests/test_for_arith_nosemi.expect
+++ b/tests/test_for_arith_nosemi.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "for ((i=0; i<3; i=i+1)) do echo \$i; done\r"
+expect {
+    -re "0\[\r\n\]+1\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "arith for output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- support arithmetic `for` loops that omit the trailing semicolon before `do`
- add regression test covering the new form

## Testing
- `make`
- `tests/run_tests.sh tests/test_for_arith_nosemi.expect` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68502b5c5de48324885e95aa4a7d6327