### PR TITLE
Fix special parameter lexing

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -765,7 +765,8 @@ static int handle_param(const char **p, char **out, size_t *outlen) {
         }
     } else {
         const char *q = s + 1;
-        if (*q == '#' || *q == '?' || *q == '*' || *q == '@' || *q == '$' || *q == '!') {
+        if (*q == '#' || *q == '?' || *q == '*' || *q == '@' ||
+            *q == '$' || *q == '!' || *q == '-') {
             q++;
         } else if (isdigit((unsigned char)*q)) {
             q++;

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -298,6 +298,12 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
             /* unmatched, reset pointer for error */
             *p = (char *)start;
         }
+        if (**p == '$' && strchr("#?*@-$!", *(*p + 1))) {
+            if (*len < MAX_LINE - 1) buf[(*len)++] = *(*p)++; /* '$' */
+            if (*len < MAX_LINE - 1) buf[(*len)++] = *(*p)++;
+            first = 0;
+            continue;
+        }
         if (**p == '$' && (isalnum((unsigned char)*(*p + 1)))) {
             if (*len < MAX_LINE - 1)
                 buf[(*len)++] = *(*p)++; /* '$' */


### PR DESCRIPTION
## Summary
- handle `$-` expansion in lexer
- treat special parameters `$-`, `$?`, `$@`, `$*`, etc. as single tokens

## Testing
- `make`
- `./vush -c 'set -e -u; echo $-'`

------
https://chatgpt.com/codex/tasks/task_e_68503da728cc8324a2396c894cc3f1ef