### PR TITLE
Add array index arithmetic

### DIFF
--- a/src/vars.h
+++ b/src/vars.h
@@ -5,6 +5,7 @@ const char *get_shell_var(const char *name);
 char **get_shell_array(const char *name, int *len);
 void set_shell_var(const char *name, const char *value);
 void set_shell_array(const char *name, char **values, int count);
+void set_shell_array_index(const char *name, int idx, const char *value);
 void unset_shell_var(const char *name);
 void free_shell_vars(void);
 /*

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -92,6 +92,8 @@ test_cond.expect
 test_ls_l.expect
 test_process_sub.expect
 test_array.expect
+test_array_let.expect
+test_arith_array.expect
 test_brace_expand.expect
 test_for_arith.expect
 test_printf.expect

--- a/tests/test_arith_array.expect
+++ b/tests/test_arith_array.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "nums=(1 2 3)\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$((nums\[1\]=7))\r"
+expect {
+    -re "\[\r\n\]+7\[\r\n\]+vush> " {}
+    timeout { send_user "arith assign output\n"; exit 1 }
+}
+send "echo \${nums\[@\]}\r"
+expect {
+    -re "\[\r\n\]+1 7 3\[\r\n\]+vush> " {}
+    timeout { send_user "arith array update failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_array_let.expect
+++ b/tests/test_array_let.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "nums=(1 2 3)\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "let nums\[1\]=5\r"
+expect {
+    "vush> " {}
+    timeout { send_user "let assign failed\n"; exit 1 }
+}
+send "echo \${nums\[@\]}\r"
+expect {
+    -re "\[\r\n\]+1 5 3\[\r\n\]+vush> " {}
+    timeout { send_user "array update failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- support array subscripts in arithmetic expressions
- allow assignments to array elements via `let` and `$(( ))`
- add helper `set_shell_array_index`
- test array element assignment in `let` and arithmetic expansion

## Testing
- `expect -f tests/test_array_let.expect`
- `expect -f tests/test_arith_array.expect`
- `make test` *(fails: send: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6850c3b2d980832483c8c95e7b5f1151