### PR TITLE
Encapsulate globals with ShellState

### DIFF
--- a/src/arith.c
+++ b/src/arith.c
@@ -4,7 +4,6 @@
  *
  * Expressions are parsed using a tiny recursive–descent parser with the
  * following grammar.  Each non‑terminal corresponds to a static parse_*()
- * function below.
  *
  *   expression  := assignment
  *   assignment  := NAME '=' assignment |
@@ -29,6 +28,7 @@
  * string and returns the resulting numeric value.
  */
 #include "vars.h" // for set_shell_var and get_shell_var
+#include "shell_state.h"
 #include "arith.h"
 #include <ctype.h>
 #include <stdlib.h>
@@ -37,7 +37,6 @@
 #include <limits.h>
 #include <errno.h>
 
-extern int last_status;
 
 #define PARSE_RHS(fn)              \
     long long rhs = fn(state);    \

--- a/src/builtins_core.c
+++ b/src/builtins_core.c
@@ -5,6 +5,7 @@
  */
 #define _GNU_SOURCE
 #include "builtins.h"
+#include "shell_state.h"
 #include "vars.h"
 #include "history.h"
 #include <stdio.h>
@@ -12,7 +13,6 @@
 #include <unistd.h>
 #include <errno.h>
 
-extern int last_status;
 
 /* Exit the shell, freeing resources and using the provided status
  * or the status of the last command when none is given. */

--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -16,7 +16,6 @@
 #include <limits.h>
 #include <sys/wait.h>
 
-extern int last_status;
 extern FILE *parse_input;
 
 static int prepare_source_args(char **args, int *old_argc, char ***old_argv,

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -21,8 +21,8 @@
 #include <unistd.h>
 #include <limits.h>
 #include "util.h"
+#include "shell_state.h"
 
-extern int last_status;
 
 static FuncEntry *functions = NULL;
 

--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-extern int last_status;
 
 /* Pointer into the current $@ item being parsed by getopts. When script_argv
  * is replaced or freed this must be cleared so it does not reference stale

--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -5,6 +5,7 @@
 #include "execute.h"
 #include "util.h"
 
+#include "shell_state.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,7 +16,6 @@
 #include <ctype.h>
 #include <stdbool.h>
 
-extern int last_status;
 
 /* Display the command history or modify it with -c to clear or -d N to
  * delete a specific entry. */

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -4,7 +4,6 @@
  * This file gathers builtins that don't fit the alias, variable,
  * file system or job-control groups.  Keeping them here avoids
  * cluttering those more focused modules.
- *
  * Some helpers, such as `source` and `eval`, invoke the parser and
  * executor directly so they behave like normal command evaluation.
  */
@@ -16,7 +15,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
-extern int last_status;
+#include "shell_state.h"
 /* Manage or display command hash table. */
 int builtin_hash(char **args) {
     int i = 1;

--- a/src/builtins_print.c
+++ b/src/builtins_print.c
@@ -5,11 +5,11 @@
 #include "builtins.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "shell_state.h"
 #include <string.h>
 #include <ctype.h>
 #include <stdint.h>
 
-extern int last_status;
 
 /* Print arguments separated by spaces. Supports -n to suppress the
  * trailing newline and -e to interpret common backslash escapes. */

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -5,9 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "shell_state.h"
 #include <unistd.h>
 #include <errno.h>
-extern int last_status;
 
 /* ---- helper functions for builtin_read -------------------------------- */
 static int parse_read_options(char **args, int *raw, const char **array_name,

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "shell_state.h"
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
@@ -12,7 +13,6 @@
 #include "signal_map.h"
 #include "util.h"
 
-extern int last_status;
 void list_signals(void);
 
 /* Map signal names to numbers for trap builtin is now defined in signal_map.h */

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -5,6 +5,7 @@
  * creation masks such as `ulimit` and `umask`.
  */
 #define _GNU_SOURCE
+#include "shell_state.h"
 #include "builtins.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,7 +15,6 @@
 #include <sys/stat.h>
 #include <sys/resource.h>
 
-extern int last_status;
 
 /* Helper to print a mask in symbolic form like u=rwx,g=rx,o=rx. */
 static void print_symbolic_umask(mode_t mask)

--- a/src/builtins_test.c
+++ b/src/builtins_test.c
@@ -5,6 +5,7 @@
  * expression evaluator.
  */
 #define _GNU_SOURCE
+#include "shell_state.h"
 #include "builtins.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,7 +14,6 @@
 #include <sys/stat.h>
 #include <fnmatch.h>
 
-extern int last_status;
 
 static int eval_primary(char ***cur);
 static int eval_not(char ***cur);

--- a/src/builtins_time.c
+++ b/src/builtins_time.c
@@ -5,11 +5,11 @@
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <time.h>
+#include "shell_state.h"
 #include <string.h>
 #include <sys/times.h>
 #include <unistd.h>
 
-extern int last_status;
 
 static int do_time(int posix, int (*func)(void *), void *data)
 {

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -27,7 +27,6 @@
 #include "util.h"
 #include "assignment_utils.h"
 
-extern int last_status;
 
 
 static void print_option(const char *name, int enabled)

--- a/src/cmd_subst.c
+++ b/src/cmd_subst.c
@@ -10,7 +10,6 @@
 #include <sys/wait.h>
 #include <stdio.h>
 
-extern int last_status;
 
 /* Execute CMD and capture its stdout using the shell itself so that shell
  * variables and functions are visible.  The command's output is returned as a

--- a/src/control.c
+++ b/src/control.c
@@ -5,6 +5,7 @@
  */
 #define _GNU_SOURCE
 #include <stdio.h>
+#include "shell_state.h"
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -21,7 +22,6 @@
 #include "util.h"
 #include "var_expand.h"
 
-extern int last_status;
 
 int exec_if(Command *cmd, const char *line) {
     run_command_list(cmd->cond, line);

--- a/src/execute.c
+++ b/src/execute.c
@@ -33,8 +33,6 @@
 #include "assignment_utils.h"
 #include "control.h"
 
-extern int last_status;
-extern int param_error;
 
 int loop_break = 0;
 int loop_continue = 0;

--- a/src/func_exec.c
+++ b/src/func_exec.c
@@ -19,7 +19,6 @@
 #include "vars.h"
 #include "util.h"
 
-extern int last_status;
 
 int func_return = 0;
 

--- a/src/history_expand.c
+++ b/src/history_expand.c
@@ -5,6 +5,7 @@
  * references with the corresponding history entry.
  */
 #define _GNU_SOURCE
+#include "shell_state.h"
 #include "history_expand.h"
 #include "history.h"
 #include "parser.h" /* for MAX_LINE */
@@ -13,7 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern int last_status;
 
 char *expand_history(const char *line) {
     const char *p = line;

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -20,7 +20,6 @@
 #include "util.h"
 #include "cmd_subst.h"
 
-extern int last_status;
 
 /* Append STR to OUT reallocating as needed. Returns 0 on allocation failure. */
 static int append_str(char **out, size_t *len, const char *str) {

--- a/src/main.c
+++ b/src/main.c
@@ -32,8 +32,8 @@
 #include "lexer.h"
 #include "history.h"
 #include "lineedit.h"
+#include "shell_state.h"
 #include "scriptargs.h"
-#include "options.h"
 #include "dirstack.h"
 #include "util.h"
 #include "version.h"
@@ -44,30 +44,12 @@
 #include "repl.h"
 
 
-int last_status = 0;
-int param_error = 0;
-int script_argc = 0;
-char **script_argv = NULL;
-int opt_errexit = 0;
-int opt_nounset = 0;
-int opt_xtrace = 0;
-int opt_verbose = 0;
-int opt_pipefail = 0;
-int opt_ignoreeof = 0;
-int opt_noclobber = 0;
-int opt_noexec = 0;
-int opt_noglob = 0;
-int opt_allexport = 0;
-int opt_monitor = 1;
-int opt_notify = 1;
-int opt_privileged = 0;
-int opt_posix = 0;
-int opt_onecmd = 0;
-int opt_hashall = 0;
-int opt_keyword = 0;
-int current_lineno = 0;
-pid_t parent_pid = 0;
+ShellState shell_state = {
+    .opt_monitor = 1,
+    .opt_notify = 1
+};
 
+#include "options.h"
 
 int main(int argc, char **argv) {
 

--- a/src/options.h
+++ b/src/options.h
@@ -1,26 +1,26 @@
 #ifndef OPTIONS_H
 #define OPTIONS_H
 
-#include <sys/types.h>
+#include "shell_state.h"
 
-extern int opt_errexit;
-extern int opt_nounset;
-extern int opt_xtrace;
-extern int opt_verbose;
-extern int opt_pipefail;
-extern int opt_ignoreeof;
-extern int opt_noclobber;
-extern int opt_noexec;
-extern int opt_noglob;
-extern int opt_allexport;
-extern int opt_monitor;
-extern int opt_notify;
-extern int opt_privileged;
-extern int opt_posix;
-extern int opt_onecmd;
-extern int opt_hashall;
-extern int opt_keyword;
-extern int current_lineno;
-extern pid_t parent_pid;
+#define opt_errexit   (shell_state.opt_errexit)
+#define opt_nounset   (shell_state.opt_nounset)
+#define opt_xtrace    (shell_state.opt_xtrace)
+#define opt_verbose   (shell_state.opt_verbose)
+#define opt_pipefail  (shell_state.opt_pipefail)
+#define opt_ignoreeof (shell_state.opt_ignoreeof)
+#define opt_noclobber (shell_state.opt_noclobber)
+#define opt_noexec    (shell_state.opt_noexec)
+#define opt_noglob    (shell_state.opt_noglob)
+#define opt_allexport (shell_state.opt_allexport)
+#define opt_monitor   (shell_state.opt_monitor)
+#define opt_notify    (shell_state.opt_notify)
+#define opt_privileged (shell_state.opt_privileged)
+#define opt_posix     (shell_state.opt_posix)
+#define opt_onecmd    (shell_state.opt_onecmd)
+#define opt_hashall   (shell_state.opt_hashall)
+#define opt_keyword   (shell_state.opt_keyword)
+#define current_lineno (shell_state.current_lineno)
+#define parent_pid    (shell_state.parent_pid)
 
 #endif /* OPTIONS_H */

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -24,7 +24,6 @@
 extern char *process_substitution(char **p, int read_from);
 extern char *gather_dbl_parens(char **p); /* for arithmetic for loops */
 extern char *trim_ws(const char *s);
-extern int last_status;
 
 #define MAX_ALIAS_DEPTH 10
 

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -5,6 +5,7 @@
 #include "parser.h"
 #include "lexer.h"
 #include "execute.h"
+#include "shell_state.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -16,7 +17,6 @@
 #include <sys/stat.h>
 #include <signal.h>
 
-extern int last_status;
 
 /* Temporary variable tracking for process substitutions */
 struct proc_sub {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -26,7 +26,6 @@
 #include "options.h"
 #include "hash.h"
 #include "redir.h"
-extern int last_status;
 
 
 /*

--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -28,8 +28,6 @@
 #include "assignment_utils.h"
 #include "parser.h"
 
-extern int last_status;
-extern int param_error;
 
 static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
                                    const char *line);

--- a/src/repl.c
+++ b/src/repl.c
@@ -18,7 +18,6 @@
 #include "options.h"
 #include "vars.h"
 
-extern int last_status;
 
 void repl_loop(FILE *input)
 {

--- a/src/scriptargs.h
+++ b/src/scriptargs.h
@@ -1,18 +1,11 @@
 #ifndef SCRIPTARGS_H
 #define SCRIPTARGS_H
 
-/*
- * Store the argument vector for the currently running script or function.
- *
- * script_argv[0] holds the script name just like $0. When a shell function is
- * invoked, these globals are replaced with copies of the function's arguments
- * so that $1, $2, ... expand correctly within the body. They are restored once
- * the function returns.
- */
+#include "shell_state.h"
 
 /* Number of positional parameters; updated before a function body executes. */
-extern int script_argc;
+#define script_argc (shell_state.script_argc)
 /* Null terminated array of parameters; swapped during function calls. */
-extern char **script_argv;
+#define script_argv (shell_state.script_argv)
 
 #endif /* SCRIPTARGS_H */

--- a/src/shell_state.h
+++ b/src/shell_state.h
@@ -1,0 +1,42 @@
+#ifndef SHELL_STATE_H
+#define SHELL_STATE_H
+
+#include <sys/types.h>
+
+/*
+ * Central structure storing shell runtime state.
+ */
+typedef struct ShellState {
+    int last_status;
+    int param_error;
+    int script_argc;
+    char **script_argv;
+    int opt_errexit;
+    int opt_nounset;
+    int opt_xtrace;
+    int opt_verbose;
+    int opt_pipefail;
+    int opt_ignoreeof;
+    int opt_noclobber;
+    int opt_noexec;
+    int opt_noglob;
+    int opt_allexport;
+    int opt_monitor;
+    int opt_notify;
+    int opt_privileged;
+    int opt_posix;
+    int opt_onecmd;
+    int opt_hashall;
+    int opt_keyword;
+    int current_lineno;
+    pid_t parent_pid;
+} ShellState;
+
+extern ShellState shell_state;
+
+#define last_status  (shell_state.last_status)
+#define param_error  (shell_state.param_error)
+#define script_argc  (shell_state.script_argc)
+#define script_argv  (shell_state.script_argv)
+
+#endif /* SHELL_STATE_H */

--- a/src/startup.c
+++ b/src/startup.c
@@ -12,7 +12,6 @@
 #include "util.h"
 #include "options.h"
 
-extern int last_status;
 
 /* Source the specified RC file and execute its commands. */
 int process_rc_file(const char *path, FILE *input)

--- a/src/trap.c
+++ b/src/trap.c
@@ -5,9 +5,9 @@
 #include "trap.h"
 #include "parser.h"
 #include "execute.h"
+#include "shell_state.h"
 #include "builtins.h"
 
-extern int last_status;
 
 static volatile sig_atomic_t pending_traps[NSIG];
 

--- a/src/var_expand.c
+++ b/src/var_expand.c
@@ -19,8 +19,6 @@
 #include "util.h"
 #include "cmd_subst.h"
 
-extern int last_status;
-extern int param_error;
 
 
 char **split_fields(const char *text, int *count_out) {


### PR DESCRIPTION
## Summary
- add `shell_state.h` defining a `ShellState` struct
- replace global variables in `main.c` with a single instance
- map option and argument globals through macros
- update modules to include `shell_state.h`

## Testing
- `make -j4`
- `make test` *(fails: test_negate.expect, test_negate_multi.expect)*

------
https://chatgpt.com/codex/tasks/task_e_6853595e40f48324a34199ca3a7d829e