### PR TITLE
Enable globbing after parameter expansion

### DIFF
--- a/tests/test_glob.expect
+++ b/tests/test_glob.expect
@@ -16,6 +16,16 @@ expect {
     -re "\[\r\n\]+g1.c g2.c\[\r\n\]+vush> " {}
     timeout { send_user "glob expansion failed\n"; exit 1 }
 }
+send "PAT='*.c'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$PAT\r"
+expect {
+    -re "\[\r\n\]+g1.c g2.c\[\r\n\]+vush> " {}
+    timeout { send_user "glob var expansion failed\n"; exit 1 }
+}
 send "exit\r"
 expect {
     eof {}


### PR DESCRIPTION
## Summary
- run glob() on words produced by parameter expansion
- test that patterns from variables glob correctly

## Testing
- `make`
- `make test` *(fails: send: spawn id exp4 not open ...)*

------
https://chatgpt.com/codex/tasks/task_e_6851fbd7cebc8324adf0fe26d05e4ccc