### PR TITLE
Preserve escaped double quotes in variable expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -828,7 +828,20 @@ char *expand_var(const char *token) {
         memcpy(inner, token + 1, innerlen);
         inner[innerlen] = '\0';
         char *res = expand_var(inner);
-        return res;
+        if (!res)
+            return NULL;
+        char *quoted = malloc(strlen(res) + 3);
+        if (!quoted) {
+            free(res);
+            return NULL;
+        }
+        quoted[0] = '"';
+        strcpy(quoted + 1, res);
+        size_t rlen = strlen(res);
+        quoted[rlen + 1] = '"';
+        quoted[rlen + 2] = '\0';
+        free(res);
+        return quoted;
     }
 
     char *out = calloc(1, 1);

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -280,7 +280,8 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
         }
         if (**p == '\\') {
             if (disable_first && *(*p + 1) == '"') {
-                /* Treat \"...\" in unquoted context as a quoted segment */
+                /* Treat \"...\" in unquoted context as a quoted segment but
+                 * preserve the quote characters. */
                 char *start = *p + 2; /* skip opening \" */
                 char *end = strstr(start, "\\\"");
                 if (!end) {
@@ -301,8 +302,12 @@ static int read_simple_token(char **p, int (*is_end)(int), char buf[],
                 char *part = parse_quoted_word(&tp, &q, &de);
                 if (!part)
                     return -1;
+                if (*len < MAX_LINE - 1)
+                    buf[(*len)++] = '"';
                 for (int ci = 0; part[ci] && *len < MAX_LINE - 1; ci++)
                     buf[(*len)++] = part[ci];
+                if (*len < MAX_LINE - 1)
+                    buf[(*len)++] = '"';
                 free(part);
                 *p = end + 2; /* skip closing \" */
                 *do_expand = de;


### PR DESCRIPTION
## Summary
- keep literal quotes when parsing `\"...\"`
- wrap expanded result in quotes when token starts and ends with `"`
- update variable expansion accordingly

## Testing
- `tests/test_dquote_escape.expect`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6850ee14c5ec83248785674434b4c9b3