### PR TITLE
Fix stray job message

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -100,7 +100,7 @@ int check_jobs_internal(int prefix) {
             curr = curr->next;
 
         if (WIFEXITED(status) || WIFSIGNALED(status)) {
-            if (opt_monitor && opt_notify) {
+            if (curr && opt_monitor && opt_notify) {
                 if (prefix && !printed) {
                     if (prefix == 1)
                         printf("\n");

--- a/tests/test_badcmd_noninteractive.expect
+++ b/tests/test_badcmd_noninteractive.expect
@@ -6,6 +6,7 @@ expect {
     timeout { send_user "missing command not found message\n"; exit 1 }
 }
 expect {
+    -re "\[vush\]" { send_user "unexpected notification\n"; exit 1 }
     eof {}
     timeout { send_user "eof timeout\n"; exit 1 }
 }


### PR DESCRIPTION
## Summary
- avoid printing job completion when the job isn't tracked
- check test output for unexpected job notice in noninteractive mode

## Testing
- `expect -f tests/test_badcmd_noninteractive.expect` (passes)
- `make test` *(fails: FAILed tests and interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68504750ec4c83248351615ce10439a0