### PR TITLE
Add arithmetic for loop expect test

### DIFF
--- a/tests/arithmetic_forloop.expect
+++ b/tests/arithmetic_forloop.expect
@@ -1,0 +1,30 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# simple arithmetic for loop
+send "for ((i=0; i<3; i++)); do echo \$i; done\r"
+expect {
+    -re "0\[\r\n\]+1\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "arith for output mismatch\n"; exit 1 }
+}
+# break inside arithmetic for loop
+send "for ((i=0; i<3; i++)); do echo \$i; break; done\r"
+expect {
+    -re "0\[\r\n\]+vush> " {}
+    timeout { send_user "arith for break failed\n"; exit 1 }
+}
+# continue inside arithmetic for loop
+send "for ((i=0; i<3; i++)); do if test \$i -eq 1; then continue; fi; echo \$i; done\r"
+expect {
+    -re "0\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "arith for continue failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -141,6 +141,7 @@ arithmetic_basic.expect
 arithmetic_cmd.expect
 arithmetic_errors.expect
 arithmetic_overflow.expect
+arithmetic_forloop.expect
 test_pipe_cr.expect
 "
 for test in $tests; do


### PR DESCRIPTION
## Summary
- add test to check arithmetic C-style loops
- run the new test as part of builtin tests

## Testing
- `make test` *(fails: test_var_brace.expect, test_ulimit.expect, arithmetic_cmd.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5090e308324a1761770ffb98941