### PR TITLE
Ensure bg uses last job info and add regression test

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -711,7 +711,12 @@ static int run_pipeline_internal(PipelineSegment *pipeline, int background, cons
         cleanup_proc_subs();
         return last_status;
     }
-    int r = spawn_pipeline_segments(copy, background, line);
+    char *job_line = NULL;
+    if (background)
+        job_line = pipeline_to_str(copy);
+    int r = spawn_pipeline_segments(copy, background,
+                                    job_line ? job_line : line);
+    free(job_line);
     if (param_error)
         last_status = 1;
     free_pipeline(copy);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -30,6 +30,37 @@ extern int last_status;
 extern void setup_redirections(PipelineSegment *seg);
 
 /*
+ * Convert a pipeline into a simplified command string for job tracking.
+ * Tokens are concatenated with spaces and segments are separated with "|".
+ */
+char *pipeline_to_str(PipelineSegment *pipeline) {
+    size_t len = 0;
+    for (PipelineSegment *seg = pipeline; seg; seg = seg->next) {
+        if (seg != pipeline)
+            len += 2; /* for "| " */
+        for (int i = 0; seg->argv[i]; i++) {
+            len += strlen(seg->argv[i]) + 1;
+        }
+    }
+    char *out = malloc(len + 1);
+    if (!out)
+        return NULL;
+    out[0] = '\0';
+    for (PipelineSegment *seg = pipeline; seg; seg = seg->next) {
+        if (seg != pipeline)
+            strcat(out, "| ");
+        for (int i = 0; seg->argv[i]; i++) {
+            strcat(out, seg->argv[i]);
+            if (seg->argv[i + 1])
+                strcat(out, " ");
+        }
+        if (seg->next)
+            strcat(out, " ");
+    }
+    return out;
+}
+
+/*
  * Configure the child's standard input and output.
  *
  * If 'in_fd' is valid it becomes the child's stdin.  When the segment has a

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -18,4 +18,7 @@ pid_t fork_segment(PipelineSegment *seg, int *in_fd);
  * is recorded using LINE instead of blocking. */
 void wait_for_pipeline(pid_t *pids, int count, int background, const char *line);
 
+/* Convert PIPELINE into a space-separated string suitable for job display. */
+char *pipeline_to_str(PipelineSegment *pipeline);
+
 #endif /* PIPELINE_H */

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -37,6 +37,7 @@ test_redir.expect
 test_source.expect
 test_fg.expect
 test_bg.expect
+test_bg_chain.expect
 test_kill.expect
 test_sequence.expect
 test_andor.expect

--- a/tests/test_bg_chain.expect
+++ b/tests/test_bg_chain.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 6
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 2 &; kill -SIGSTOP 1; bg\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 2 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "bg chain output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- generate proper job command strings for background tasks
- call pipeline_to_str when launching background pipelines
- include new bg_chain.expect test
- run bg_chain.expect as part of builtins tests

## Testing
- `make` (builds vush)
- `./tests/test_bg_chain.expect`

------
https://chatgpt.com/codex/tasks/task_e_6851bf2650888324a4f676f91e266bf4