### PR TITLE
Add -t option to type builtin

### DIFF
--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -362,7 +362,9 @@ hi
 - Aliases are stored in the file specified by `VUSH_ALIASFILE` (default
   `~/.vush_aliases`).
   The file contains one `name=value` pair per line without quotes.
-- `type NAME...` - display how each NAME would be interpreted.
+- `type [-t] NAME...` - display how each NAME would be interpreted. With `-t`
+  only the classification (`alias`, `function`, `builtin`, `file` or `not found`)
+  is printed.
 - `command [-p] [-v|-V] NAME [args...]` - run `NAME` ignoring shell functions.
   With `-v` or `-V` display how the name would be resolved. The `-p` option searches or executes using `/bin:/usr/bin` instead of the current `$PATH`.
 
@@ -524,6 +526,11 @@ ll is an alias for 'ls -l'
 cd is a builtin
 ls is /bin/ls
 unknown not found
+vush> type -t ll cd ls unknown
+alias
+builtin
+file
+not found
 ```
 
 ## Trap Example

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -89,24 +89,39 @@ int builtin_help(char **args) {
 
 /* Show how each argument would be resolved: alias, function, builtin or file. */
 int builtin_type(char **args) {
-    if (!args[1]) {
-        fprintf(stderr, "usage: type name...\n");
+    int opt_t = 0;
+    int i = 1;
+    if (args[i] && strcmp(args[i], "-t") == 0) {
+        opt_t = 1;
+        i++;
+    }
+    if (!args[i]) {
+        fprintf(stderr, "usage: type [-t] name...\n");
         return 1;
     }
-    for (int i = 1; args[i]; i++) {
+    for (; args[i]; i++) {
         const char *alias = get_alias(args[i]);
         if (alias) {
-            printf("%s is an alias for '%s'\n", args[i], alias);
+            if (opt_t)
+                printf("alias\n");
+            else
+                printf("%s is an alias for '%s'\n", args[i], alias);
             continue;
         }
         if (find_function(args[i])) {
-            printf("%s is a function\n", args[i]);
+            if (opt_t)
+                printf("function\n");
+            else
+                printf("%s is a function\n", args[i]);
             continue;
         }
         int is_builtin = 0;
         for (int j = 0; builtin_table[j].name; j++) {
             if (strcmp(args[i], builtin_table[j].name) == 0) {
-                printf("%s is a builtin\n", args[i]);
+                if (opt_t)
+                    printf("builtin\n");
+                else
+                    printf("%s is a builtin\n", args[i]);
                 is_builtin = 1;
                 break;
             }
@@ -130,7 +145,10 @@ int builtin_type(char **args) {
                 break;
             snprintf(full, len, "%s/%s", d, args[i]);
             if (access(full, X_OK) == 0) {
-                printf("%s is %s\n", args[i], full);
+                if (opt_t)
+                    printf("file\n");
+                else
+                    printf("%s is %s\n", args[i], full);
                 found = 1;
                 free(full);
                 break;
@@ -139,8 +157,12 @@ int builtin_type(char **args) {
             dir = strtok_r(NULL, ":", &saveptr);
         }
         free(paths);
-        if (!found)
-            printf("%s not found\n", args[i]);
+        if (!found) {
+            if (opt_t)
+                printf("not found\n");
+            else
+                printf("%s not found\n", args[i]);
+        }
     }
     return 1;
 }

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -55,6 +55,7 @@ test_envfile.expect
 test_unmatched.expect
 test_jobs.expect
 test_type.expect
+test_type_t.expect
 test_dash_c.expect
 test_dash_c_quotes.expect
 test_echo_options.expect

--- a/tests/test_type_t.expect
+++ b/tests/test_type_t.expect
@@ -1,0 +1,25 @@
+#!/usr/bin/env expect
+set dir [exec mktemp -d]
+set env(HOME) $dir
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias ll='echo hi'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "type -t ll cd ls nosuch\r"
+expect {
+    -re "\[\r\n\]+alias\[\r\n\]+builtin\[\r\n\]+file\[\r\n\]+not found\[\r\n\]+vush> " {}
+    timeout { send_user "type -t output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- support `-t` flag in the `type` builtin to print only the classification
- document the new flag in `vushdoc.md`
- add automated test for `type -t`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6852f1414d9483249d61e1c97ea07d58