### PR TITLE
Add arithmetic expect tests

### DIFF
--- a/tests/arithmetic_basic.expect
+++ b/tests/arithmetic_basic.expect
@@ -1,0 +1,56 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# addition
+send "echo \$((1 + 2))\r"
+expect {
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
+    timeout { send_user "addition failed\n"; exit 1 }
+}
+# subtraction with variable
+send "num=8\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$((num - 3))\r"
+expect {
+    -re "\[\r\n\]+5\[\r\n\]+vush> " {}
+    timeout { send_user "variable subtraction failed\n"; exit 1 }
+}
+# let modifies variable and sets status
+send "let num=num+1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$num\r"
+expect {
+    -re "\[\r\n\]+9\[\r\n\]+vush> " {}
+    timeout { send_user "let result mismatch\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "let status mismatch\n"; exit 1 }
+}
+# let returning zero
+send "let 0\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "let zero status mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/arithmetic_cmd.expect
+++ b/tests/arithmetic_cmd.expect
@@ -1,0 +1,60 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# non-zero arithmetic result
+send "((1 + 1))\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "non-zero status mismatch\n"; exit 1 }
+}
+# variable usage yielding zero
+send "val=3\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "(( val -= 3 ))\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "zero status mismatch\n"; exit 1 }
+}
+send "echo \$val\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "variable update mismatch\n"; exit 1 }
+}
+# another non-zero result
+send "(( val += 5 ))\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "non-zero status mismatch\n"; exit 1 }
+}
+send "echo \$val\r"
+expect {
+    -re "\[\r\n\]+5\[\r\n\]+vush> " {}
+    timeout { send_user "variable update mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -137,6 +137,8 @@ test_command_v_path_long.expect
 test_dquote_escape.expect
 test_calloc_fail.expect
 test_fc_fork_fail.expect
+arithmetic_basic.expect
+arithmetic_cmd.expect
 test_pipe_cr.expect
 "
 for test in $tests; do


### PR DESCRIPTION
## Summary
- add `arithmetic_basic.expect` to cover arithmetic expansions and `let`
- add `arithmetic_cmd.expect` to verify `(( ))` command behaviour
- run the new tests from `run_builtins_tests.sh`

## Testing
- `make test` *(fails: send: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6851b17f64808324bdfb83a0e7faf1f6