### PR TITLE
Handle single-quoted expansion tokens

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -887,6 +887,9 @@ char *expand_var(const char *token) {
      * processing so that expansions inside quoted strings don't
      * preserve the quote characters. */
     size_t tlen = strlen(token);
+    if (tlen >= 2 && token[0] == '\'' && token[tlen - 1] == '\'') {
+        return strndup(token + 1, tlen - 2);
+    }
     if (tlen >= 2 && token[0] == '"' && token[tlen - 1] == '"') {
         size_t innerlen = tlen - 2;
         if (innerlen >= MAX_LINE)


### PR DESCRIPTION
## Summary
- treat tokens wrapped in `'` as literals inside `expand_var`

## Testing
- `make -j4`
- `./tests/run_var_tests.sh test_var_brace.expect` *(fails: quoted brace expansion failed)*

------
https://chatgpt.com/codex/tasks/task_e_68522202d23c8324b45458f103e8a4d2