### PR TITLE
Fix zero-length read handling in read builtin

### DIFF
--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -95,8 +95,11 @@ static int read_terminal_line(char *buf, size_t size) {
         do {
             n = read(STDIN_FILENO, &c, 1);
         } while (n == -1 && errno == EINTR);
-        if (n == 0)
+        if (n == 0 || (n > 0 && pos == 0 && c == 0x04)) {
+            errno = 0;
+            last_status = 1;
             return 1; /* EOF */
+        }
         if (n < 0)
             return -1;
         if (c == '\n' || c == '\r')


### PR DESCRIPTION
## Summary
- handle Ctrl-D correctly in `read` builtin
- set `errno` and `last_status` when EOF encountered

## Testing
- `expect -f tests/test_read_eof.expect`

------
https://chatgpt.com/codex/tasks/task_e_68503de6c8148324886a1cb12f495dcc