### PR TITLE
Add OPTERR support in getopts

### DIFF
--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -357,7 +357,8 @@ hi
 - `continue [N]` - start the next iteration of the `N`th enclosing loop (default 1).
 - `getopts OPTSTRING VAR` - parse positional parameters, storing the
   current option letter in `VAR`, any argument in `OPTARG`, and advancing
-  `OPTIND`.
+  `OPTIND`. When `OPTERR` is set to `0` the call behaves as if
+  `OPTSTRING` began with `:` and no error messages are printed.
 - `let EXPR` - evaluate an arithmetic expression.
 - `(( EXPR ))` - evaluate an arithmetic expression. The exit status is 0 when
   the value is non-zero and 1 otherwise.
@@ -605,6 +606,8 @@ vush> echo $((16#ff + 2#10))
 - `MAILPATH` is a `:` separated list of mailbox files also checked. Each path
   prints `New mail in <file>` when updated. Memory used to track mailbox
   modification times is freed when the shell exits.
+- `OPTERR` set to `0` disables `getopts` error messages and treats missing
+  arguments as if the option string started with `:`.
 - `VUSH_HISTFILE` names the history file; `VUSH_HISTSIZE` limits retained entries (defaults `~/.vush_history` and `1000`).
 - `VUSH_ALIASFILE` and `VUSH_FUNCFILE` store persistent aliases and functions (defaults `~/.vush_aliases` and `~/.vush_funcs`).
 - `CDPATH` lists directories searched by `cd` for relative paths.

--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -149,6 +149,10 @@ int builtin_getopts(char **args) {
         optstr++;
     }
 
+    const char *opterr = get_shell_var("OPTERR");
+    if (opterr && atoi(opterr) == 0)
+        silent = 1;
+
     char opt = '\0';
     int res = getopts_next_option(optstr, silent, &ind, &opt);
 

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -86,6 +86,7 @@ test_exit_trap.expect
 test_eval.expect
 test_exec_builtin.expect
 test_getopts.expect
+test_getopts_opterr.expect
 test_subshell.expect
 test_brace_group.expect
 test_break.expect

--- a/tests/test_getopts_opterr.expect
+++ b/tests/test_getopts_opterr.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+set env(OPTERR) 0
+set script [exec mktemp]
+set f [open $script "w"]
+puts $f {while getopts "ab:" o; do echo "$o:$OPTARG"; done; echo index:$OPTIND}
+close $f
+spawn [file dirname [info script]]/../build/vush $script -z
+expect {
+    -re "\?:\r\nindex:2\r\n" {}
+    timeout { send_user "silent invalid option failed\n"; exec rm $script; exit 1 }
+    "getopts:" { send_user "unexpected error output\n"; exec rm $script; exit 1 }
+}
+set code [lindex [wait] 3]
+spawn [file dirname [info script]]/../build/vush $script -b
+expect {
+    -re ":\r\nindex:2\r\n" {}
+    timeout { send_user "silent missing argument failed\n"; exec rm $script; exit 1 }
+    "getopts:" { send_user "unexpected error output\n"; exec rm $script; exit 1 }
+}
+set code [lindex [wait] 3]
+exec rm $script


### PR DESCRIPTION
## Summary
- respect `OPTERR` in `getopts` implementation
- mention the variable in the documentation and show how it affects `getopts`
- add tests for the quiet mode

## Testing
- `make`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68573310a88083248b0dce253178c04b