### PR TITLE
Add subtraction and shift overflow checks

### DIFF
--- a/tests/test_arith_overflow.expect
+++ b/tests/test_arith_overflow.expect
@@ -38,6 +38,28 @@ expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "let overflow status\n"; exit 1 }
 }
+# subtraction overflow
+send {echo $((9223372036854775807 - -1))\r}
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "subtraction overflow output\n"; exit 1 }
+}
+send "echo $?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "subtraction overflow status\n"; exit 1 }
+}
+# left shift overflow
+send {echo $((1 << 63))\r}
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "lshift overflow output\n"; exit 1 }
+}
+send "echo $?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "lshift overflow status\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- add `sub_overflow` helper in `arith.c`
- detect overflow for left and right shifts
- test subtraction and shift overflow in arithmetic evaluation

## Testing
- `make`
- `tests/run_tests.sh` *(fails: test_var_brace.expect, test_arith.expect, test_arith_expr.expect, test_arith_complex.expect, test_arith_overflow.expect, test_arith_quote_parens.expect, test_bitwise.expect, test_ulimit.expect)*

------
https://chatgpt.com/codex/tasks/task_e_685191d82f9c8324ba304e5c3674e50c