### PR TITLE
Fix hash path resolution

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -62,6 +62,11 @@ int hash_add(const char *name) {
     char *path = search_path(name);
     if (!path)
         return -1;
+    char *resolved = realpath(path, NULL);
+    if (resolved) {
+        free(path);
+        path = resolved;
+    }
     struct hash_entry *e = malloc(sizeof(struct hash_entry));
     if (!e) {
         free(path);


### PR DESCRIPTION
## Summary
- resolve command path with `realpath` when adding to hash table

## Testing
- `expect tests/test_hash.expect` *(fails: "foo: command not found")*


------
https://chatgpt.com/codex/tasks/task_e_6850847dfad48324a23765f4ae5ef44f