### PR TITLE
Add cleanup to tilde user test

### DIFF
--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -1,8 +1,7 @@
 #!/usr/bin/env expect
 set timeout 5
-set user "tildeuser"
-set home "/tmp/vush_$user"
-exec mkdir -p $home
+set user "tempuser"
+set home [exec mktemp -d]
 exec sh -c "echo \"$user:x:12345:12345::$home:/bin/false\" >> /etc/passwd"
 spawn [file dirname [info script]]/../build/vush
 expect {
@@ -12,17 +11,17 @@ expect {
 send "cd ~$user\r"
 expect {
     "vush> " {}
-    timeout { send_user "prompt timeout\n"; exit 1 }
+    timeout { send_user "prompt timeout\n"; exec sed -i \"/$user:x:12345/d\" /etc/passwd; exec rm -rf $home; exit 1 }
 }
 send "pwd\r"
 expect {
     -re "\[\r\n\]+$home\[\r\n\]+vush> " {}
-    timeout { send_user "tilde expansion failed\n"; exec sed -i "/$user:x:12345/d" /etc/passwd; exec rm -rf $home; exit 1 }
+    timeout { send_user "tilde expansion failed\n"; exec sed -i \"/$user:x:12345/d\" /etc/passwd; exec rm -rf $home; exit 1 }
 }
 send "exit\r"
 expect {
     eof {}
-    timeout { send_user "eof timeout\n"; exit 1 }
+    timeout { send_user "eof timeout\n"; exec sed -i \"/$user:x:12345/d\" /etc/passwd; exec rm -rf $home; exit 1 }
 }
 exec sed -i "/$user:x:12345/d" /etc/passwd
 exec rm -rf $home


### PR DESCRIPTION
## Summary
- rewrite `test_tilde_user.expect` to create a temporary user
- ensure the test cleans up the passwd entry and directory

## Testing
- `make`
- `cd tests && ./run_builtins_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852302285c88324b3c172e66fce86db