### PR TITLE
Improve arithmetic for-loop error handling

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -929,29 +929,39 @@ static int exec_for_arith(Command *cmd, const char *line) {
     (void)line;
     int err = 0;
     loop_depth++;
+
     eval_arith(cmd->arith_init ? cmd->arith_init : "0", &err);
     if (err) {
         last_status = 1;
         loop_depth--;
         return last_status;
     }
+
     while (1) {
+        err = 0;
         long cond = eval_arith(cmd->arith_cond ? cmd->arith_cond : "1", &err);
         if (err) { last_status = 1; break; }
         if (cond == 0)
             break;
+
         run_command_list(cmd->body, line);
         if (loop_break) { loop_break--; break; }
-        eval_arith(cmd->arith_update ? cmd->arith_update : "0", &err);
-        if (err) { last_status = 1; break; }
         if (loop_continue) {
             if (--loop_continue) {
                 loop_depth--;
                 return last_status;
             }
+            err = 0;
+            eval_arith(cmd->arith_update ? cmd->arith_update : "0", &err);
+            if (err) { last_status = 1; break; }
             continue;
         }
+
+        err = 0;
+        eval_arith(cmd->arith_update ? cmd->arith_update : "0", &err);
+        if (err) { last_status = 1; break; }
     }
+
     loop_depth--;
     return last_status;
 }

--- a/tests/test_for_arith.expect
+++ b/tests/test_for_arith.expect
@@ -10,6 +10,32 @@ expect {
     -re "0\[\r\n\]+1\[\r\n\]+2\[\r\n\]+vush> " {}
     timeout { send_user "arith for output mismatch\n"; exit 1 }
 }
+
+# nested continue
+send "for ((i=0; i<2; i++)); do echo start\$i; for ((j=0; j<2; j++)); do continue 2; done; echo end\$i; done\r"
+expect {
+    -re "start0\r\nstart1\r\nvush> " {}
+    timeout { send_user "arith continue2 failed\n"; exit 1 }
+}
+
+# nested break
+send "for ((i=0; i<2; i++)); do echo bstart\$i; for ((j=0; j<2; j++)); do break 2; done; echo bend\$i; done; echo done\r"
+expect {
+    -re "bstart0\r\ndone\r\nvush> " {}
+    timeout { send_user "arith break2 failed\n"; exit 1 }
+}
+
+# arithmetic error aborts loop
+send "for ((i=0/0; i<3; i++)); do :; done\r"
+expect {
+    "vush> " {}
+    timeout { send_user "arith init error prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "1\r\nvush> " {}
+    timeout { send_user "arith init error status\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- handle errors from all arithmetic phases in `exec_for_arith`
- correctly process nested `continue`/`break` for arithmetic loops
- extend `test_for_arith.expect` to cover nested loop behaviour and error handling

## Testing
- `make`
- `expect -f tests/test_for_arith.expect`

------
https://chatgpt.com/codex/tasks/task_e_68518c6b95488324a6bb9852b7369402