### PR TITLE
Improve ulimit test coverage

### DIFF
--- a/tests/test_ulimit.expect
+++ b/tests/test_ulimit.expect
@@ -1,5 +1,7 @@
 #!/usr/bin/env expect
 set timeout 5
+# disable history writes so RLIMIT_FSIZE tests do not kill the shell
+set env(VUSH_HISTFILE) "/dev/null"
 spawn [file dirname [info script]]/../build/vush
 expect {
     "vush> " {}
@@ -29,6 +31,21 @@ send "ulimit -H -f\r"
 expect {
     -re "\r\n1234\r?\nvush> " {}
     timeout { send_user "ulimit hard set failed\n"; exit 1 }
+}
+send "ulimit -S -f 123\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "ulimit -S -f\r"
+expect {
+    -re "\r\n123\r?\nvush> " {}
+    timeout { send_user "ulimit soft set failed\n"; exit 1 }
+}
+send "ulimit -H -f\r"
+expect {
+    -re "\r\n1234\r?\nvush> " {}
+    timeout { send_user "ulimit hard query failed\n"; exit 1 }
 }
 send "exit\r"
 expect {


### PR DESCRIPTION
## Summary
- disable history in `test_ulimit.expect` so file size limits don't kill the shell
- verify soft/hard limit behaviour by testing `-S` and `-H`

## Testing
- `make -j$(nproc)`
- `make test` *(fails: test_var_brace.expect, test_ps1.expect, test_ifs_split.expect, arithmetic_compound.expect)*

------
https://chatgpt.com/codex/tasks/task_e_68522514b0648324ac2f2c9416d1f676