### PR TITLE
Add pipeline timing with `time` reserved word

### DIFF
--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -369,7 +369,10 @@ hi
 - `eval WORDS...` - concatenate arguments and execute the result.
 - `source file [args...]` or `. file [args...]` - execute commands from a file with optional positional parameters. If `file` contains no `/`, each directory in `$PATH` is searched.
 - `help` - display information about built-in commands.
-- `time [-p] command [args...]` - run a command and print timing statistics. With `-p`, output follows the POSIX `real`, `user`, `sys` format.
+- `time [-p] command [args...]` - run a command and print timing statistics. With `-p`, output follows the POSIX `real`, `user`, `sys` format. Placing `time` before a pipeline times the entire sequence.
+```sh
+time ls | wc
+```
 - `times` - print cumulative user/system CPU times.
 - `ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v [limit]]` - display or set resource limits.
 - `umask [-S] [mask]` - set or display the file creation mask. `mask` may be an octal number or a symbolic string like `u=rwx,g=rx,o=rx`. With `-S`, the mask is shown in symbolic form.

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -37,6 +37,7 @@ int builtin_exec(char **args);
 int builtin_command(char **args);
 int builtin_time(char **args);
 int builtin_times(char **args);
+int builtin_time_callback(int (*func)(void *), void *data, int posix);
 int builtin_umask(char **args);
 int builtin_ulimit(char **args);
 int builtin_source(char **args);

--- a/src/builtins_time.c
+++ b/src/builtins_time.c
@@ -7,10 +7,42 @@
 #include <time.h>
 #include <string.h>
 #include <sys/times.h>
-#include <sys/resource.h>
 #include <unistd.h>
 
 extern int last_status;
+
+static int do_time(int posix, int (*func)(void *), void *data)
+{
+    struct timespec start, end;
+    struct tms t0, t1;
+    long hz = sysconf(_SC_CLK_TCK);
+    if (hz <= 0)
+        hz = 100;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    times(&t0);
+    int status = func(data);
+    times(&t1);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    double real = (end.tv_sec - start.tv_sec) +
+                  (end.tv_nsec - start.tv_nsec) / 1e9;
+    double user = ((t1.tms_utime - t0.tms_utime) +
+                   (t1.tms_cutime - t0.tms_cutime)) / (double)hz;
+    double sys = ((t1.tms_stime - t0.tms_stime) +
+                  (t1.tms_cstime - t0.tms_cstime)) / (double)hz;
+
+    if (posix)
+        printf("real %.3f\nuser %.3f\nsys %.3f\n", real, user, sys);
+    else
+        printf("real %.3f sec\n", real);
+
+    return status;
+}
+
+int builtin_time_callback(int (*func)(void *), void *data, int posix)
+{
+    return do_time(posix, func, data);
+}
 
 /* Run a command and report the elapsed real time. */
 int builtin_time(char **args)
@@ -28,45 +60,36 @@ int builtin_time(char **args)
         return 1;
     }
 
-    struct timespec start, end;
-    struct rusage ru;
-    clock_gettime(CLOCK_MONOTONIC, &start);
-    pid_t pid = fork();
-    if (pid == 0) {
-        execvp(args[idx], &args[idx]);
-        perror(args[idx]);
-        _exit(127);
-    } else if (pid > 0) {
-        int status;
-        if (wait4(pid, &status, 0, &ru) == -1) {
-            perror("wait4");
-            last_status = 1;
+    struct run_data { char **argv; } rd = { &args[idx] };
+    int exec_cmd(void *d)
+    {
+        char **av = ((struct run_data *)d)->argv;
+        pid_t pid = fork();
+        if (pid == 0) {
+            execvp(av[0], av);
+            perror(av[0]);
+            _exit(127);
+        } else if (pid > 0) {
+            int status;
+            if (waitpid(pid, &status, 0) == -1) {
+                perror("waitpid");
+                return 1;
+            }
+            if (WIFEXITED(status))
+                return WEXITSTATUS(status);
+            else if (WIFSIGNALED(status))
+                return 128 + WTERMSIG(status);
+            else
+                return status;
+        } else {
+            perror("fork");
             return 1;
         }
-        clock_gettime(CLOCK_MONOTONIC, &end);
-
-        double real = (end.tv_sec - start.tv_sec) +
-                      (end.tv_nsec - start.tv_nsec) / 1e9;
-        double user = ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6;
-        double sys = ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6;
-
-        if (posix)
-            printf("real %.3f\nuser %.3f\nsys %.3f\n", real, user, sys);
-        else
-            printf("real %.3f sec\n", real);
-
-        if (WIFEXITED(status))
-            last_status = WEXITSTATUS(status);
-        else if (WIFSIGNALED(status))
-            last_status = 128 + WTERMSIG(status);
-        else
-            last_status = status;
-        return 1;
-    } else {
-        perror("fork");
-        last_status = 1;
-        return 1;
     }
+
+    int status = do_time(posix, exec_cmd, &rd);
+    last_status = status;
+    return 1;
 }
 
 /* Print user/system CPU times for the shell and its children. */

--- a/src/parser.h
+++ b/src/parser.h
@@ -84,6 +84,7 @@ typedef struct Command {
     struct Command *group;    /* commands for subshell or group */
     int negate;               /* invert status with leading ! */
     int background;
+    int time_pipeline;        /* time entire pipeline when set */
     CmdOp op; /* operator connecting to next command */
     struct Command *next;
 } Command;


### PR DESCRIPTION
## Summary
- parse `time` as a reserved word for pipeline timing
- run timed pipelines via new helper in the executor
- expose generic timing callback in `builtins_time.c`
- document pipeline timing usage

## Testing
- `make -s`
- `make -s test` *(fails: test_negate.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec45bbf083249dc6bca982a24604