### PR TITLE
Add logical operators and unary updates

### DIFF
--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -80,6 +80,46 @@ expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "arith expand status failed\n"; exit 1 }
 }
+send {echo $((!0))\r}
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "unary not failed\n"; exit 1 }
+}
+send {echo $((~0))\r}
+expect {
+    -re "\[\r\n\]+-1\[\r\n\]+vush> " {}
+    timeout { send_user "bitwise not failed\n"; exit 1 }
+}
+send {echo $((1 && 0))\r}
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "logical and failed\n"; exit 1 }
+}
+send {echo $((1 || 0))\r}
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "logical or failed\n"; exit 1 }
+}
+send "I=1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send {echo $((I++))\r}
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "postfix increment failed\n"; exit 1 }
+}
+send {echo $I\r}
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "postfix increment value failed\n"; exit 1 }
+}
+send {echo $((++I))\r}
+expect {
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
+    timeout { send_user "prefix increment failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}

--- a/tests/test_arith_complex.expect
+++ b/tests/test_arith_complex.expect
@@ -15,6 +15,11 @@ expect {
     -re "\[\r\n\]+9\[\r\n\]+vush> " {}
     timeout { send_user "complex arithmetic failed\n"; exit 1 }
 }
+send {echo $(((1 && 2) || 0))\r}
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "logical expression failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}

--- a/tests/test_arith_expr.expect
+++ b/tests/test_arith_expr.expect
@@ -10,6 +10,26 @@ expect {
     -re "\[\r\n\]+3\[\r\n\]+vush> " {}
     timeout { send_user "arithmetic expansion failed\n"; exit 1 }
 }
+send "D=3\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send {echo $((--D))\r}
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "prefix decrement failed\n"; exit 1 }
+}
+send {echo $((D--))\r}
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "postfix decrement failed\n"; exit 1 }
+}
+send {echo $D\r}
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "decrement value failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- add logical AND/OR parsing levels
- implement unary `!` and `~`
- support prefix and postfix `++`/`--`
- update grammar doc in `arith.c`
- extend arithmetic expect tests for new operators

## Testing
- `make -j4`
- `cd tests && ./run_tests.sh` *(fails: `while executing "send \"ulimit -H -f 1234\r\"" (file "./test_ulimit.expect" line 23))*

------
https://chatgpt.com/codex/tasks/task_e_685187bb8e548324b2e9c7e11f668697