### PR TITLE
Fix tilde user expansion

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -195,8 +195,9 @@ static char *expand_tilde(const char *token) {
         size_t len = slash ? (size_t)(slash - rest) : strlen(rest);
         char *user = strndup(rest, len);
         if (user) {
-            endpwent();
+            setpwent();
             struct passwd *pw = getpwnam(user);
+            endpwent();
             if (pw) {
                 home = pw->pw_dir;
             } else {


### PR DESCRIPTION
## Summary
- update tilde expansion to reread /etc/passwd before user lookup

## Testing
- `make test` *(fails: `test_ulimit.expect` and others)*

------
https://chatgpt.com/codex/tasks/task_e_6852240366f4832496c5782bec263a96