### PR TITLE
Fix fc test history state

### DIFF
--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -175,7 +175,8 @@ for test in $tests; do
         test_history_delete.expect|\
         test_bang_*|\
         test_*search.expect|\
-        test_lineedit.expect)
+        test_lineedit.expect|\
+        test_fc.expect)
             rm -f "$HOME/.vush_history"
             ;;
     esac


### PR DESCRIPTION
## Summary
- ensure fc test uses a fresh history file to keep numbering stable

## Testing
- `expect -f tests/test_fc.expect`

------
https://chatgpt.com/codex/tasks/task_e_6850ee2a43b88324b5b306df7f1d216a