### PR TITLE
Rewrite test_export_n.expect

### DIFF
--- a/tests/test_export_n.expect
+++ b/tests/test_export_n.expect
@@ -10,9 +10,9 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "env | grep FOO\r"
+send "env | grep ^FOO=\r"
 expect {
-    -re "FOO=bar" {}
+    -re "FOO=bar\r?\nvush> " {}
     timeout { send_user "export not set\n"; exit 1 }
 }
 send "export -n FOO\r"
@@ -27,7 +27,7 @@ expect {
 }
 send "echo \$FOO\r"
 expect {
-    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
+    -re "\r\nbar\r?\nvush> " {}
     timeout { send_user "export -n removed variable\n"; exit 1 }
 }
 send "exit\r"


### PR DESCRIPTION
## Summary
- remove `tests/test_export_n.expect` and rewrite it
- new test checks that `export -n FOO` unexports `FOO` while the variable remains in the shell

## Testing
- `make test` *(fails: FAILED: test_var_brace.expect, FAILED: test_ifs_split.expect, FAILED: arithmetic_compound.expect)*

------
https://chatgpt.com/codex/tasks/task_e_68523016ef4483249d4af0855ea2fb9b