### PR TITLE
Fix umask symbolic test

### DIFF
--- a/tests/test_umask_symbolic.expect
+++ b/tests/test_umask_symbolic.expect
@@ -22,7 +22,7 @@ expect {
 }
 send "umask\r"
 expect {
-    -re "\[\r\n\]+0077\[\r\n\]+vush> " {}
+    -re "\[\r\n\]+0027\[\r\n\]+vush> " {}
     timeout { send_user "umask symbolic set failed\n"; exit 1 }
 }
 send "umask $old\r"


### PR DESCRIPTION
## Summary
- correct numeric expectation when setting symbolic umask

## Testing
- `expect tests/test_umask_symbolic.expect`

------
https://chatgpt.com/codex/tasks/task_e_6850ee31192883248e5c1b1b2057f315