### PR TITLE
Add last_status to eval_arith and fix compound tests

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -37,6 +37,8 @@
 #include <limits.h>
 #include <errno.h>
 
+extern int last_status;
+
 #define PARSE_RHS(fn)              \
     long long rhs = fn(state);    \
     if (state->err) return 0;
@@ -705,7 +707,9 @@ long long eval_arith(const char *expr, int *err, char **errmsg) {
             *errmsg = strdup(st.err_msg[0] ? st.err_msg : "error");
         else
             fprintf(stderr, "arith: %s\n", st.err_msg[0] ? st.err_msg : "error");
+        last_status = 1;
         return 0;
     }
+    last_status = (result != 0) ? 0 : 1;
     return result;
 }

--- a/tests/arithmetic_compound.expect
+++ b/tests/arithmetic_compound.expect
@@ -19,15 +19,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
-    timeout { send_user "plus assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "plus status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "plus assign failed\n"; exit 1 }
 }
 
 # -=
@@ -36,15 +36,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
-    timeout { send_user "minus assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+1\[\r\n\]+vush> " {}
     timeout { send_user "minus status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+0\[\r\n\]+vush> " {}
+    timeout { send_user "minus assign failed\n"; exit 1 }
 }
 
 # reset var
@@ -60,15 +60,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+15\[\r\n\]+vush> " {}
-    timeout { send_user "mul assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "mul status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+15\[\r\n\]+vush> " {}
+    timeout { send_user "mul assign failed\n"; exit 1 }
 }
 
 # /=
@@ -77,15 +77,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
-    timeout { send_user "div assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "div status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
+    timeout { send_user "div assign failed\n"; exit 1 }
 }
 
 # %=
@@ -94,15 +94,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
-    timeout { send_user "mod assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "mod status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "mod assign failed\n"; exit 1 }
 }
 
 # <<=
@@ -111,15 +111,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+8\[\r\n\]+vush> " {}
-    timeout { send_user "lshift assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "lshift status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+8\[\r\n\]+vush> " {}
+    timeout { send_user "lshift assign failed\n"; exit 1 }
 }
 
 # >>=
@@ -128,15 +128,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
-    timeout { send_user "rshift assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "rshift status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "rshift assign failed\n"; exit 1 }
 }
 
 # &=
@@ -145,15 +145,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
-    timeout { send_user "and assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "and status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+2\[\r\n\]+vush> " {}
+    timeout { send_user "and assign failed\n"; exit 1 }
 }
 
 # ^=
@@ -162,15 +162,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
-    timeout { send_user "xor assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "xor status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+3\[\r\n\]+vush> " {}
+    timeout { send_user "xor assign failed\n"; exit 1 }
 }
 
 # |=
@@ -179,15 +179,15 @@ expect {
     "vush> " {}
     timeout { send_user "prompt timeout\n"; exit 1 }
 }
-send "echo \$var\r"
-expect {
-    -re "\[\r\n\]+7\[\r\n\]+vush> " {}
-    timeout { send_user "or assign failed\n"; exit 1 }
-}
 send "echo \$?\r"
 expect {
     -re "\[\r\n\]+0\[\r\n\]+vush> " {}
     timeout { send_user "or status mismatch\n"; exit 1 }
+}
+send "echo \$var\r"
+expect {
+    -re "\[\r\n\]+7\[\r\n\]+vush> " {}
+    timeout { send_user "or assign failed\n"; exit 1 }
 }
 
 send "exit\r"


### PR DESCRIPTION
## Summary
- update arithmetic evaluator to set `last_status`
- adjust compound assignment expect script to check status before printing variable

## Testing
- `make test` *(fails: test_ifs_split.expect)*

------
https://chatgpt.com/codex/tasks/task_e_685231eb83ac83249613df6e051c18fb