### PR TITLE
Fix tilde expansion for newly added users

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -142,8 +142,16 @@ static char *expand_tilde(const char *token) {
         size_t len = slash ? (size_t)(slash - rest) : strlen(rest);
         char *user = strndup(rest, len);
         if (user) {
+            endpwent();
             struct passwd *pw = getpwnam(user);
-            if (pw) home = pw->pw_dir;
+            if (pw) {
+                home = pw->pw_dir;
+            } else {
+                fprintf(stderr, "cd: %s: no such user\n", user);
+                last_status = 1;
+                free(user);
+                return NULL;
+            }
             free(user);
         }
         rest = slash ? slash : rest + len;


### PR DESCRIPTION
## Summary
- refresh passwd cache before resolving `~user`
- print a diagnostic when the user can't be found
- return `NULL` so builtins see the failure

## Testing
- `make`
- `cd tests && expect -f test_tilde_user.expect`

------
https://chatgpt.com/codex/tasks/task_e_6850f43ca69c8324bae713e8bbaccf74