### PR TITLE
Add ulimit flags for RSS and NPROC

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -160,7 +160,7 @@ Run a command and print timing statistics. With \-p, output follows the POSIX re
 .B times
 Print cumulative user/system CPU times.
 .TP
-.B "ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v [limit]]"
+.B "ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v [limit]]"
 Display or set resource limits.
 .TP
 .B "umask [-S] [mask]"

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -386,7 +386,7 @@ hi
 time ls | wc
 ```
 - `times` - print cumulative user/system CPU times.
-- `ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v [limit]]` - display or set resource limits.
+- `ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v [limit]]` - display or set resource limits.
 - `umask [-S] [mask]` - set or display the file creation mask. `mask` may be an octal number or a symbolic string like `u=rwx,g=rx,o=rx`. With `-S`, the mask is shown in symbolic form.
 
 ## Redirection Examples
@@ -442,6 +442,10 @@ vush> ulimit -S -s
 8192
 vush> ulimit -S -s 1024
 vush> ulimit -H -n 4096
+vush> ulimit -S -m
+unlimited
+vush> ulimit -S -u
+unlimited
 vush> ulimit -a | head -n 3
 -c 0
 -d unlimited

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -77,7 +77,7 @@ int builtin_help(char **args) {
     printf("  let EXPR  Evaluate arithmetic expression\n");
     printf("  set [-e|-u|-x] Toggle shell options\n");
     printf("  test EXPR ([ EXPR ])  Evaluate a test expression (!, -a, -o)\n");
-    printf("  ulimit [-HS] [-a|-f|-n] [limit]  Display or set resource limits\n");
+    printf("  ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v] [limit]  Display or set resource limits\n");
     printf("  eval WORDS  Concatenate arguments and execute the result\n");
     printf("  exec CMD [ARGS]  Replace the shell with CMD\n");
     printf("  source FILE [ARGS...] (. FILE [ARGS...])\n");

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -146,7 +146,13 @@ int builtin_ulimit(char **args)
     } const map[] = {
         {'c', RLIMIT_CORE},
         {'d', RLIMIT_DATA},
+#ifdef RLIMIT_RSS
+        {'m', RLIMIT_RSS},
+#endif
         {'f', RLIMIT_FSIZE},
+#ifdef RLIMIT_NPROC
+        {'u', RLIMIT_NPROC},
+#endif
         {'n', RLIMIT_NOFILE},
         {'s', RLIMIT_STACK},
         {'t', RLIMIT_CPU},
@@ -175,18 +181,18 @@ int builtin_ulimit(char **args)
                 }
             }
             if (!found) {
-                fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
+                fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v] [limit]\n");
                 return 1;
             }
         } else {
-            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
+            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v] [limit]\n");
             return 1;
         }
     }
 
     if (show_all) {
         if (args[i]) {
-            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
+            fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v] [limit]\n");
             return 1;
         }
         struct rlimit rl;
@@ -222,7 +228,7 @@ int builtin_ulimit(char **args)
     }
 
     if (args[i+1]) {
-        fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-n|-s|-t|-v] [limit]\n");
+        fprintf(stderr, "usage: ulimit [-HS] [-a|-c|-d|-f|-m|-n|-s|-t|-u|-v] [limit]\n");
         return 1;
     }
 

--- a/tests/test_ulimit.expect
+++ b/tests/test_ulimit.expect
@@ -9,7 +9,7 @@ expect {
 }
 send "ulimit -a\r"
 expect {
-    -re "\r\n-c (?:unlimited|\[0-9\]+)\r?\n-d (?:unlimited|\[0-9\]+)\r?\n-f (?:unlimited|\[0-9\]+)\r?\n-n (?:unlimited|\[0-9\]+)\r?\n-s (?:unlimited|\[0-9\]+)\r?\n-t (?:unlimited|\[0-9\]+)\r?\n-v (?:unlimited|\[0-9\]+)\r?\nvush> " {}
+    -re "\r\n-c (?:unlimited|\[0-9\]+)\r?\n-d (?:unlimited|\[0-9\]+)\r?\n-m (?:unlimited|\[0-9\]+)\r?\n-f (?:unlimited|\[0-9\]+)\r?\n-u (?:unlimited|\[0-9\]+)\r?\n-n (?:unlimited|\[0-9\]+)\r?\n-s (?:unlimited|\[0-9\]+)\r?\n-t (?:unlimited|\[0-9\]+)\r?\n-v (?:unlimited|\[0-9\]+)\r?\nvush> " {}
     timeout { send_user "ulimit -a output mismatch\n"; exit 1 }
 }
 send "ulimit -f 1234\r"
@@ -46,6 +46,16 @@ send "ulimit -H -f\r"
 expect {
     -re "\r\n1234\r?\nvush> " {}
     timeout { send_user "ulimit hard query failed\n"; exit 1 }
+}
+send "ulimit -m\r"
+expect {
+    -re "\r\n(?:unlimited|[0-9]+)\r?\nvush> " {}
+    timeout { send_user "ulimit -m query failed\n"; exit 1 }
+}
+send "ulimit -u\r"
+expect {
+    -re "\r\n(?:unlimited|[0-9]+)\r?\nvush> " {}
+    timeout { send_user "ulimit -u query failed\n"; exit 1 }
 }
 send "exit\r"
 expect {


### PR DESCRIPTION
## Summary
- support `-m` (RLIMIT_RSS) and `-u` (RLIMIT_NPROC) in `ulimit`
- document new options in the manual and docs
- test querying `ulimit -m` and `ulimit -u`

## Testing
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_685731b497588324bcab9a74e349953c