### PR TITLE
Improve arithmetic error handling

### DIFF
--- a/src/arith.h
+++ b/src/arith.h
@@ -1,6 +1,6 @@
 #ifndef ARITH_H
 #define ARITH_H
 
-long eval_arith(const char *expr);
+long eval_arith(const char *expr, int *err);
 
 #endif /* ARITH_H */

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -215,8 +215,9 @@ int builtin_let(char **args) {
             strcat(expr, " ");
         strncat(expr, args[i], sizeof(expr) - strlen(expr) - 1);
     }
-    long val = eval_arith(expr);
-    last_status = (val != 0) ? 0 : 1;
+    int err = 0;
+    long val = eval_arith(expr, &err);
+    last_status = err ? 1 : (val != 0 ? 0 : 1);
     return 1;
 }
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -947,14 +947,14 @@ static int exec_select(Command *cmd, const char *line) {
 static int exec_for_arith(Command *cmd, const char *line) {
     (void)line;
     loop_depth++;
-    eval_arith(cmd->arith_init ? cmd->arith_init : "0");
+    eval_arith(cmd->arith_init ? cmd->arith_init : "0", NULL);
     while (1) {
-        long cond = eval_arith(cmd->arith_cond ? cmd->arith_cond : "1");
+        long cond = eval_arith(cmd->arith_cond ? cmd->arith_cond : "1", NULL);
         if (cond == 0)
             break;
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        eval_arith(cmd->arith_update ? cmd->arith_update : "0");
+        eval_arith(cmd->arith_update ? cmd->arith_update : "0", NULL);
         if (loop_continue) {
             if (--loop_continue) {
                 loop_depth--;

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -166,7 +166,7 @@ static char *expand_arith(const char *token) {
         return NULL;
     char *expr = strndup(token + 3, tlen - 5);
     if (!expr) return strdup("");
-    long val = eval_arith(expr);
+    long val = eval_arith(expr, NULL);
     free(expr);
     char buf[32];
     snprintf(buf, sizeof(buf), "%ld", val);

--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -50,6 +50,16 @@ expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "let failure failed\n"; exit 1 }
 }
+send "let 1+\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo $?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "let error failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- surface parser errors from `eval_arith`
- update `let` builtin to fail on invalid arithmetic
- pass `NULL` error flag in other callers
- add tests for failing arithmetic expressions

## Testing
- `make`
- `expect -f tests/test_arith.expect` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6850b549651083248150a04cc302bb92