### PR TITLE
Refactor assignment helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/arith.c \
        src/parser_utils.c src/parser_clauses.c \
        src/parser_pipeline.c \
-       src/dirstack.c src/util.c src/pipeline.c src/redir.c src/func_exec.c \
+       src/dirstack.c src/util.c src/assignment_utils.c src/pipeline.c src/redir.c src/func_exec.c \
        src/hash.c src/trap.c src/startup.c src/mail.c src/repl.c \
        src/main.c
 

--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -1,0 +1,149 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "assignment_utils.h"
+#include "vars.h"
+#include "util.h"
+
+char **parse_array_values(const char *val, int *count) {
+    *count = 0;
+    char *body = strndup(val + 1, strlen(val) - 2);
+    if (!body)
+        return NULL;
+
+    char **vals = NULL;
+    char *p = body;
+    while (*p) {
+        while (*p == ' ' || *p == '\t')
+            p++;
+        if (*p == '\0')
+            break;
+        char *start = p;
+        while (*p && *p != ' ' && *p != '\t')
+            p++;
+        if (*p)
+            *p++ = '\0';
+
+        char **tmp = realloc(vals, sizeof(char *) * (*count + 1));
+        if (!tmp) {
+            free(body);
+            for (int i = 0; i < *count; i++)
+                free(vals[i]);
+            free(vals);
+            *count = 0;
+            return NULL;
+        }
+        vals = tmp;
+        vals[*count] = strdup(start);
+        if (!vals[*count]) {
+            for (int i = 0; i < *count; i++)
+                free(vals[i]);
+            free(vals);
+            free(body);
+            *count = 0;
+            return NULL;
+        }
+        (*count)++;
+    }
+    free(body);
+
+    if (*count == 0) {
+        vals = xcalloc(1, sizeof(char *));
+    }
+
+    return vals;
+}
+
+void apply_array_assignment(const char *name, const char *val, int export_env) {
+    int count = 0;
+    char **vals = parse_array_values(val, &count);
+    if (!vals && count > 0)
+        return;
+
+    set_shell_array(name, vals, count);
+
+    if (export_env) {
+        size_t joinlen = 0;
+        for (int j = 0; j < count; j++)
+            joinlen += strlen(vals[j]) + 1;
+        char *joined = malloc(joinlen + 1);
+        if (joined) {
+            joined[0] = '\0';
+            for (int j = 0; j < count; j++) {
+                strcat(joined, vals[j]);
+                if (j < count - 1)
+                    strcat(joined, " ");
+            }
+            setenv(name, joined, 1);
+            free(joined);
+        }
+    }
+
+    for (int j = 0; j < count; j++)
+        free(vals[j]);
+    free(vals);
+}
+
+struct assign_backup *backup_assignments(PipelineSegment *pipeline) {
+    if (pipeline->assign_count == 0)
+        return NULL;
+
+    struct assign_backup *backs = xcalloc(pipeline->assign_count, sizeof(*backs));
+
+    for (int i = 0; i < pipeline->assign_count; i++) {
+        char *eq = strchr(pipeline->assigns[i], '=');
+        if (!eq) {
+            backs[i].name = NULL;
+            continue;
+        }
+        backs[i].name = strndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
+        if (!backs[i].name) {
+            backs[i].env = backs[i].var = NULL;
+            backs[i].had_env = backs[i].had_var = 0;
+            continue;
+        }
+        const char *oe = getenv(backs[i].name);
+        backs[i].had_env = oe != NULL;
+        backs[i].env = oe ? strdup(oe) : NULL;
+        if (oe && !backs[i].env) {
+            free(backs[i].name);
+            backs[i].name = NULL;
+            continue;
+        }
+        const char *ov = get_shell_var(backs[i].name);
+        backs[i].had_var = ov != NULL;
+        backs[i].var = ov ? strdup(ov) : NULL;
+        if (ov && !backs[i].var) {
+            free(backs[i].env);
+            free(backs[i].name);
+            backs[i].name = NULL;
+            continue;
+        }
+    }
+
+    return backs;
+}
+
+void restore_assignments(PipelineSegment *pipeline, struct assign_backup *backs) {
+    if (!backs)
+        return;
+    for (int i = 0; i < pipeline->assign_count; i++) {
+        if (!backs[i].name)
+            continue;
+        if (backs[i].had_env)
+            setenv(backs[i].name, backs[i].env, 1);
+        else
+            unsetenv(backs[i].name);
+        if (backs[i].had_var)
+            set_shell_var(backs[i].name, backs[i].var);
+        else
+            unset_shell_var(backs[i].name);
+        free(backs[i].name);
+        free(backs[i].env);
+        free(backs[i].var);
+    }
+    free(backs);
+}
+

--- a/src/assignment_utils.h
+++ b/src/assignment_utils.h
@@ -1,0 +1,19 @@
+#ifndef ASSIGNMENT_UTILS_H
+#define ASSIGNMENT_UTILS_H
+
+#include "parser.h"
+
+struct assign_backup {
+    char *name;
+    char *env;
+    char *var;
+    int had_env;
+    int had_var;
+};
+
+char **parse_array_values(const char *val, int *count);
+void apply_array_assignment(const char *name, const char *val, int export_env);
+struct assign_backup *backup_assignments(PipelineSegment *pipeline);
+void restore_assignments(PipelineSegment *pipeline, struct assign_backup *backs);
+
+#endif /* ASSIGNMENT_UTILS_H */

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -25,6 +25,7 @@
 #include <limits.h>
 #include <errno.h>
 #include "util.h"
+#include "assignment_utils.h"
 
 extern int last_status;
 
@@ -445,49 +446,6 @@ int builtin_readonly(char **args) {
     return 1;
 }
 
-static char **parse_array_values(const char *val, int *count) {
-    *count = 0;
-    char *body = strndup(val + 1, strlen(val) - 2);
-    if (!body)
-        return NULL;
-
-    char **vals = NULL;
-    char *p = body;
-    while (*p) {
-        while (*p == ' ' || *p == '\t')
-            p++;
-        if (*p == '\0')
-            break;
-        char *start = p;
-        while (*p && *p != ' ' && *p != '\t')
-            p++;
-        if (*p)
-            *p++ = '\0';
-
-        char **tmp = realloc(vals, sizeof(char *) * (*count + 1));
-        if (!tmp) {
-            for (int i = 0; i < *count; i++)
-                free(vals[i]);
-            free(vals);
-            free(body);
-            *count = 0;
-            return NULL;
-        }
-        vals = tmp;
-        vals[*count] = strdup(start);
-        if (!vals[*count]) {
-            for (int i = 0; i < *count; i++)
-                free(vals[i]);
-            free(vals);
-            free(body);
-            *count = 0;
-            return NULL;
-        }
-        (*count)++;
-    }
-    free(body);
-    return vals;
-}
 
 int builtin_local(char **args) {
     if (!args[1])

--- a/src/execute.c
+++ b/src/execute.c
@@ -29,6 +29,7 @@
 #include "hash.h"
 #include "lexer.h"
 #include "redir.h"
+#include "assignment_utils.h"
 
 extern int last_status;
 extern int param_error;
@@ -57,19 +58,6 @@ static int exec_subshell(Command *cmd, const char *line);
 static int exec_cond(Command *cmd, const char *line);
 static int exec_group(Command *cmd, const char *line);
 static int exec_arith(Command *cmd, const char *line);
-
-struct assign_backup {
-    char *name;
-    char *env;
-    char *var;
-    int had_env;
-    int had_var;
-};
-
-static struct assign_backup *backup_assignments(PipelineSegment *pipeline);
-static void restore_assignments(PipelineSegment *pipeline, struct assign_backup *backs);
-static void apply_array_assignment(const char *name, const char *val, int export_env);
-static char **parse_array_values(const char *val, int *count);
 
 /* Determine if a command name corresponds to a builtin. */
 static int is_builtin_command(const char *name) {
@@ -355,145 +343,6 @@ static PipelineSegment *copy_pipeline(PipelineSegment *src) {
     return head;
 }
 
-static char **parse_array_values(const char *val, int *count) {
-    *count = 0;
-    char *body = strndup(val + 1, strlen(val) - 2);
-    if (!body)
-        return NULL;
-
-    char **vals = NULL;
-    char *p = body;
-    while (*p) {
-        while (*p == ' ' || *p == '\t')
-            p++;
-        if (*p == '\0')
-            break;
-        char *start = p;
-        while (*p && *p != ' ' && *p != '\t')
-            p++;
-        if (*p)
-            *p++ = '\0';
-
-        char **tmp = realloc(vals, sizeof(char *) * (*count + 1));
-        if (!tmp) {
-            free(body);
-            for (int i = 0; i < *count; i++)
-                free(vals[i]);
-            free(vals);
-            *count = 0;
-            return NULL;
-        }
-        vals = tmp;
-        vals[*count] = strdup(start);
-        if (!vals[*count]) {
-            for (int i = 0; i < *count; i++)
-                free(vals[i]);
-            free(vals);
-            free(body);
-            *count = 0;
-            return NULL;
-        }
-        (*count)++;
-    }
-    free(body);
-
-    if (*count == 0) {
-        vals = xcalloc(1, sizeof(char *));
-    }
-
-    return vals;
-}
-
-static void apply_array_assignment(const char *name, const char *val, int export_env) {
-    int count = 0;
-    char **vals = parse_array_values(val, &count);
-    if (!vals && count > 0)
-        return;
-
-    set_shell_array(name, vals, count);
-
-    if (export_env) {
-        size_t joinlen = 0;
-        for (int j = 0; j < count; j++)
-            joinlen += strlen(vals[j]) + 1;
-        char *joined = malloc(joinlen + 1);
-        if (joined) {
-            joined[0] = '\0';
-            for (int j = 0; j < count; j++) {
-                strcat(joined, vals[j]);
-                if (j < count - 1)
-                    strcat(joined, " ");
-            }
-            setenv(name, joined, 1);
-            free(joined);
-        }
-    }
-
-    for (int j = 0; j < count; j++)
-        free(vals[j]);
-    free(vals);
-}
-
-static struct assign_backup *backup_assignments(PipelineSegment *pipeline) {
-    if (pipeline->assign_count == 0)
-        return NULL;
-
-    struct assign_backup *backs = xcalloc(pipeline->assign_count, sizeof(*backs));
-
-    for (int i = 0; i < pipeline->assign_count; i++) {
-        char *eq = strchr(pipeline->assigns[i], '=');
-        if (!eq) {
-            backs[i].name = NULL;
-            continue;
-        }
-        backs[i].name = strndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
-        if (!backs[i].name) {
-            backs[i].env = backs[i].var = NULL;
-            backs[i].had_env = backs[i].had_var = 0;
-            continue;
-        }
-        const char *oe = getenv(backs[i].name);
-        backs[i].had_env = oe != NULL;
-        backs[i].env = oe ? strdup(oe) : NULL;
-        if (oe && !backs[i].env) {
-            free(backs[i].name);
-            backs[i].name = NULL;
-            continue;
-        }
-        const char *ov = get_shell_var(backs[i].name);
-        backs[i].had_var = ov != NULL;
-        backs[i].var = ov ? strdup(ov) : NULL;
-        if (ov && !backs[i].var) {
-            free(backs[i].env);
-            free(backs[i].name);
-            backs[i].name = NULL;
-            continue;
-        }
-    }
-
-    return backs;
-}
-
-static void restore_assignments(PipelineSegment *pipeline, struct assign_backup *backs) {
-    if (!backs)
-        return;
-    for (int i = 0; i < pipeline->assign_count; i++) {
-        if (!backs[i].name)
-            continue;
-        if (backs[i].had_env)
-            setenv(backs[i].name, backs[i].env, 1);
-        else
-            unsetenv(backs[i].name);
-        if (backs[i].had_var)
-            set_shell_var(backs[i].name, backs[i].var);
-        else
-            unset_shell_var(backs[i].name);
-        free(backs[i].name);
-        free(backs[i].env);
-        free(backs[i].var);
-    }
-    free(backs);
-}
 /*
  * Apply temporary variable assignments before running a pipeline.
  * Builtins and functions are executed directly while environment


### PR DESCRIPTION
## Summary
- split assignment helper code into a new module
- share array parsing helpers with builtins
- wire new module into build

## Testing
- `make -j4`
- `make test` *(fails: `make: *** [Makefile:37: test] Error 1`)*

------
https://chatgpt.com/codex/tasks/task_e_6852ff166b6483248cad2cb9057619b2