### PR TITLE
Implement jobs filter options

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -58,8 +58,8 @@ Replace the shell with \fIcommand\fP.
 .B "pwd [-L|-P]"
 Print the current working directory. \-P displays the physical directory from \fBgetcwd()\fP while \-L (the default) prints \$PWD.
 .TP
-.B "jobs [-l|-p] [ID]"
-List background jobs. \-l prints the PID and status and \-p prints only the PID. With IDs only those jobs are shown.
+.B "jobs [-l|-p] [-r|-s] [ID]"
+List background jobs. \-l prints the PID and status, \-p prints only the PID, \-r lists only running jobs and \-s shows only stopped ones. With IDs only those jobs are shown.
 .TP
 .B "fg [ID]"
 Wait for background job \fIID\fP or the most recent job when omitted.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -317,7 +317,7 @@ hi
 - `exec command [args...]` - replace the shell with `command`.
 - `pwd [-L|-P]` - print the current working directory. `-P` displays the
   physical directory from `getcwd()` while `-L` (the default) prints `$PWD`.
-- `jobs [-l|-p] [ID]` - list background jobs. `-l` prints the PID and status and `-p` prints only the PID. With IDs only those jobs are shown.
+- `jobs [-l|-p] [-r|-s] [ID]` - list background jobs. `-l` prints the PID and status, `-p` prints only the PID, `-r` shows running jobs only and `-s` lists only stopped jobs. With IDs only those jobs are shown.
 - `fg [ID]` - wait for background job `ID` or the most recent job when omitted.
 - `bg [ID]` - resume the specified job or the last started job if no ID is given.
   Job IDs may also be written as `%N`, `%%`/`%+` for the current job, `%-` for

--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -37,17 +37,22 @@ void list_signals(void)
     printf("\n");
 }
 
-/* builtin_jobs - usage: jobs [-l|-p] [ID...] */
+/* builtin_jobs - usage: jobs [-l|-p] [-r|-s] [ID...] */
 int builtin_jobs(char **args) {
-    int mode = 0; /* 0=normal, 1=long, 2=pids */
+    int mode = 0;   /* 0=normal, 1=long, 2=pids */
+    int filter = 0; /* 0=all, 1=running, 2=stopped */
     int idx = 1;
     for (; args[idx] && args[idx][0] == '-' && args[idx][1]; idx++) {
         if (strcmp(args[idx], "-l") == 0) {
             mode = 1;
         } else if (strcmp(args[idx], "-p") == 0) {
             mode = 2;
+        } else if (strcmp(args[idx], "-r") == 0) {
+            filter = 1;
+        } else if (strcmp(args[idx], "-s") == 0) {
+            filter = 2;
         } else {
-            fprintf(stderr, "usage: jobs [-l|-p] [ID...]\n");
+            fprintf(stderr, "usage: jobs [-l|-p] [-r|-s] [ID...]\n");
             return 1;
         }
     }
@@ -58,7 +63,7 @@ int builtin_jobs(char **args) {
         ids[count++] = atoi(args[idx]);
     }
 
-    print_jobs(mode, count, ids);
+    print_jobs(mode, filter, count, ids);
     return 1;
 }
 

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -184,11 +184,19 @@ static void print_job(Job *j, int mode) {
     }
 }
 
-void print_jobs(int mode, int count, int *ids) {
+static int match_filter(Job *j, int filter) {
+    if (filter == 1)
+        return j->state == JOB_RUNNING;
+    if (filter == 2)
+        return j->state == JOB_STOPPED;
+    return 1;
+}
+
+void print_jobs(int mode, int filter, int count, int *ids) {
     if (count > 0) {
         for (int i = 0; i < count; i++) {
             Job *j = find_job(ids[i]);
-            if (j)
+            if (j && match_filter(j, filter))
                 print_job(j, mode);
             else
                 fprintf(stderr, "jobs: %d: no such job\n", ids[i]);
@@ -197,7 +205,8 @@ void print_jobs(int mode, int count, int *ids) {
     }
     Job *j = jobs;
     while (j) {
-        print_job(j, mode);
+        if (match_filter(j, filter))
+            print_job(j, mode);
         j = j->next;
     }
 }

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -13,7 +13,7 @@ void add_job(pid_t pid, const char *cmd);
 void remove_job(pid_t pid);
 int check_jobs(void);
 int check_jobs_internal(int prefix);
-void print_jobs(int mode, int count, int *ids);
+void print_jobs(int mode, int filter, int count, int *ids);
 pid_t get_job_pid(int id);
 int wait_job(int id);
 int kill_job(int id, int sig);

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -132,6 +132,8 @@ test_negate.expect
 test_negate_multi.expect
 test_jobs_l.expect
 test_jobs_p.expect
+test_jobs_r.expect
+test_jobs_s.expect
 test_kill_s.expect
 test_command_pv.expect
 test_command_pV.expect

--- a/tests/test_jobs_r.expect
+++ b/tests/test_jobs_r.expect
@@ -1,0 +1,42 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 5 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 5 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "kill -SIGSTOP 2\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "jobs -r\r"
+expect {
+    -re {\[1\] [0-9]+ sleep 5 &\r\nvush> } {}
+    timeout { send_user "jobs -r output mismatch\n"; exit 1 }
+}
+send "kill 1\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "kill 2\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_jobs_s.expect
+++ b/tests/test_jobs_s.expect
@@ -1,0 +1,42 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 5 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "sleep 5 &\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "kill -SIGSTOP 1\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "jobs -s\r"
+expect {
+    -re {\[1\] [0-9]+ sleep 5 &\r\nvush> } {}
+    timeout { send_user "jobs -s output mismatch\n"; exit 1 }
+}
+send "kill 1\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "kill 2\r"
+expect {
+    -re {.*\[vush\] job [0-9]+ \(sleep 5 \&\) finished[\r\n]+vush> } {}
+    timeout { send_user "kill output mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- add `-r` and `-s` flags for `jobs` builtin
- filter running or stopped jobs in `print_jobs`
- update manpage and docs for new options
- include tests demonstrating the flags

## Testing
- `make` *(passes)*
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68571ecf75348324978916dc34925d17