### PR TITLE
Fix negation with history expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -864,6 +864,8 @@ char *expand_history(const char *line) {
         p++;
     if (*p != '!')
         return strdup(line);
+    if (p[1] == '\0' || isspace((unsigned char)p[1]))
+        return strdup(line);
     const char *bang = p;
     const char *rest;
     char *expansion = NULL;


### PR DESCRIPTION
## Summary
- stop history substitution for `!` followed by whitespace
- confirm negated commands work

## Testing
- `tests/test_negate.expect`

------
https://chatgpt.com/codex/tasks/task_e_685092a026d0832480609fabfc1bd585