### PR TITLE
Remove unused variable in apply_modifier

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -302,7 +302,6 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
         if (!res) { free(pattern); return NULL; }
         size_t out = 0;
         size_t pos = 0;
-        int replaced = 0;
         while (pos < vlen) {
             size_t s, l;
             if (find_glob_substring(val + pos, pattern, &s, &l)) {
@@ -311,7 +310,6 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
                 memcpy(res + out, repl, rlen);
                 out += rlen;
                 pos += s + l;
-                replaced = 1;
                 if (!global)
                     break;
             } else {


### PR DESCRIPTION
## Summary
- remove stale `replaced` variable from `apply_modifier`

## Testing
- `make`
- `./tests/run_tests.sh` *(fails: expect scripts hang)*

------
https://chatgpt.com/codex/tasks/task_e_68504782f4c08324b55e88c76a96ce00