### PR TITLE
Fix array parsing and expansions

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -199,8 +199,11 @@ static char *expand_array_element(const char *name, const char *idxstr) {
     } else {
         int idx = atoi(idxstr);
         int alen = 0; char **arr = get_shell_array(name, &alen);
-        if (arr && idx >= 0 && idx < alen)
-            return strdup(arr[idx]);
+        if (arr) {
+            if (idx >= 0 && idx < alen)
+                return strdup(arr[idx]);
+            return strdup("");
+        }
         const char *val = getenv(name);
         if (!val) val = "";
         return strdup(val);

--- a/src/parser_clauses.c
+++ b/src/parser_clauses.c
@@ -94,14 +94,38 @@ static int parse_word_list(char **p, char ***out, int *count) {
     char **words = NULL;
     int c = 0;
     while (1) {
+        int q = 0; int de = 1;
         while (**p == ' ' || **p == '\t') (*p)++;
+        if (**p == ';') {
+            (*p)++;
+            while (**p == ' ' || **p == '\t') (*p)++;
+            char *next = read_token(p, &q, &de);
+            if (!next) {
+                for (int i = 0; i < c; i++)
+                    free(words[i]);
+                free(words);
+                return -1;
+            }
+            if (!q && strcmp(next, "do") == 0) { free(next); break; }
+            char **tmp = realloc(words, sizeof(char *) * (c + 1));
+            if (!tmp) {
+                free(next);
+                for (int i = 0; i < c; i++)
+                    free(words[i]);
+                free(words);
+                return -1;
+            }
+            words = tmp;
+            words[c++] = next;
+            continue;
+        }
         if (**p == '\0') {
             for (int i = 0; i < c; i++)
                 free(words[i]);
             free(words);
             return -1;
         }
-        int q = 0; int de = 1;
+        q = 0; de = 1;
         char *w = read_token(p, &q, &de);
         if (!w) {
             for (int i = 0; i < c; i++)

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -470,9 +470,17 @@ static int handle_assignment_or_alias(PipelineSegment *seg, int *argc, char **p,
             int parens = 1;
             char *tmp;
             do {
+                while (**p == ' ' || **p == '\t') (*p)++;
                 int q2 = 0; int de2 = 1;
                 tmp = read_token(p, &q2, &de2);
                 if (!tmp) { free(assign); free(tok); return -1; }
+                if (*tmp == '\0') {
+                    free(tmp);
+                    free(assign);
+                    free(tok);
+                    parse_need_more = 1;
+                    return -1;
+                }
                 alloc += strlen(tmp) + 1;
                 char *new_assign = realloc(assign, alloc);
                 if (!new_assign) { free(assign); free(tmp); free(tok); return -1; }


### PR DESCRIPTION
## Summary
- handle whitespace when gathering array assignments
- avoid infinite loops on incomplete array assignment
- improve array element expansion
- parse for loop word lists correctly
- expand `for` loop words at runtime

## Testing
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_685092910dac832483d2ecc6f8785002