### PR TITLE
Add build directory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Module.symvers
 Mkfile.old
 dkms.conf
 vush
+build/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CC ?= cc
 CFLAGS ?= -Wall -Wextra -std=c99
 PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
+BUILDDIR := build
+OBJDIR := $(BUILDDIR)
 
 .PHONY: clean test install uninstall
 
@@ -18,24 +20,25 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/hash.c src/trap.c src/startup.c src/mail.c src/repl.c \
        src/main.c
 
-OBJS := $(patsubst src/%.c,%.o,$(SRCS))
+OBJS := $(patsubst src/%.c,$(OBJDIR)/%.o,$(SRCS))
 
-vush: $(OBJS)
+$(BUILDDIR)/vush: $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(OBJS)
 
-%.o: src/%.c
+$(OBJDIR)/%.o: src/%.c
+	mkdir -p $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f vush $(OBJS)
+	rm -rf $(BUILDDIR)
 
 
-test: vush
+test: $(BUILDDIR)/vush
 	cd tests && ./run_tests.sh
 
-install: vush
+install: $(BUILDDIR)/vush
 	install -d $(PREFIX)/bin
-	install -m 755 vush $(PREFIX)/bin
+	install -m 755 $(BUILDDIR)/vush $(PREFIX)/bin
 	install -d $(MANPREFIX)/man1
 	install -m 644 docs/vush.1 $(MANPREFIX)/man1
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Use the provided `Makefile` to build the shell:
 make
 ```
 
-The resulting binary will be `./vush`. Remove the binary with:
+The resulting binary will be `build/vush`. Remove the directory with:
 
 ```sh
 make clean


### PR DESCRIPTION
## Summary
- compile objects in `build/` and create `build/vush`
- update install/test rules for new path
- ignore the new build directory
- document new binary location in README

## Testing
- `make clean`
- `make`
- `make test` *(fails: Expect is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685033ec63fc832496cbb8809be8691f