### PR TITLE
Add extended options to read builtin

### DIFF
--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -344,8 +344,11 @@ hi
 - `hash [-r] [name...]` - manage cached command paths.
 - `alias [-p] [NAME[=VALUE]]` - set or display aliases. With no arguments all aliases are listed. A single NAME prints that alias. `-p` lists using `alias NAME='value'` format.
 - `unalias [-a] NAME` - remove aliases. With `-a` all aliases are cleared.
-- `read [-r] VAR...` - read a line of input into variables using the first
-  character of `$IFS` to split fields.
+- `read [-r] [-a NAME] [-p prompt] [-n nchars] [-s] [-t timeout] [-u fd] [VAR...]` -
+  read a line from input. `-a` stores fields in array `NAME`, `-p` displays a
+  prompt, `-n` reads up to `nchars` characters, `-s` disables echo, `-t` sets a
+  timeout in seconds, and `-u` reads from the specified file descriptor. The
+  input is split using the first character of `$IFS`.
 - `return [status]` - return from a shell function with an optional status.
 - `shift [N]` - drop the first `N` positional parameters (default 1).
 - `break [N]` - exit `N` levels of loops (default 1).

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -9,25 +9,51 @@
 #include "strarray.h"
 #include <unistd.h>
 #include <errno.h>
+#include <termios.h>
+#include <sys/select.h>
+#include "util.h"
 
 /* ---- helper functions for builtin_read -------------------------------- */
 static int parse_read_options(char **args, int *raw, const char **array_name,
-                              int *idx) {
+                              const char **prompt, int *nchars, int *silent,
+                              int *timeout, int *fd, int *idx) {
     int i = 1;
     *raw = 0;
     *array_name = NULL;
+    *prompt = NULL;
+    *nchars = -1;
+    *silent = 0;
+    *timeout = -1;
+    *fd = STDIN_FILENO;
 
-    if (args[i] && strcmp(args[i], "-r") == 0) {
-        *raw = 1;
-        i++;
+    for (; args[i] && args[i][0] == '-'; i++) {
+        if (strcmp(args[i], "-r") == 0) {
+            *raw = 1;
+        } else if (strcmp(args[i], "-a") == 0 && args[i + 1]) {
+            *array_name = args[i + 1];
+            i++;
+        } else if (strcmp(args[i], "-p") == 0 && args[i + 1]) {
+            *prompt = args[i + 1];
+            i++;
+        } else if (strcmp(args[i], "-n") == 0 && args[i + 1]) {
+            if (parse_positive_int(args[i + 1], nchars) < 0)
+                return -1;
+            i++;
+        } else if (strcmp(args[i], "-s") == 0) {
+            *silent = 1;
+        } else if (strcmp(args[i], "-t") == 0 && args[i + 1]) {
+            if (parse_positive_int(args[i + 1], timeout) < 0)
+                return -1;
+            i++;
+        } else if (strcmp(args[i], "-u") == 0 && args[i + 1]) {
+            if (parse_positive_int(args[i + 1], fd) < 0)
+                return -1;
+            i++;
+        } else {
+            break;
+        }
     }
 
-    if (args[i] && strcmp(args[i], "-a") == 0 && args[i + 1]) {
-        *array_name = args[i + 1];
-        i += 2;
-    }
-
-    /* Do not error when no variable names remain */
     *idx = i;
     return 0;
 }
@@ -84,41 +110,98 @@ static void assign_read_vars(char **args, int idx, char *line, char sep) {
     }
 }
 
-static int read_terminal_line(char *buf, size_t size) {
+static int read_fd_line(int fd, char *buf, size_t size, int nchars,
+                        int timeout, int silent) {
+    struct termios orig;
+    int use_tty = silent && isatty(fd);
+    if (use_tty) {
+        if (tcgetattr(fd, &orig) == -1)
+            return -1;
+        struct termios raw = orig;
+        raw.c_lflag &= ~(ECHO);
+        if (tcsetattr(fd, TCSAFLUSH, &raw) == -1)
+            return -1;
+    }
+
     size_t pos = 0;
     while (pos < size - 1) {
+        if (timeout >= 0) {
+            fd_set set;
+            FD_ZERO(&set);
+            FD_SET(fd, &set);
+            struct timeval tv = { timeout, 0 };
+            int rv;
+            do {
+                rv = select(fd + 1, &set, NULL, NULL, &tv);
+            } while (rv == -1 && errno == EINTR);
+            if (rv == 0) {
+                if (use_tty)
+                    tcsetattr(fd, TCSANOW, &orig);
+                return 2; /* timeout */
+            }
+            if (rv < 0) {
+                if (use_tty)
+                    tcsetattr(fd, TCSANOW, &orig);
+                return -1;
+            }
+        }
+
         char c;
         ssize_t n;
         do {
-            n = read(STDIN_FILENO, &c, 1);
+            n = read(fd, &c, 1);
         } while (n == -1 && errno == EINTR);
         if (n == 0 || (n > 0 && pos == 0 && c == 0x04)) {
+            if (use_tty)
+                tcsetattr(fd, TCSANOW, &orig);
             errno = 0;
-            last_status = 1;
             return 1; /* EOF */
         }
-        if (n < 0)
+        if (n < 0) {
+            if (use_tty)
+                tcsetattr(fd, TCSANOW, &orig);
             return -1;
+        }
         if (c == '\n' || c == '\r')
             break;
         buf[pos++] = c;
+        if (nchars >= 0 && (int)pos >= nchars)
+            break;
     }
     buf[pos] = '\0';
+    if (use_tty) {
+        tcsetattr(fd, TCSANOW, &orig);
+        putchar('\n');
+        fflush(stdout);
+    }
     return 0;
 }
 
+
 int builtin_read(char **args) {
     int raw = 0;
+    int silent = 0;
+    int nchars = -1;
+    int timeout = -1;
+    int fd = STDIN_FILENO;
     const char *array_name = NULL;
+    const char *prompt = NULL;
     int idx;
-    if (parse_read_options(args, &raw, &array_name, &idx) != 0) {
-        fprintf(stderr, "usage: read [-r] [-a NAME] [NAME...]\n");
+    if (parse_read_options(args, &raw, &array_name, &prompt, &nchars,
+                           &silent, &timeout, &fd, &idx) != 0) {
+        fprintf(stderr,
+                "usage: read [-r] [-a NAME] [-p prompt] [-n nchars] [-s] [-t timeout] [-u fd] [NAME...]\n");
         last_status = 1;
         return 1;
     }
 
+    if (prompt) {
+        fputs(prompt, stdout);
+        fflush(stdout);
+    }
+
     char line[MAX_LINE];
-    int r = read_terminal_line(line, sizeof(line));
+    int r = read_fd_line(fd, line, sizeof(line), nchars, timeout, silent);
     if (r != 0) {
         last_status = 1;
         return 1;

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -72,6 +72,11 @@ test_function.expect
 test_read.expect
 test_read_eof.expect
 test_read_signal.expect
+test_read_p.expect
+test_read_n.expect
+test_read_s.expect
+test_read_t.expect
+test_read_u.expect
 test_case.expect
 test_case_posix.expect
 test_trap.expect

--- a/tests/test_read_n.expect
+++ b/tests/test_read_n.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush -c {printf foobar | read -n 3 var; echo $var}
+expect {
+    -re "foo\r?\n" {}
+    timeout { send_user "read -n failed\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_read_p.expect
+++ b/tests/test_read_p.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "read -p 'foo> ' var\r"
+expect {
+    "foo> " {}
+    timeout { send_user "prompt missing\n"; exit 1 }
+}
+send "bar\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo $var\r"
+expect {
+    -re "\[\r\n\]+bar\[\r\n\]+vush> " {}
+    timeout { send_user "read -p failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_read_s.expect
+++ b/tests/test_read_s.expect
@@ -1,0 +1,23 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "read -s var\r"
+send "hidden\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo $var\r"
+expect {
+    -re "\[\r\n\]+hidden\[\r\n\]+vush> " {}
+    timeout { send_user "silent read failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_read_t.expect
+++ b/tests/test_read_t.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "read -t 1 var\r"
+expect {
+    "vush> " {}
+    timeout { send_user "timeout failed\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_read_u.expect
+++ b/tests/test_read_u.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush -c {exec 3<<<"hello"; read -u 3 var; echo $var}
+expect {
+    -re "hello\r?\n" {}
+    timeout { send_user "read -u failed\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- support additional `read` options: `-p`, `-n`, `-s`, `-t`, and `-u`
- display prompts, limit characters, silence echo, allow timeouts and alternate descriptors
- document new options
- test the new functionality

## Testing
- `make test` *(fails: `send: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_6857125f4bec8324b5a626c4a64da3a4