### PR TITLE
Fix sourced script argument handling

### DIFF
--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -55,9 +55,12 @@ static int prepare_source_args(char **args, int *old_argc, char ***old_argv,
 
 static void restore_source_args(int old_argc, char **old_argv, int new_argc)
 {
-    for (int i = 0; i <= new_argc; i++)
-        free(script_argv[i]);
-    free(script_argv);
+    (void)new_argc; /* parameters may have shifted */
+    if (script_argv) {
+        for (int i = 0; script_argv[i]; i++)
+            free(script_argv[i]);
+        free(script_argv);
+    }
     script_argv = old_argv;
     script_argc = old_argc;
     getopts_pos = NULL; /* argv replaced; reset getopts pointer */

--- a/tests/test_source_args.expect
+++ b/tests/test_source_args.expect
@@ -13,7 +13,7 @@ expect {
 }
 send "source $script foo bar\r"
 expect {
-    -re "\[\r\n\]+$script,foo,bar,2,foo bar\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+$script,foo,bar,2,foo bar\r?\n$script,bar,,1,bar\r?\nvush> " {}
     timeout { send_user "source args failed\n"; exec rm $script; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- correct cleanup of sourced script argument array
- adjust `test_source_args.expect` to check shifted parameters

## Testing
- `make`
- `expect -f tests/test_source_args.expect`

------
https://chatgpt.com/codex/tasks/task_e_6850781f0f248324b55e6dcdab979d89