### PR TITLE
Rewrite variable brace expect test

### DIFF
--- a/tests/test_var_brace.expect
+++ b/tests/test_var_brace.expect
@@ -10,7 +10,7 @@ expect {
     -re "\[\r\n\]+$env(HOME)\[\r\n\]+vush> " {}
     timeout { send_user "brace expansion failed\n"; exit 1 }
 }
-send "echo \\\"\${HOME}\\\"\r"
+send "echo \"\${HOME}\"\r"
 expect {
     -re "\[\r\n\]+$env(HOME)\[\r\n\]+vush> " {}
     timeout { send_user "quoted brace expansion failed\n"; exit 1 }


### PR DESCRIPTION
## Summary
- reimplement `tests/test_var_brace.expect` using the regular Expect template
- verify variable expansion with braces in multiple quoting contexts

## Testing
- `make -j$(nproc)`
- `cd tests && ./run_var_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68523005661083249e2cb5778c98d380