### PR TITLE
Replace IFS splitting test script

### DIFF
--- a/tests/test_ifs_split.expect
+++ b/tests/test_ifs_split.expect
@@ -1,20 +1,24 @@
 #!/usr/bin/env expect
+# Validate IFS splitting behavior
 set timeout 5
 spawn [file dirname [info script]]/../build/vush
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
+# Assign a variable containing a space
 send "FOO='a b'\r"
 expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
+# Expanding without quotes should split
 send "for w in \$FOO; do echo \$w; done\r"
 expect {
     -re "\r\na\r\nb\r\nvush> " {}
     timeout { send_user "split failed\n"; exit 1 }
 }
+# Quoting preserves the space
 send "for w in \"\$FOO\"; do echo \$w; done\r"
 expect {
     -re "\r\na b\r\nvush> " {}


### PR DESCRIPTION
## Summary
- refresh `tests/test_ifs_split.expect` by recreating it with explanatory comments

## Testing
- `make test` *(fails: test_var_brace.expect, test_ifs_split.expect, arithmetic_compound.expect)*

------
https://chatgpt.com/codex/tasks/task_e_685230259e088324876a3e9b5674298a