### PR TITLE
Fix break propagation in for loops

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -869,16 +869,16 @@ static int exec_for(Command *cmd, const char *line) {
                 setenv(cmd->var, w, 1);
             }
             run_command_list(cmd->body, line);
-            if (loop_break) { loop_break--; break; }
+            if (loop_break) break;
             if (loop_continue) {
                 if (--loop_continue) { free(exp); loop_depth--; return last_status; }
-                w = strtok_r(NULL, " \t", &save);
-                continue;
+                    w = strtok_r(NULL, " \t", &save);
+                    continue;
             }
             w = strtok_r(NULL, " \t", &save);
         }
         free(exp);
-        if (loop_break) break;
+        if (loop_break) { loop_break--; break; }
     }
     loop_depth--;
     return last_status;


### PR DESCRIPTION
## Summary
- ensure builtin_break sets loop_break
- fix for-loop logic so break exits loop immediately
- verify with regression test

## Testing
- `make -j$(nproc)`
- `cd tests && ./test_break.expect` *(passed)*
- `make test` *(fails: `send: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_6850f44b36a4832490b53e4b3643d537