### PR TITLE
Refactor modules to use shared list API

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -7,6 +7,7 @@
 #define BUILTINS_H
 
 #include "parser.h"
+#include "list.h"
 #include <signal.h>
 #ifndef NSIG
 #define NSIG _NSIG
@@ -46,7 +47,7 @@ typedef struct func_entry {
     char *name;
     char *text;
     Command *body;
-    struct func_entry *next;
+    ListNode node;
 } FuncEntry;
 void define_function(const char *name, Command *body, const char *text);
 FuncEntry *find_function(const char *name);

--- a/src/list.h
+++ b/src/list.h
@@ -1,0 +1,48 @@
+#ifndef VUSH_LIST_H
+#define VUSH_LIST_H
+
+#include <stddef.h>
+
+typedef struct ListNode {
+    struct ListNode *next;
+    struct ListNode *prev;
+} ListNode;
+
+typedef struct {
+    ListNode *head;
+    ListNode *tail;
+} List;
+
+static inline void list_init(List *list) {
+    list->head = NULL;
+    list->tail = NULL;
+}
+
+static inline void list_append(List *list, ListNode *node) {
+    node->next = NULL;
+    node->prev = list->tail;
+    if (list->tail)
+        list->tail->next = node;
+    else
+        list->head = node;
+    list->tail = node;
+}
+
+static inline void list_remove(List *list, ListNode *node) {
+    if (node->prev)
+        node->prev->next = node->next;
+    else
+        list->head = node->next;
+    if (node->next)
+        node->next->prev = node->prev;
+    else
+        list->tail = node->prev;
+}
+
+#define LIST_FOR_EACH(var, list) \
+    for (ListNode *var = (list)->head; var; var = var->next)
+
+#define LIST_ENTRY(ptr, type, member) \
+    ((type *)((char *)(ptr) - offsetof(type, member)))
+
+#endif /* VUSH_LIST_H */


### PR DESCRIPTION
## Summary
- add generic doubly-linked list helper `list.h`
- switch alias, function and history code to use `List` helpers
- simplify data structures and operations in those modules

## Testing
- `make`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_685381e130748324b15a000c4331f4fd