### PR TITLE
Handle realpath failures in cd -P

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -131,21 +131,29 @@ int builtin_cd(char **args) {
 
     if (!searched) {
         const char *path = dir;
+        int unresolved = 0;
         if (physical) {
-            if (!realpath(dir, used)) {
-                perror("cd");
-                return 1;
+            if (realpath(dir, used)) {
+                path = used;
+            } else {
+                unresolved = 1;
             }
-            path = used;
         }
         if (chdir(path) != 0) {
             perror("cd");
             return 1;
         }
-        if (physical)
-            dir = path;
+        if (physical) {
+            if (!unresolved) {
+                dir = path;
+            } else if (getcwd(used, sizeof(used))) {
+                dir = used;
+            }
+        }
     } else if (physical) {
         if (realpath(".", used))
+            dir = used;
+        else if (getcwd(used, sizeof(used)))
             dir = used;
     }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -150,6 +150,7 @@ tests="
     test_version.expect
     test_ulimit.expect
     test_cd_P.expect
+    test_cd_P_dangle.expect
     test_pwd_options.expect
     test_fc.expect
     test_trap_p.expect

--- a/tests/test_cd_P_dangle.expect
+++ b/tests/test_cd_P_dangle.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [exec mktemp -d]
+file mkdir "$dir/real"
+exec ln -s "$dir/real" "$dir/link"
+exec ln -s "$dir/missing" "$dir/real/bad"
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "cd -P $dir/link\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exec rm -rf $dir; exit 1 }
+}
+send "pwd\r"
+expect {
+    -re "\[\r\n\]+$dir/real\[\r\n\]+vush> " {}
+    timeout { send_user "cd -P dangle failed\n"; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- fall back to `getcwd()` when `realpath()` fails in `builtin_cd`
- add regression test for `cd -P` with dangling symlinks

## Testing
- `make -j$(nproc)`
- `expect -f tests/test_cd_P_dangle.expect`

------
https://chatgpt.com/codex/tasks/task_e_68504767749483249fcd5c60af6c5814