### PR TITLE
Fix division by zero checks in arithmetic parser

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -110,9 +110,21 @@ static long parse_mul(const char **s) {
         if (op == '*' || op == '/' || op == '%') {
             (*s)++;
             long rhs = parse_unary(s);
-            if (op == '*') v *= rhs;
-            else if (op == '/') v /= rhs;
-            else v %= rhs;
+            if (op == '*') {
+                v *= rhs;
+            } else if (op == '/') {
+                if (rhs == 0) {
+                    parse_error = 1;
+                    return 0;
+                }
+                v /= rhs;
+            } else {
+                if (rhs == 0) {
+                    parse_error = 1;
+                    return 0;
+                }
+                v %= rhs;
+            }
         } else break;
     }
     return v;

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -166,8 +166,13 @@ static char *expand_arith(const char *token) {
         return NULL;
     char *expr = strndup(token + 3, tlen - 5);
     if (!expr) return strdup("");
-    long val = eval_arith(expr, NULL);
+    int err = 0;
+    long val = eval_arith(expr, &err);
     free(expr);
+    if (err) {
+        param_error = 1;
+        last_status = 1;
+    }
     char buf[32];
     snprintf(buf, sizeof(buf), "%ld", val);
     return strdup(buf);

--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -60,6 +60,26 @@ expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "let error failed\n"; exit 1 }
 }
+send "let 1/0\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo $?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "let divide by zero failed\n"; exit 1 }
+}
+send {echo $((5 % 0))\r}
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "arith expand divide by zero output\n"; exit 1 }
+}
+send "echo $?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "arith expand status failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- avoid SIGFPE in `parse_mul` by checking divisor/modulus
- propagate arithmetic errors during `$(( ))` expansion
- add regression tests covering divide-by-zero

## Testing
- `make test` *(fails: send: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6850b73723b08324bd8623ca4b2c66a2