### PR TITLE
Add arithmetic error and overflow tests

### DIFF
--- a/tests/arithmetic_errors.expect
+++ b/tests/arithmetic_errors.expect
@@ -1,0 +1,57 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# invalid variable assignment with trailing letters
+send "echo \$((X=123abc))\r"
+expect {
+    -re "syntax error" {}
+    timeout { send_user "missing syntax error\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+# invalid numeric base
+send "echo \$((1#123))\r"
+expect {
+    -re "invalid base" {}
+    timeout { send_user "missing invalid base error\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+# divide by zero
+send "echo \$((1/0))\r"
+expect {
+    -re "divide by zero" {}
+    timeout { send_user "missing divide by zero error\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/arithmetic_overflow.expect
+++ b/tests/arithmetic_overflow.expect
@@ -1,0 +1,57 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# overflow when parsing literal
+send "echo \$((9223372036854775808))\r"
+expect {
+    -re "overflow" {}
+    timeout { send_user "missing literal overflow\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+# overflow via shift
+send "echo \$((1<<63))\r"
+expect {
+    -re "overflow" {}
+    timeout { send_user "missing shift overflow\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+# overflow via addition
+send "echo \$((9223372036854775807 + 1))\r"
+expect {
+    -re "overflow" {}
+    timeout { send_user "missing addition overflow\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -139,6 +139,8 @@ test_calloc_fail.expect
 test_fc_fork_fail.expect
 arithmetic_basic.expect
 arithmetic_cmd.expect
+arithmetic_errors.expect
+arithmetic_overflow.expect
 test_pipe_cr.expect
 "
 for test in $tests; do


### PR DESCRIPTION
## Summary
- add `arithmetic_errors.expect` for invalid inputs and divide by zero
- add `arithmetic_overflow.expect` for overflow conditions
- run these new tests in `run_builtins_tests.sh`

## Testing
- `make test` *(fails: FAILED: test_var_brace.expect, FAILED: test_ps1.expect, FAILED: test_ulimit.expect, FAILED: arithmetic_cmd.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6851b37df1f48324b58a9ad853b3d505