### PR TITLE
Add error handling macros

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include "util.h"
+#include "error.h"
 
 struct alias_entry {
     char *name;
@@ -98,20 +99,17 @@ static int set_alias(const char *name, const char *value)
     remove_all_aliases(name);
 
     struct alias_entry *new_alias = malloc(sizeof(struct alias_entry));
-    if (!new_alias) {
-        perror("malloc");
-        return -1;
-    }
+    CHECK_ALLOC(new_alias);
     new_alias->name = strdup(name);
     if (!new_alias->name) {
         free(new_alias);
-        return -1;
+        RETURN_IF_ERR_RET(1, "strdup", -1);
     }
     new_alias->value = strdup(value);
     if (!new_alias->value) {
         free(new_alias->name);
         free(new_alias);
-        return -1;
+        RETURN_IF_ERR_RET(1, "strdup", -1);
     }
     new_alias->next = NULL;
     if (!aliases) {

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,36 @@
+/*
+ * Error handling macros used across the shell.
+ */
+#ifndef VUSH_ERROR_H
+#define VUSH_ERROR_H
+
+#include <stdio.h>
+
+/*
+ * Check memory allocation and return -1 on failure while printing a
+ * diagnostic with perror().
+ */
+#define CHECK_ALLOC_RET(ptr, retval) \
+    do { \
+        if (!(ptr)) { \
+            perror("malloc"); \
+            return retval; \
+        } \
+    } while (0)
+
+#define CHECK_ALLOC(ptr) CHECK_ALLOC_RET(ptr, -1)
+
+/*
+ * Return -1 when COND is true after reporting MSG with perror().
+ */
+#define RETURN_IF_ERR_RET(cond, msg, retval) \
+    do { \
+        if (cond) { \
+            perror(msg); \
+            return retval; \
+        } \
+    } while (0)
+
+#define RETURN_IF_ERR(cond, msg) RETURN_IF_ERR_RET(cond, msg, -1)
+
+#endif /* VUSH_ERROR_H */

--- a/src/history.c
+++ b/src/history.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include "common.h"
 #include "util.h"
+#include "error.h"
 
 typedef struct HistEntry {
     int id;
@@ -109,7 +110,7 @@ static void history_init(void) {
 static void add_history_entry(const char *cmd, int save_file) {
     history_init();
     HistEntry *e = malloc(sizeof(HistEntry));
-    if (!e) return;
+    RETURN_IF_ERR_RET(!e, "malloc", );
     e->id = next_id++;
     strncpy(e->cmd, cmd, MAX_LINE - 1);
     e->cmd[MAX_LINE - 1] = '\0';
@@ -432,8 +433,7 @@ static char *dup_last_word(const char *cmd) {
         start--;
     size_t len = (size_t)(end - start);
     char *res = malloc(len + 1);
-    if (!res)
-        return NULL;
+    CHECK_ALLOC_RET(res, NULL);
     memcpy(res, start, len);
     res[len] = '\0';
     return res;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -26,6 +26,7 @@
 #include "options.h"
 #include "hash.h"
 #include "redir.h"
+#include "error.h"
 
 
 /*
@@ -64,10 +65,8 @@ pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
     }
 
     int pipefd[2];
-    if (seg->next && pipe(pipefd) < 0) {
-        perror("pipe");
-        return -1;
-    }
+    if (seg->next)
+        RETURN_IF_ERR(pipe(pipefd) < 0, "pipe");
 
     pid_t pid = fork();
     if (pid == 0) {


### PR DESCRIPTION
## Summary
- add shared `CHECK_ALLOC` and `RETURN_IF_ERR` macros
- use the macros in `builtins_alias.c`, `history.c` and `pipeline.c`

## Testing
- `make test` *(fails: spawn id not open)*

------
https://chatgpt.com/codex/tasks/task_e_68537a493a4c8324b5b03142d3fc9ae9