### PR TITLE
Return arithmetic error messages

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 /*
  * Simple arithmetic expression evaluator used by the shell.
  *
@@ -563,7 +564,7 @@ static long long parse_expression(ArithState *state) {
  * Evaluate an arithmetic expression contained in 'expr'.
  * Returns the resulting long long value; does not modify 'expr'.
  */
-long long eval_arith(const char *expr, int *err) {
+long long eval_arith(const char *expr, int *err, char **errmsg) {
     ArithState st = { .p = expr, .err = 0, .err_msg = "" };
     current_state = &st;
     long long result = parse_expression(&st);
@@ -582,8 +583,13 @@ long long eval_arith(const char *expr, int *err) {
     current_state = NULL;
     if (err)
         *err = st.err;
+    if (errmsg)
+        *errmsg = NULL;
     if (st.err) {
-        fprintf(stderr, "arith: %s\n", st.err_msg[0] ? st.err_msg : "error");
+        if (errmsg)
+            *errmsg = strdup(st.err_msg[0] ? st.err_msg : "error");
+        else
+            fprintf(stderr, "arith: %s\n", st.err_msg[0] ? st.err_msg : "error");
         return 0;
     }
     return result;

--- a/src/arith.h
+++ b/src/arith.h
@@ -7,6 +7,6 @@ typedef struct ArithState {
     char err_msg[64];
 } ArithState;
 
-long long eval_arith(const char *expr, int *err);
+long long eval_arith(const char *expr, int *err, char **errmsg);
 
 #endif /* ARITH_H */

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -214,7 +214,12 @@ int builtin_let(char **args) {
         strncat(expr, args[i], sizeof(expr) - strlen(expr) - 1);
     }
     int err = 0;
-    long val = eval_arith(expr, &err);
+    char *msg = NULL;
+    long val = eval_arith(expr, &err, &msg);
+    if (err && msg) {
+        fprintf(stderr, "arith: %s\n", msg);
+        free(msg);
+    }
     last_status = err ? 1 : (val != 0 ? 0 : 1);
     return 1;
 }

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -176,9 +176,14 @@ static char *expand_arith(const char *token) {
     char *expr = strndup(token + 3, tlen - 5);
     if (!expr) return strdup("");
     int err = 0;
-    long val = eval_arith(expr, &err);
+    char *msg = NULL;
+    long val = eval_arith(expr, &err, &msg);
     free(expr);
     if (err) {
+        if (msg) {
+            fprintf(stderr, "arith: %s\n", msg);
+            free(msg);
+        }
         param_error = 1;
         last_status = 1;
     }

--- a/tests/test_arith.expect
+++ b/tests/test_arith.expect
@@ -52,6 +52,10 @@ expect {
 }
 send "let 1+\r"
 expect {
+    -re "arith: invalid number\r\n" {}
+    timeout { send_user "arith error message missing\n"; exit 1 }
+}
+expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
@@ -61,6 +65,10 @@ expect {
     timeout { send_user "let error failed\n"; exit 1 }
 }
 send "let 1/0\r"
+expect {
+    -re "arith: divide by zero\r\n" {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -72,8 +80,12 @@ expect {
 }
 send {echo $((5 % 0))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: divide by zero\r\n0\r\n" {}
     timeout { send_user "arith expand divide by zero output\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
 }
 send "echo $?\r"
 expect {

--- a/tests/test_arith_invalid.expect
+++ b/tests/test_arith_invalid.expect
@@ -12,7 +12,7 @@ expect {
 }
 send {echo $((X))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: invalid number\r\n0\r\n" {}
     timeout { send_user "invalid number output\n"; exit 1 }
 }
 send "echo $?\r"

--- a/tests/test_arith_overflow.expect
+++ b/tests/test_arith_overflow.expect
@@ -8,7 +8,7 @@ expect {
 # numeric literal overflow
 send {echo $((9223372036854775808))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: overflow\r\n0\r\n" {}
     timeout { send_user "literal overflow output\n"; exit 1 }
 }
 send "echo $?\r"
@@ -19,7 +19,7 @@ expect {
 # addition overflow
 send {echo $((9223372036854775807 + 1))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: overflow\r\n0\r\n" {}
     timeout { send_user "addition overflow output\n"; exit 1 }
 }
 send "echo $?\r"
@@ -29,6 +29,10 @@ expect {
 }
 # let builtin overflow
 send {let 9223372036854775807 + 1\r}
+expect {
+    -re "arith: overflow\r\n" {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
@@ -41,7 +45,7 @@ expect {
 # subtraction overflow
 send {echo $((9223372036854775807 - -1))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: overflow\r\n0\r\n" {}
     timeout { send_user "subtraction overflow output\n"; exit 1 }
 }
 send "echo $?\r"
@@ -52,7 +56,7 @@ expect {
 # left shift overflow
 send {echo $((1 << 63))\r}
 expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    -re "arith: overflow\r\n0\r\n" {}
     timeout { send_user "lshift overflow output\n"; exit 1 }
 }
 send "echo $?\r"

--- a/tests/test_for_arith.expect
+++ b/tests/test_for_arith.expect
@@ -28,6 +28,10 @@ expect {
 # arithmetic error aborts loop
 send "for ((i=0/0; i<3; i++)); do :; done\r"
 expect {
+    -re "arith: divide by zero\r\n" {}
+    timeout { send_user "arith init error message\n"; exit 1 }
+}
+expect {
     "vush> " {}
     timeout { send_user "arith init error prompt timeout\n"; exit 1 }
 }


### PR DESCRIPTION
## Summary
- modify `eval_arith` to return an allocated error string instead of printing
- print error messages at call sites (`let`, arithmetic expansion, loops, and `(( ))`)
- update tests to check for single error messages

## Testing
- `make`
- `cd tests && ./run_tests.sh` *(fails: `send: spawn id exp4 not open` in test_ulimit.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6851a7aa3eb08324be19715f4ae91457