### PR TITLE
Fix ulimit limit handling

### DIFF
--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -240,10 +240,15 @@ int builtin_ulimit(char **args)
         last_status = 1;
         return 1;
     }
-    if (hard)
+    if (hard) {
         rl.rlim_max = val;
-    else
+        if (rl.rlim_cur > rl.rlim_max)
+            rl.rlim_cur = rl.rlim_max;
+    } else {
         rl.rlim_cur = val;
+        if (rl.rlim_max < rl.rlim_cur)
+            rl.rlim_max = rl.rlim_cur;
+    }
     if (setrlimit(resource, &rl) != 0) {
         perror("ulimit");
         last_status = 1;

--- a/tests/test_ulimit.expect
+++ b/tests/test_ulimit.expect
@@ -20,6 +20,16 @@ expect {
     -re "\r\n1234\r?\nvush> " {}
     timeout { send_user "ulimit set failed\n"; exit 1 }
 }
+send "ulimit -H -f 1234\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "ulimit -H -f\r"
+expect {
+    -re "\r\n1234\r?\nvush> " {}
+    timeout { send_user "ulimit hard set failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- preserve RLIMIT_FSIZE updates
- ensure both soft and hard limits are tracked
- check hard limit support in `test_ulimit.expect`

## Testing
- `expect -f tests/test_ulimit.expect`

------
https://chatgpt.com/codex/tasks/task_e_6850849184388324bef922d681eb0dfa