### PR TITLE
Refactor test scripts into groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 
 test: $(BUILDDIR)/vush
-	cd tests && ./run_tests.sh
+	cd tests && ./run_tests.sh $(CATEGORY)
 
 install: $(BUILDDIR)/vush
 	install -d $(PREFIX)/bin

--- a/README.md
+++ b/README.md
@@ -272,6 +272,13 @@ Ensure `expect` is installed and run:
 make test
 ```
 
+Run a subset of tests with the `CATEGORY` variable. For example, to run only
+the alias tests:
+
+```sh
+make test CATEGORY=alias
+```
+
 The test scripts under `tests/` will launch `build/vush` with predefined commands and verify the output.
 
 ## Debugging

--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Alias related tests
+tests="
+    test_alias.expect
+    test_alias_flags.expect
+    test_alias_update.expect
+    test_alias_persist.expect
+    test_unalias_a.expect
+    test_custom_aliasfile.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_expansion_tests.sh
+++ b/tests/run_expansion_tests.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Expansion related tests
+tests="
+    test_ps1_cmdsub.expect
+    test_glob.expect
+    test_cmdsub.expect
+    test_cmdsub_regress.expect
+    test_var_brace.expect
+    test_param_expand.expect
+    test_param_inline.expect
+    test_unmatched.expect
+    test_arith.expect
+    test_arith_expr.expect
+    test_arith_complex.expect
+    test_subshell.expect
+    test_brace_group.expect
+    test_array.expect
+    test_brace_expand.expect
+    test_param_replace.expect
+    test_param_substring.expect
+    test_param_error.expect
+    test_pid_params.expect
+    test_base_arith.expect
+    test_dquote_escape.expect
+    test_tilde_user.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_fs_tests.sh
+++ b/tests/run_fs_tests.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# File system related tests
+tests="
+    test_pwd.expect
+    test_cd_dash.expect
+    test_cdpath.expect
+    test_pushd.expect
+    test_dirs.expect
+    test_tilde_user.expect
+    test_completion_path.expect
+    test_vushrc.expect
+    test_ls_l.expect
+    test_noclobber.expect
+    test_umask.expect
+    test_cd_P.expect
+    test_pwd_options.expect
+    test_umask_symbolic.expect
+    test_path_blank.expect
+    test_path_long.expect
+    test_command_v_path_long.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_history_tests.sh
+++ b/tests/run_history_tests.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# History related tests
+tests="
+    test_history.expect
+    test_history_clear.expect
+    test_history_limit.expect
+    test_history_delete.expect
+    test_lineedit.expect
+    test_reverse_search.expect
+    test_forward_search.expect
+    test_custom_histfile.expect
+    test_bang_numeric.expect
+    test_bang_words.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_io_tests.sh
+++ b/tests/run_io_tests.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Input/output related tests
+tests="
+    test_pipe.expect
+    test_redir.expect
+    test_assign_redir.expect
+    test_err_redir.expect
+    test_fd_dup.expect
+    test_heredoc.expect
+    test_herestring.expect
+    test_heredoc_unterminated.expect
+    test_read.expect
+    test_read_eof.expect
+    test_read_signal.expect
+    test_process_sub.expect
+    test_pipefail.expect
+    test_readonly.expect
+    test_heredoc_dash.expect
+    test_heredoc_tabs.expect
+    test_readonly_p.expect
+    test_pipe_cr.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_job_tests.sh
+++ b/tests/run_job_tests.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Job control related tests
+tests="
+    test_fg.expect
+    test_bg.expect
+    test_kill.expect
+    test_jobs.expect
+    test_trap.expect
+    test_wait.expect
+    test_trap_p.expect
+    test_jobs_l.expect
+    test_jobs_p.expect
+    test_kill_s.expect
+    test_kill_l.expect
+    test_kill_l_num.expect
+    test_trap_no_args.expect
+    test_trap_l.expect
+    test_fg_default.expect
+    test_bg_default.expect
+    test_exit_trap.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_loop_tests.sh
+++ b/tests/run_loop_tests.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Loop related tests
+tests="
+    test_for.expect
+    test_for_shellvar.expect
+    test_for_env.expect
+    test_while.expect
+    test_until.expect
+    test_break.expect
+    test_continue.expect
+    test_continue_n.expect
+    test_for_arith.expect
+    test_select.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_misc_tests.sh
+++ b/tests/run_misc_tests.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+set -e
+
+if ! command -v expect >/dev/null; then
+    echo "Expect is not installed. Please install Expect to run tests." >&2
+    exit 1
+fi
+
+if [ ! -x ../build/vush ]; then
+    echo "Error: ../build/vush not found. Please build the project first." >&2
+    exit 1
+fi
+
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export VUSH_FUNCFILE=/dev/null
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+failed=0
+
+# Miscellaneous tests
+tests="
+    test_basic_cmd.expect
+    test_env.expect
+    test_ps1.expect
+    test_export_ps1.expect
+    test_export.expect
+    test_unset.expect
+    test_unset_function.expect
+    test_local.expect
+    test_func_scope.expect
+    test_local_shadow.expect
+    test_script.expect
+    test_script_args.expect
+    test_comments.expect
+    test_source.expect
+    test_sequence.expect
+    test_andor.expect
+    test_status.expect
+    test_badcmd.expect
+    test_badcmd_noninteractive.expect
+    test_completion.expect
+    test_envfile.expect
+    test_type.expect
+    test_dash_c.expect
+    test_dash_c_quotes.expect
+    test_echo_options.expect
+    test_set_options.expect
+    test_nounset.expect
+    test_line_cont.expect
+    test_if.expect
+    test_function.expect
+    test_assign.expect
+    test_case.expect
+    test_exit_trap.expect
+    test_eval.expect
+    test_exec_builtin.expect
+    test_getopts.expect
+    test_test.expect
+    test_cond.expect
+    test_printf.expect
+    test_printf_escapes.expect
+    test_source_args.expect
+    test_time.expect
+    test_times.expect
+    test_command.expect
+    test_command_v.expect
+    test_command_V.expect
+    test_command_p.expect
+    test_true_builtin.expect
+    test_false_builtin.expect
+    test_colon.expect
+    test_hash.expect
+    test_version.expect
+    test_ulimit.expect
+    test_fc.expect
+    test_negate.expect
+    test_command_pv.expect
+    test_command_pV.expect
+    test_export_p.expect
+    test_export_n.expect
+    test_export_p_listing.expect
+    test_export_n_unexport.expect
+    test_set_list.expect
+    test_function_keyword.expect
+    test_test_bool.expect
+    test_time_p.expect
+    test_calloc_fail.expect
+"
+
+for test in $tests; do
+    echo "Running $test"
+    if [ "$test" = "test_glob.expect" ]; then
+        tmpdir=$(mktemp -d)
+        curdir=$(pwd)
+        cd "$tmpdir"
+        if [ -x "$curdir/$test" ]; then
+            cmd="$curdir/$test"
+        else
+            cmd="expect -f $curdir/$test"
+        fi
+        if ! eval "$cmd"; then
+            echo "FAILED: $test"
+            failed=1
+        else
+            echo "PASSED: $test"
+        fi
+        cd "$curdir"
+        rm -rf "$tmpdir"
+        echo
+        continue
+    fi
+    case "$test" in
+        test_history.expect|\
+        test_history_clear.expect|\
+        test_history_limit.expect|\
+        test_history_delete.expect|\
+        test_bang_*|\
+        test_*search.expect|\
+        test_lineedit.expect)
+            rm -f "$HOME/.vush_history"
+            ;;
+    esac
+    if [ -x "$test" ]; then
+        cmd="./$test"
+    else
+        cmd="expect -f $test"
+    fi
+    if ! eval "$cmd"; then
+        echo "FAILED: $test"
+        failed=1
+    else
+        echo "PASSED: $test"
+    fi
+    echo
+done
+exit $failed

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,233 +1,38 @@
 #!/bin/sh
 set -e
 
-if ! command -v expect >/dev/null; then
-    echo "Expect is not installed. Please install Expect to run tests." >&2
-    exit 1
-fi
+USAGE="Usage: $0 [alias|fs|job|history|io|loop|expansion|misc]"
 
-if [ ! -x ../build/vush ]; then
-    echo "Error: ../build/vush not found. Please build the project first." >&2
-    exit 1
-fi
+scripts="alias fs job history io loop expansion misc"
 
-TMP_HOME=$(mktemp -d)
-export HOME="$TMP_HOME"
-export VUSH_FUNCFILE=/dev/null
-trap 'rm -rf "$TMP_HOME"' EXIT
+run_script() {
+    sh "run_${1}_tests.sh" && return 0 || return 1
+}
 
 failed=0
 
-tests="
-    test_basic_cmd.expect
-    test_env.expect
-    test_ps1.expect
-    test_export_ps1.expect
-    test_ps1_cmdsub.expect
-    test_pwd.expect
-    test_cd_dash.expect
-    test_cdpath.expect
-    test_pushd.expect
-    test_dirs.expect
-    test_tilde_user.expect
-    test_export.expect
-    test_unset.expect
-    test_unset_function.expect
-    test_local.expect
-    test_func_scope.expect
-    test_local_shadow.expect
-    test_script.expect
-    test_script_args.expect
-    test_comments.expect
-    test_history.expect
-    test_history_clear.expect
-    test_history_limit.expect
-    test_history_delete.expect
-    test_pipe.expect
-    test_redir.expect
-    test_assign_redir.expect
-    test_source.expect
-    test_fg.expect
-    test_bg.expect
-    test_kill.expect
-    test_sequence.expect
-    test_andor.expect
-    test_glob.expect
-    test_alias.expect
-    test_alias_flags.expect
-    test_alias_update.expect
-    test_alias_persist.expect
-    test_unalias_a.expect
-    test_status.expect
-    test_badcmd.expect
-    test_badcmd_noninteractive.expect
-    test_cmdsub.expect
-    test_cmdsub_regress.expect
-    test_lineedit.expect
-    test_completion.expect
-    test_completion_path.expect
-    test_reverse_search.expect
-    test_forward_search.expect
-    test_err_redir.expect
-    test_fd_dup.expect
-    test_vushrc.expect
-    test_envfile.expect
-    test_var_brace.expect
-    test_param_expand.expect
-    test_param_inline.expect
-    test_unmatched.expect
-    test_jobs.expect
-    test_type.expect
-    test_custom_histfile.expect
-    test_custom_aliasfile.expect
-    test_dash_c.expect
-    test_dash_c_quotes.expect
-    test_echo_options.expect
-    test_set_options.expect
-    test_nounset.expect
-    test_heredoc.expect
-    test_herestring.expect
-    test_heredoc_unterminated.expect
-    test_line_cont.expect
-    test_if.expect
-    test_for.expect
-    test_for_shellvar.expect
-    test_for_env.expect
-    test_while.expect
-    test_until.expect
-    test_function.expect
-    test_assign.expect
-    test_arith.expect
-    test_arith_expr.expect
-    test_arith_complex.expect
-    test_read.expect
-    test_read_eof.expect
-    test_read_signal.expect
-    test_case.expect
-    test_trap.expect
-    test_exit_trap.expect
-    test_eval.expect
-    test_exec_builtin.expect
-    test_getopts.expect
-    test_subshell.expect
-    test_brace_group.expect
-    test_break.expect
-    test_continue.expect
-    test_continue_n.expect
-    test_test.expect
-    test_cond.expect
-    test_ls_l.expect
-    test_process_sub.expect
-    test_array.expect
-    test_brace_expand.expect
-    test_for_arith.expect
-    test_printf.expect
-    test_printf_escapes.expect
-    test_select.expect
-    test_pipefail.expect
-    test_noclobber.expect
-    test_param_replace.expect
-    test_source_args.expect
-    test_bang_numeric.expect
-    test_bang_words.expect
-    test_time.expect
-    test_times.expect
-    test_command.expect
-    test_command_v.expect
-    test_command_V.expect
-    test_command_p.expect
-    test_param_substring.expect
-    test_param_error.expect
-    test_wait.expect
-    test_umask.expect
-    test_true_builtin.expect
-    test_false_builtin.expect
-    test_colon.expect
-    test_readonly.expect
-    test_hash.expect
-    test_heredoc_dash.expect
-    test_heredoc_tabs.expect
-    test_version.expect
-    test_ulimit.expect
-    test_cd_P.expect
-    test_pwd_options.expect
-    test_fc.expect
-    test_trap_p.expect
-    test_pid_params.expect
-    test_negate.expect
-    test_jobs_l.expect
-    test_jobs_p.expect
-    test_kill_s.expect
-    test_command_pv.expect
-    test_command_pV.expect
-    test_kill_l.expect
-    test_kill_l_num.expect
-    test_export_p.expect
-    test_export_n.expect
-    test_export_p_listing.expect
-    test_export_n_unexport.expect
-    test_readonly_p.expect
-    test_trap_no_args.expect
-    test_umask_symbolic.expect
-    test_set_list.expect
-    test_function_keyword.expect
-    test_trap_l.expect
-    test_fg_default.expect
-    test_bg_default.expect
-    test_test_bool.expect
-    test_time_p.expect
-    test_base_arith.expect
-    test_path_blank.expect
-    test_path_long.expect
-    test_command_v_path_long.expect
-    test_dquote_escape.expect
-    test_calloc_fail.expect
-    test_pipe_cr.expect
-"
-for test in $tests; do
-    echo "Running $test"
-    if [ "$test" = "test_glob.expect" ]; then
-        tmpdir=$(mktemp -d)
-        curdir=$(pwd)
-        cd "$tmpdir"
-        if [ -x "$curdir/$test" ]; then
-            cmd="$curdir/$test"
-        else
-            cmd="expect -f $curdir/$test"
-        fi
-        if ! eval "$cmd"; then
-            echo "FAILED: $test"
-            failed=1
-        else
-            echo "PASSED: $test"
-        fi
-        cd "$curdir"
-        rm -rf "$tmpdir"
-        echo
-        continue
-    fi
-    case "$test" in
-        test_history.expect|\
-        test_history_clear.expect|\
-        test_history_limit.expect|\
-        test_history_delete.expect|\
-        test_bang_*|\
-        test_*search.expect|\
-        test_lineedit.expect)
-            rm -f "$HOME/.vush_history"
+if [ $# -gt 1 ]; then
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+if [ $# -eq 1 ]; then
+    cat_name="$1"
+    case "$scripts" in
+        *$cat_name*)
+            run_script "$cat_name" || failed=1
+            ;;
+        *)
+            echo "$USAGE" >&2
+            exit 1
             ;;
     esac
-    if [ -x "$test" ]; then
-        cmd="./$test"
-    else
-        cmd="expect -f $test"
-    fi
-    if ! eval "$cmd"; then
-        echo "FAILED: $test"
-        failed=1
-    else
-        echo "PASSED: $test"
-    fi
-    echo
-done
+else
+    for cat in $scripts; do
+        echo "=== Running $cat tests ==="
+        if ! run_script "$cat"; then
+            failed=1
+        fi
+    done
+fi
 exit $failed


### PR DESCRIPTION
## Summary
- split the huge `run_tests.sh` into themed sub‐scripts
- run the appropriate sub-script based on a category argument
- expose `CATEGORY` variable in `make test`
- document how to run groups of tests

## Testing
- `make test CATEGORY=alias`

------
https://chatgpt.com/codex/tasks/task_e_68504a44a0a08324a3b372a72fcdf1f1