### PR TITLE
Refactor history management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SRCS := src/builtins.c src/builtins_core.c src/builtins_fs.c src/builtins_jobs.c
        src/builtins_alias.c src/builtins_func.c src/builtins_vars.c \
        src/builtins_read.c src/builtins_getopts.c src/builtins_exec.c src/vars.c \
        src/builtins_misc.c src/builtins_test.c src/builtins_print.c src/builtins_history.c src/builtins_time.c src/builtins_sys.c \
-       src/builtins_signals.c src/execute.c src/history.c \
+       src/builtins_signals.c src/execute.c src/history_list.c src/history_file.c \
        src/jobs.c src/lineedit.c src/history_search.c src/completion.c \
        src/parser.c src/lexer.c src/lexer_token.c src/lexer_expand.c src/history_expand.c src/param_expand.c src/field_split.c src/quote_utils.c src/prompt_expand.c src/brace_expand.c src/arith.c \
        src/cmd_subst.c \

--- a/src/history_file.c
+++ b/src/history_file.c
@@ -1,0 +1,83 @@
+#define _GNU_SOURCE
+#include "history.h"
+#include "parser.h" /* for MAX_LINE */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "util.h"
+#include "error.h"
+
+/* functions from history_list.c */
+void history_add_entry(const char *cmd, int save_file);
+void history_list_iter(void (*cb)(const char *cmd, void *arg), void *arg);
+void history_renumber(void);
+
+/* Determine the path to the history file. */
+static char *histfile_path(void) {
+    return make_user_path("VUSH_HISTFILE", "HISTFILE", ".vush_history");
+}
+
+/* Append CMD to the history file. */
+void history_file_append(const char *cmd) {
+    char *path = histfile_path();
+    if (!path)
+        return;
+    FILE *f = fopen(path, "a");
+    free(path);
+    if (!f)
+        return;
+    fprintf(f, "%s\n", cmd);
+    fclose(f);
+}
+
+struct rewrite_ctx { FILE *f; };
+static void rewrite_cb(const char *cmd, void *arg) {
+    struct rewrite_ctx *ctx = arg;
+    fprintf(ctx->f, "%s\n", cmd);
+}
+
+/* Rewrite the entire history file from the current list. */
+void history_file_rewrite(void) {
+    char *path = histfile_path();
+    if (!path)
+        return;
+    FILE *f = fopen(path, "w");
+    free(path);
+    if (!f)
+        return;
+    struct rewrite_ctx ctx = { .f = f };
+    history_list_iter(rewrite_cb, &ctx);
+    fclose(f);
+}
+
+/* Truncate the history file. */
+void history_file_clear(void) {
+    char *path = histfile_path();
+    if (!path)
+        return;
+    FILE *f = fopen(path, "w");
+    free(path);
+    if (f)
+        fclose(f);
+}
+
+/* Load history entries from the history file. */
+void load_history(void) {
+    char *path = histfile_path();
+    if (!path)
+        return;
+    FILE *f = fopen(path, "r");
+    free(path);
+    if (!f)
+        return;
+    char line[MAX_LINE];
+    while (fgets(line, sizeof(line), f)) {
+        size_t len = strlen(line);
+        if (len && line[len - 1] == '\n')
+            line[len - 1] = '\0';
+        history_add_entry(line, 0);
+    }
+    fclose(f);
+    history_renumber();
+    history_file_rewrite();
+}


### PR DESCRIPTION
## Summary
- split history logic into list vs file modules
- update Makefile for new source files
- keep public interface via history.h intact

## Testing
- `make`
- `./run_tests.sh` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6853869d872c8324a14d9e24c593fb61