### PR TITLE
Refactor expansion helpers into modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/builtins_misc.c src/builtins_test.c src/builtins_print.c src/builtins_history.c src/builtins_time.c src/builtins_sys.c \
        src/builtins_signals.c src/execute.c src/history.c \
        src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
-       src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/history_expand.c src/var_expand.c src/prompt_expand.c src/brace_expand.c src/arith.c \
+       src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/history_expand.c src/param_expand.c src/field_split.c src/quote_utils.c src/prompt_expand.c src/brace_expand.c src/arith.c \
        src/cmd_subst.c \
        src/parser_utils.c src/parser_clauses.c \
        src/parser_pipeline.c src/parser_here_doc.c src/alias_expand.c \

--- a/src/field_split.c
+++ b/src/field_split.c
@@ -1,0 +1,140 @@
+#define _GNU_SOURCE
+#include "var_expand.h"
+#include "vars.h"
+#include <stdlib.h>
+#include <string.h>
+
+char **split_fields(const char *text, int *count_out) {
+    if (count_out)
+        *count_out = 0;
+
+    const char *ifs = get_shell_var("IFS");
+    if (!ifs)
+        ifs = getenv("IFS");
+    if (!ifs)
+        ifs = " \t\n";
+
+    if (!*ifs) {
+        char **res = malloc(2 * sizeof(char *));
+        if (!res)
+            return NULL;
+        res[0] = strdup(text);
+        if (!res[0]) {
+            free(res);
+            return NULL;
+        }
+        res[1] = NULL;
+        if (count_out)
+            *count_out = 1;
+        return res;
+    }
+
+    char ws_tab[256] = {0};
+    char other_tab[256] = {0};
+    for (const char *p = ifs; *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c == ' ' || c == '\t' || c == '\n')
+            ws_tab[c] = 1;
+        else
+            other_tab[c] = 1;
+    }
+
+    char *dup = strdup(text);
+    if (!dup)
+        return NULL;
+    char *p = dup;
+    char *field_start = dup;
+    char **out = NULL;
+    int count = 0;
+    int last_nonspace = 0;
+
+    while (*p) {
+        unsigned char c = (unsigned char)*p;
+        if (ws_tab[c]) {
+            if (p > field_start) {
+                char save = *p;
+                *p = '\0';
+                char **tmp = realloc(out, sizeof(char *) * (count + 1));
+                if (!tmp) {
+                    goto fail;
+                }
+                out = tmp;
+                out[count] = strdup(field_start);
+                if (!out[count]) {
+                    goto fail;
+                }
+                count++;
+                *p = save;
+            }
+            while (ws_tab[(unsigned char)*p])
+                p++;
+            field_start = p;
+            last_nonspace = 0;
+            continue;
+        } else if (other_tab[c]) {
+            char save = *p;
+            *p = '\0';
+            char **tmp = realloc(out, sizeof(char *) * (count + 1));
+            if (!tmp) {
+                goto fail;
+            }
+            out = tmp;
+            out[count] = strdup(field_start);
+            if (!out[count]) {
+                goto fail;
+            }
+            count++;
+            *p = save;
+            p++;
+            field_start = p;
+            last_nonspace = 1;
+            continue;
+        }
+        last_nonspace = 0;
+        p++;
+    }
+
+    if (p > field_start || last_nonspace) {
+        char **tmp = realloc(out, sizeof(char *) * (count + 1));
+        if (!tmp) {
+            goto fail;
+        }
+        out = tmp;
+        out[count] = strdup(field_start);
+        if (!out[count]) {
+            goto fail;
+        }
+        count++;
+    }
+
+    free(dup);
+
+    if (count == 0) {
+        out = malloc(sizeof(char *));
+        if (!out)
+            return NULL;
+        out[0] = NULL;
+    } else {
+        char **tmp = realloc(out, sizeof(char *) * (count + 1));
+        if (!tmp) {
+            goto fail_alloc;
+        }
+        out = tmp;
+        out[count] = NULL;
+    }
+    if (count_out)
+        *count_out = count;
+    return out;
+
+fail:
+    free(dup);
+fail_alloc:
+    if (out) {
+        for (int i = 0; i < count; i++)
+            free(out[i]);
+        free(out);
+    }
+    if (count_out)
+        *count_out = 0;
+    return NULL;
+}

--- a/src/quote_utils.c
+++ b/src/quote_utils.c
@@ -1,0 +1,45 @@
+#define _GNU_SOURCE
+#include "var_expand.h"
+#include <stdlib.h>
+#include <string.h>
+
+char *ansi_unescape(const char *src) {
+    size_t len = strlen(src);
+    char *out = malloc(len + 1);
+    if (!out)
+        return NULL;
+    char *d = out;
+    for (const char *s = src; *s; s++) {
+        if (*s == '\\' && s[1]) {
+            s++;
+            switch (*s) {
+            case 'n': *d++ = '\n'; break;
+            case 't': *d++ = '\t'; break;
+            case 'r': *d++ = '\r'; break;
+            case 'b': *d++ = '\b'; break;
+            case 'a': *d++ = '\a'; break;
+            case 'f': *d++ = '\f'; break;
+            case 'v': *d++ = '\v'; break;
+            case '\\': *d++ = '\\'; break;
+            case '\'': *d++ = '\''; break;
+            case '"': *d++ = '"'; break;
+            case '0': {
+                int val = 0, cnt = 0;
+                while (cnt < 3 && s[1] >= '0' && s[1] <= '7') {
+                    s++; cnt++; val = val * 8 + (*s - '0');
+                }
+                *d++ = (char)val;
+                break;
+            }
+            default:
+                *d++ = '\\';
+                *d++ = *s;
+                break;
+            }
+        } else {
+            *d++ = *s;
+        }
+    }
+    *d = '\0';
+    return out;
+}

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -45,6 +45,9 @@ test_export_p_listing.expect
 test_export_n_unexport.expect
 test_readonly_p.expect
 test_set_list.expect
+test_field_split_module.expect
+test_param_expand_module.expect
+test_quote_utils_module.expect
 "
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_field_split_module.expect
+++ b/tests/test_field_split_module.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "IFS=:\r"
+expect {
+    "vush> " {}
+    timeout { send_user "set IFS failed\n"; exit 1 }
+}
+send "set -- a:b::c:\r"
+expect {
+    "vush> " {}
+    timeout { send_user "set args failed\n"; exit 1 }
+}
+send "echo \$#\r"
+expect {
+    -re "\r\n5\r\nvush> " {}
+    timeout { send_user "count failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_param_expand_module.expect
+++ b/tests/test_param_expand_module.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "unset FOO\r"
+expect {
+    "vush> " {}
+    timeout { send_user "unset failed\n"; exit 1 }
+}
+send "echo \${FOO:-bar}\r"
+expect {
+    -re "\r\nbar\r\nvush> " {}
+    timeout { send_user "expand failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_quote_utils_module.expect
+++ b/tests/test_quote_utils_module.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush -c {printf '%s\n' $'x\ny'}
+expect {
+    -re "x\r\ny\r" {}
+    timeout { send_user "quote failed\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- split `split_fields` into `field_split.c`
- factor out parameter expansion helpers into `param_expand.c`
- move quoting utilities to `quote_utils.c`
- adjust Makefile for new sources
- add minimal tests for each new module

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68535ded78cc83249e05fdac87ccfed8