### PR TITLE
Move command substitution helpers to separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/builtins_signals.c src/execute.c src/history.c \
        src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
        src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/arith.c \
+       src/cmd_subst.c \
        src/parser_utils.c src/parser_clauses.c \
        src/parser_pipeline.c \
        src/dirstack.c src/util.c src/assignment_utils.c src/pipeline.c src/pipeline_exec.c src/control.c src/redir.c src/func_exec.c \

--- a/src/cmd_subst.c
+++ b/src/cmd_subst.c
@@ -1,0 +1,120 @@
+#define _GNU_SOURCE
+#include "cmd_subst.h"
+#include "parser.h" /* for MAX_LINE and parse_line */
+#include "execute.h"
+#include "options.h"
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <stdio.h>
+
+extern int last_status;
+
+/* Execute CMD and capture its stdout using the shell itself so that shell
+ * variables and functions are visible.  The command's output is returned as a
+ * newly allocated string with any trailing newline removed. */
+char *command_output(const char *cmd) {
+    int saved_notify = opt_notify;
+    opt_notify = 0;
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        opt_notify = saved_notify;
+        return NULL;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        signal(SIGINT, SIG_DFL);
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        close(pipefd[1]);
+        char *copy = strdup(cmd);
+        Command *c = copy ? parse_line(copy) : NULL;
+        free(copy);
+        if (c) {
+            run_command_list(c, cmd);
+            free_commands(c);
+        }
+        exit(last_status);
+    } else if (pid > 0) {
+        close(pipefd[1]);
+        char out[MAX_LINE];
+        size_t total = 0;
+        ssize_t n;
+        while ((n = read(pipefd[0], out + total, sizeof(out) - 1 - total)) > 0) {
+            total += (size_t)n;
+            if (total >= sizeof(out) - 1)
+                break;
+        }
+        close(pipefd[0]);
+        waitpid(pid, NULL, 0);
+        opt_notify = saved_notify;
+        if (total > 0 && out[total - 1] == '\n')
+            total--;
+        out[total] = '\0';
+        char *ret = strdup(out);
+        return ret;
+    } else {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        opt_notify = saved_notify;
+        return NULL;
+    }
+}
+
+/* Parse a command substitution starting at *p. Supports both $(...) and
+ * backtick forms. On success *p is advanced past the closing delimiter and
+ * the command's output is returned. NULL is returned on syntax errors or
+ * allocation failures. */
+char *parse_substitution(char **p) {
+    if (!p || !*p || !**p)
+        return NULL;
+
+    int depth = 0;
+    int is_dollar = (**p == '$');
+    (*p)++;
+    if (is_dollar) {
+        if (**p != '(')
+            return NULL;
+        (*p)++; /* skip '(' */
+        depth = 1;
+    }
+
+    char cmd[MAX_LINE];
+    int clen = 0;
+    while (**p) {
+        if (is_dollar) {
+            if (**p == '(') {
+                depth++;
+            } else if (**p == ')') {
+                depth--;
+                if (depth == 0) {
+                    (*p)++; /* skip closing ')' */
+                    break;
+                }
+            }
+        } else if (**p == '`') {
+            (*p)++; /* skip closing backtick */
+            break;
+        }
+
+        if (clen < MAX_LINE - 1)
+            cmd[clen++] = **p;
+        (*p)++;
+    }
+
+    if ((is_dollar && depth > 0) || (!is_dollar && *(*p - 1) != '`')) {
+        parse_need_more = 1;
+        return NULL;
+    }
+
+    cmd[clen] = '\0';
+    char *res = command_output(cmd);
+    if (!res)
+        return NULL;
+    return res;
+}
+

--- a/src/cmd_subst.h
+++ b/src/cmd_subst.h
@@ -1,0 +1,8 @@
+#ifndef CMD_SUBST_H
+#define CMD_SUBST_H
+
+char *command_output(const char *cmd);
+char *parse_substitution(char **p);
+
+#endif /* CMD_SUBST_H */
+

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -14,11 +14,10 @@
 #include <ctype.h>
 #include <pwd.h>
 #include <unistd.h>
-#include <signal.h>
-#include <sys/wait.h>
 #include "parser.h" /* for MAX_LINE */
 #include "execute.h"
 #include "util.h"
+#include "cmd_subst.h"
 
 extern int last_status;
 extern int param_error;
@@ -157,112 +156,6 @@ fail_alloc:
     if (count_out)
         *count_out = 0;
     return NULL;
-}
-
-/* Execute CMD and capture its stdout using the shell itself so that shell
- * variables and functions are visible.  The command's output is returned as a
- * newly allocated string with any trailing newline removed. */
-static char *command_output(const char *cmd) {
-    int saved_notify = opt_notify;
-    opt_notify = 0;
-
-    int pipefd[2];
-    if (pipe(pipefd) != 0) {
-        opt_notify = saved_notify;
-        return NULL;
-    }
-
-    pid_t pid = fork();
-    if (pid == 0) {
-        signal(SIGINT, SIG_DFL);
-        close(pipefd[0]);
-        dup2(pipefd[1], STDOUT_FILENO);
-        close(pipefd[1]);
-        char *copy = strdup(cmd);
-        Command *c = copy ? parse_line(copy) : NULL;
-        free(copy);
-        if (c) {
-            run_command_list(c, cmd);
-            free_commands(c);
-        }
-        exit(last_status);
-    } else if (pid > 0) {
-        close(pipefd[1]);
-        char out[MAX_LINE];
-        size_t total = 0;
-        ssize_t n;
-        while ((n = read(pipefd[0], out + total, sizeof(out) - 1 - total)) > 0) {
-            total += (size_t)n;
-            if (total >= sizeof(out) - 1)
-                break;
-        }
-        close(pipefd[0]);
-        waitpid(pid, NULL, 0);
-        opt_notify = saved_notify;
-        if (total > 0 && out[total - 1] == '\n')
-            total--;
-        out[total] = '\0';
-        char *ret = strdup(out);
-        return ret;
-    } else {
-        close(pipefd[0]);
-        close(pipefd[1]);
-        opt_notify = saved_notify;
-        return NULL;
-    }
-}
-
-/* Parse a command substitution starting at *p. Supports both $(...) and
- * backtick forms. On success *p is advanced past the closing delimiter and
- * the command's output is returned. NULL is returned on syntax errors or
- * allocation failures. */
-char *parse_substitution(char **p) {
-    if (!p || !*p || !**p)
-        return NULL;
-
-    int depth = 0;
-    int is_dollar = (**p == '$');
-    (*p)++;
-    if (is_dollar) {
-        if (**p != '(')
-            return NULL;
-        (*p)++; /* skip '(' */
-        depth = 1;
-    }
-
-    char cmd[MAX_LINE];
-    int clen = 0;
-    while (**p) {
-        if (is_dollar) {
-            if (**p == '(') {
-                depth++;
-            } else if (**p == ')') {
-                depth--;
-                if (depth == 0) {
-                    (*p)++; /* skip closing ')' */
-                    break;
-                }
-            }
-        } else if (**p == '`') {
-            (*p)++; /* skip closing backtick */
-            break;
-        }
-
-        if (clen < MAX_LINE - 1)
-            cmd[clen++] = **p;
-        (*p)++;
-    }
-
-    if ((is_dollar && depth > 0) || (!is_dollar && *(*p - 1) != '`')) {
-        parse_need_more = 1;
-        return NULL;
-    }
-
-    cmd[clen] = '\0';
-    char *res = command_output(cmd);
-    if (!res)
-        return NULL;
-    return res;
 }
 
 /* -- Expansion helper functions --------------------------------------- */

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -5,9 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-/* Forward declaration from lexer_expand.c */
-char *parse_substitution(char **p);
+#include "cmd_subst.h"
 static char *parse_quoted_word(char **p, int *quoted, int *do_expand_out);
 static char *parse_ansi_quoted_word(char **p, int *quoted, int *do_expand_out);
 


### PR DESCRIPTION
## Summary
- add new `cmd_subst.c` and `cmd_subst.h` implementing command substitutions
- include `cmd_subst` header where needed and update Makefile
- remove the old implementation from `lexer_expand.c`
- include the new header in token and expansion code

## Testing
- `make`
- `make test` *(fails: `FAILED: test_negate.expect`, `FAILED: test_negate_multi.expect`)*

------
https://chatgpt.com/codex/tasks/task_e_6853086fc2f483248d0464233dcaaa5b