### PR TITLE
Separate history expansion logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/builtins_misc.c src/builtins_test.c src/builtins_print.c src/builtins_history.c src/builtins_time.c src/builtins_sys.c \
        src/builtins_signals.c src/execute.c src/history.c \
        src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
-       src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/var_expand.c src/arith.c \
+       src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/history_expand.c src/var_expand.c src/arith.c \
        src/cmd_subst.c \
        src/parser_utils.c src/parser_clauses.c \
        src/parser_pipeline.c \

--- a/src/history_expand.c
+++ b/src/history_expand.c
@@ -1,0 +1,103 @@
+/*
+ * History expansion helper.
+ *
+ * Provides expand_history() used to replace leading '!'
+ * references with the corresponding history entry.
+ */
+#define _GNU_SOURCE
+#include "history_expand.h"
+#include "history.h"
+#include "parser.h" /* for MAX_LINE */
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int last_status;
+
+char *expand_history(const char *line) {
+    const char *p = line;
+    while (*p == ' ' || *p == '\t')
+        p++;
+    if (*p != '!')
+        return strdup(line);
+    if (p[1] == '\0' || isspace((unsigned char)p[1]))
+        return strdup(line);
+    const char *bang = p;
+    const char *rest;
+    char *expansion = NULL;
+    char pref[MAX_LINE];
+    if (p[1] == '!' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
+        const char *tmp = history_last();
+        if (tmp)
+            expansion = strdup(tmp);
+        rest = p + 2;
+        if (!expansion) {
+            fprintf(stderr, "history: event not found\n");
+            last_status = 1;
+            return NULL;
+        }
+    } else if (isdigit((unsigned char)p[1]) ||
+               (p[1] == '-' && isdigit((unsigned char)p[2]))) {
+        int neg = (p[1] == '-');
+        p += neg ? 2 : 1;
+        int n = 0;
+        while (isdigit((unsigned char)*p) && n < MAX_LINE - 1)
+            pref[n++] = *p++;
+        pref[n] = '\0';
+        rest = p;
+        int id = atoi(pref);
+        const char *tmp = neg ? history_get_relative(id) : history_get_by_id(id);
+        if (tmp)
+            expansion = strdup(tmp);
+        if (!expansion) {
+            fprintf(stderr, "history: event not found: %s%s\n", neg ? "-" : "", pref);
+            last_status = 1;
+            return NULL;
+        }
+    } else if (p[1] == '$' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
+        expansion = history_last_word();
+        rest = p + 2;
+        if (!expansion) {
+            fprintf(stderr, "history: event not found: $\n");
+            last_status = 1;
+            return NULL;
+        }
+    } else if (p[1] == '*' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
+        expansion = history_all_words();
+        rest = p + 2;
+        if (!expansion) {
+            fprintf(stderr, "history: event not found: *\n");
+            last_status = 1;
+            return NULL;
+        }
+    } else {
+        int n = 0;
+        p++;
+        while (*p && !isspace((unsigned char)*p) && n < MAX_LINE - 1)
+            pref[n++] = *p++;
+        pref[n] = '\0';
+        const char *tmp = history_find_prefix(pref);
+        if (tmp)
+            expansion = strdup(tmp);
+        rest = p;
+        if (!expansion) {
+            fprintf(stderr, "history: event not found: %s\n", pref);
+            last_status = 1;
+            return NULL;
+        }
+    }
+    size_t pre_len = (size_t)(bang - line);
+    size_t exp_len = strlen(expansion);
+    size_t rest_len = strlen(rest);
+    char *res = malloc(pre_len + exp_len + rest_len + 1);
+    if (!res) {
+        free(expansion);
+        return NULL;
+    }
+    memcpy(res, line, pre_len);
+    memcpy(res + pre_len, expansion, exp_len);
+    memcpy(res + pre_len + exp_len, rest, rest_len + 1);
+    free(expansion);
+    return res;
+}

--- a/src/history_expand.h
+++ b/src/history_expand.h
@@ -1,0 +1,6 @@
+#ifndef HISTORY_EXPAND_H
+#define HISTORY_EXPAND_H
+
+char *expand_history(const char *line);
+
+#endif /* HISTORY_EXPAND_H */

--- a/src/repl.c
+++ b/src/repl.c
@@ -8,6 +8,7 @@
 #include "parser.h"
 #include "execute.h"
 #include "history.h"
+#include "history_expand.h"
 #include "var_expand.h"
 #include "lineedit.h"
 #include "jobs.h"

--- a/src/startup.c
+++ b/src/startup.c
@@ -6,6 +6,7 @@
 #include "startup.h"
 #include "parser.h"
 #include "history.h"
+#include "history_expand.h"
 #include "var_expand.h"
 #include "execute.h"
 #include "util.h"

--- a/src/var_expand.c
+++ b/src/var_expand.c
@@ -1,7 +1,6 @@
 #define _GNU_SOURCE
 #include "var_expand.h"
 #include "lexer.h"
-#include "history.h"
 #include "builtins.h"
 #include "vars.h"
 #include "scriptargs.h"
@@ -757,93 +756,6 @@ char *expand_simple(const char *token) {
     }
 
     return expand_plain_var(token + 1);
-}
-
-char *expand_history(const char *line) {
-    const char *p = line;
-    while (*p == ' ' || *p == '\t')
-        p++;
-    if (*p != '!')
-        return strdup(line);
-    if (p[1] == '\0' || isspace((unsigned char)p[1]))
-        return strdup(line);
-    const char *bang = p;
-    const char *rest;
-    char *expansion = NULL;
-    char pref[MAX_LINE];
-    if (p[1] == '!' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
-        const char *tmp = history_last();
-        if (tmp)
-            expansion = strdup(tmp);
-        rest = p + 2;
-        if (!expansion) {
-            fprintf(stderr, "history: event not found\n");
-            last_status = 1;
-            return NULL;
-        }
-    } else if (isdigit((unsigned char)p[1]) ||
-               (p[1] == '-' && isdigit((unsigned char)p[2]))) {
-        int neg = (p[1] == '-');
-        p += neg ? 2 : 1;
-        int n = 0;
-        while (isdigit((unsigned char)*p) && n < MAX_LINE - 1)
-            pref[n++] = *p++;
-        pref[n] = '\0';
-        rest = p;
-        int id = atoi(pref);
-        const char *tmp = neg ? history_get_relative(id) : history_get_by_id(id);
-        if (tmp)
-            expansion = strdup(tmp);
-        if (!expansion) {
-            fprintf(stderr, "history: event not found: %s%s\n", neg ? "-" : "", pref);
-            last_status = 1;
-            return NULL;
-        }
-    } else if (p[1] == '$' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
-        expansion = history_last_word();
-        rest = p + 2;
-        if (!expansion) {
-            fprintf(stderr, "history: event not found: $\n");
-            last_status = 1;
-            return NULL;
-        }
-    } else if (p[1] == '*' && (p[2] == '\0' || isspace((unsigned char)p[2]))) {
-        expansion = history_all_words();
-        rest = p + 2;
-        if (!expansion) {
-            fprintf(stderr, "history: event not found: *\n");
-            last_status = 1;
-            return NULL;
-        }
-    } else {
-        int n = 0;
-        p++;
-        while (*p && !isspace((unsigned char)*p) && n < MAX_LINE - 1)
-            pref[n++] = *p++;
-        pref[n] = '\0';
-        const char *tmp = history_find_prefix(pref);
-        if (tmp)
-            expansion = strdup(tmp);
-        rest = p;
-        if (!expansion) {
-            fprintf(stderr, "history: event not found: %s\n", pref);
-            last_status = 1;
-            return NULL;
-        }
-    }
-    size_t pre_len = (size_t)(bang - line);
-    size_t exp_len = strlen(expansion);
-    size_t rest_len = strlen(rest);
-    char *res = malloc(pre_len + exp_len + rest_len + 1);
-    if (!res) {
-        free(expansion);
-        return NULL;
-    }
-    memcpy(res, line, pre_len);
-    memcpy(res + pre_len, expansion, exp_len);
-    memcpy(res + pre_len + exp_len, rest, rest_len + 1);
-    free(expansion);
-    return res;
 }
 
 /* Expand simple brace patterns like {foo,bar} or {1..3}. Returns an array

--- a/src/var_expand.h
+++ b/src/var_expand.h
@@ -5,7 +5,6 @@ char *expand_var(const char *token);
 char *ansi_unescape(const char *src);
 char *expand_simple(const char *token);
 char **split_fields(const char *text, int *count);
-char *expand_history(const char *line);
 char **expand_braces(const char *word, int *count_out);
 char *expand_prompt(const char *prompt);
 


### PR DESCRIPTION
## Summary
- introduce `history_expand.c` and `history_expand.h`
- move `expand_history` from `var_expand.c` into new module
- include `history_expand.h` where needed
- update build rules for the new file

## Testing
- `make`
- `make test` *(fails: test_negate.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6853182af4ac832480e7e023645b1fa5