### PR TITLE
Add job spec parsing for fg/bg

### DIFF
--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -320,6 +320,8 @@ hi
 - `jobs [-l|-p] [ID]` - list background jobs. `-l` prints the PID and status and `-p` prints only the PID. With IDs only those jobs are shown.
 - `fg [ID]` - wait for background job `ID` or the most recent job when omitted.
 - `bg [ID]` - resume the specified job or the last started job if no ID is given.
+  Job IDs may also be written as `%N`, `%%`/`%+` for the current job, `%-` for
+  the previous job and `%?text` to match a command containing `text`.
 - `kill [-s SIGNAL|-SIGNAL] [-l] ID|PID` - send a signal to the given job or
   process. Use `-l` to list signals or `-l NUM` to print the signal name for
   `NUM`.

--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -73,7 +73,11 @@ int builtin_fg(char **args) {
             return 1;
         }
     } else {
-        id = atoi(args[1]);
+        id = parse_job_spec(args[1]);
+        if (id < 0) {
+            fprintf(stderr, "fg: %s: no such job\n", args[1]);
+            return 1;
+        }
     }
     wait_job(id);
     return 1;
@@ -90,7 +94,11 @@ int builtin_bg(char **args) {
             return 1;
         }
     } else {
-        id = atoi(args[1]);
+        id = parse_job_spec(args[1]);
+        if (id < 0) {
+            fprintf(stderr, "bg: %s: no such job\n", args[1]);
+            return 1;
+        }
     }
     bg_job(id);
     return 1;

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -19,6 +19,7 @@ int wait_job(int id);
 int kill_job(int id, int sig);
 int bg_job(int id);
 int get_last_job_id(void);
+int parse_job_spec(const char *spec);
 void jobs_sigchld_handler(int sig);
 
 /* True while the shell is waiting for input at the prompt */

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -36,7 +36,9 @@ test_pipe.expect
 test_redir.expect
 test_source.expect
 test_fg.expect
+test_fg_percent.expect
 test_bg.expect
+test_bg_percent.expect
 test_kill.expect
 test_sequence.expect
 test_andor.expect

--- a/tests/test_bg_percent.expect
+++ b/tests/test_bg_percent.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 1 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "kill -SIGSTOP 1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "bg %?sleep\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 1 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "bg output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_fg_percent.expect
+++ b/tests/test_fg_percent.expect
@@ -1,0 +1,32 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 1 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "fg %1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 1 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "fg %+\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- parse job spec strings like `%1` or `%?sleep` in `parse_job_spec`
- make `fg`/`bg` use the new parser
- document job spec forms in the tutorial
- test `%` job spec forms and add them to the test runner

## Testing
- `make` *(fails: Segmentation fault when running built binary)*
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68571573ce4c8324a3e39debf92de03b