### PR TITLE
Improve arithmetic error reporting

### DIFF
--- a/src/arith.h
+++ b/src/arith.h
@@ -4,6 +4,7 @@
 typedef struct ArithState {
     const char *p;
     int err;
+    char err_msg[64];
 } ArithState;
 
 long long eval_arith(const char *expr, int *err);

--- a/src/execute.c
+++ b/src/execute.c
@@ -927,15 +927,23 @@ static int exec_select(Command *cmd, const char *line) {
  */
 static int exec_for_arith(Command *cmd, const char *line) {
     (void)line;
+    int err = 0;
     loop_depth++;
-    eval_arith(cmd->arith_init ? cmd->arith_init : "0", NULL);
+    eval_arith(cmd->arith_init ? cmd->arith_init : "0", &err);
+    if (err) {
+        last_status = 1;
+        loop_depth--;
+        return last_status;
+    }
     while (1) {
-        long cond = eval_arith(cmd->arith_cond ? cmd->arith_cond : "1", NULL);
+        long cond = eval_arith(cmd->arith_cond ? cmd->arith_cond : "1", &err);
+        if (err) { last_status = 1; break; }
         if (cond == 0)
             break;
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        eval_arith(cmd->arith_update ? cmd->arith_update : "0", NULL);
+        eval_arith(cmd->arith_update ? cmd->arith_update : "0", &err);
+        if (err) { last_status = 1; break; }
         if (loop_continue) {
             if (--loop_continue) {
                 loop_depth--;


### PR DESCRIPTION
## Summary
- store arithmetic error messages in `ArithState`
- print detailed messages in `eval_arith`
- fail arithmetic `for` loops on evaluation errors

## Testing
- `make -j4`
- `make test` *(fails: `send: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_68518aabc5008324a7643e39025b8342