### PR TITLE
Fix quoting in assignment expansion

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -185,6 +185,14 @@ static void expand_assignments(PipelineSegment *seg) {
         if (eq) {
             char *name = strndup(seg->assigns[i], eq - seg->assigns[i]);
             char *val = expand_var(eq + 1);
+            if (val) {
+                size_t len = strlen(val);
+                if (len >= 2 && ((val[0] == '\'' && val[len - 1] == '\'') ||
+                                 (val[0] == '"' && val[len - 1] == '"'))) {
+                    char *trim = strndup(val + 1, len - 2);
+                    if (trim) { free(val); val = trim; }
+                }
+            }
             char *tmp = NULL;
             if (name && val)
                 asprintf(&tmp, "%s=%s", name, val);
@@ -297,6 +305,14 @@ static void expand_segment(PipelineSegment *seg) {
         if (eq) {
             char *name = strndup(seg->assigns[i], eq - seg->assigns[i]);
             char *val = expand_var(eq + 1);
+            if (val) {
+                size_t len = strlen(val);
+                if (len >= 2 && ((val[0] == '\'' && val[len - 1] == '\'') ||
+                                 (val[0] == '"' && val[len - 1] == '"'))) {
+                    char *trim = strndup(val + 1, len - 2);
+                    if (trim) { free(val); val = trim; }
+                }
+            }
             char *tmp = NULL;
             if (name && val)
                 asprintf(&tmp, "%s=%s", name, val);


### PR DESCRIPTION
## Summary
- trim surrounding single or double quotes from assignment values in `expand_assignments`

## Testing
- `make -j4`
- `./tests/test_ifs_split.expect` *(fails: `quoted failed`)*

------
https://chatgpt.com/codex/tasks/task_e_68522c12d8448324ac7e4df9e80eda2b