### PR TITLE
Fix arithmetic expansion newline handling

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -159,6 +159,8 @@ static char *expand_tilde(const char *token) {
 /* Evaluate an arithmetic expansion token $((expr)) and return its value. */
 static char *expand_arith(const char *token) {
     size_t tlen = strlen(token);
+    while (tlen > 0 && (token[tlen-1] == '\n' || token[tlen-1] == '\r'))
+        tlen--;
     if (!(tlen > 4 && strncmp(token, "$((", 3) == 0 &&
           token[tlen-2] == ')' && token[tlen-1] == ')'))
         return NULL;


### PR DESCRIPTION
## Summary
- avoid trailing newline/carriage return when checking $(( )) tokens

## Testing
- `make`
- `expect -f test_arith.expect` *(fails: basic arithmetic failed)*

------
https://chatgpt.com/codex/tasks/task_e_68506ab2af34832495c4bd8d54d52ed8