### PR TITLE
Fix negate exit status for complex pipelines

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -1236,7 +1236,7 @@ int run_pipeline(Command *cmd, const char *line) {
         r = 0; break;
     }
     if (cmd->negate) {
-        last_status = (r == 0 ? 1 : 0);
+        last_status = (last_status == 0 ? 1 : 0);
         r = last_status;
     }
     return r;

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -119,6 +119,7 @@ test_pwd_options.expect
 test_fc.expect
 test_trap_p.expect
 test_negate.expect
+test_negate_multi.expect
 test_jobs_l.expect
 test_jobs_p.expect
 test_kill_s.expect

--- a/tests/test_negate_multi.expect
+++ b/tests/test_negate_multi.expect
@@ -1,0 +1,34 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+# multi-segment pipeline negation - should invert success
+send "! true | true | false\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "negate multiseg status mismatch\n"; exit 1 }
+}
+# multi-segment pipeline negation - should invert failure
+send "! false | true | true\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "negate multiseg status mismatch 2\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- ensure negation updates `last_status` based on the actual exit code
- add multi‑segment negation regression test

## Testing
- `make`
- `cd tests && ./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852288b2478832492f0a9a522b52395