### PR TITLE
Add manual path and delete options to hash builtin

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -94,8 +94,8 @@ Show command history, clear it with \-c, or delete a specific entry with \-d. En
 .B "fc [-lnr] [-e editor] [first [last]]"
 List or edit previous commands. Use \-s [old=new] [command] to immediately run a command with optional text replacement.
 .TP
-.B "hash [-r] [name...]"
-Manage cached command paths.
+.B "hash [-r] [-d name] [-p path name] [name...]"
+Manage cached command paths. Use \-p to manually set a command path and \-d to remove an entry.
 .TP
 .B "alias [-p] [NAME[=VALUE]]"
 Set or display aliases. With no arguments all aliases are listed. A single NAME prints that alias. \-p lists using `alias NAME='value'` format.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -346,7 +346,7 @@ hi
 - `fc [-lnr] [-e editor] [first [last]]` - list or edit previous commands.
   Use `-s [old=new] [command]` to immediately run a command with optional
   text replacement.
-- `hash [-r] [name...]` - manage cached command paths.
+- `hash [-r] [-d name] [-p path name] [name...]` - manage cached command paths. Use `-p` to manually set a command path and `-d` to remove an entry.
 - `alias [-p] [NAME[=VALUE]]` - set or display aliases. With no arguments all aliases are listed. A single NAME prints that alias. `-p` lists using `alias NAME='value'` format.
 - `unalias [-a] NAME` - remove aliases. With `-a` all aliases are cleared.
 - `read [-r] [-a NAME] [-p prompt] [-n nchars] [-s] [-t timeout] [-u fd] [VAR...]` -

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -20,21 +20,49 @@
 int builtin_hash(char **args) {
     int i = 1;
     int status = 0;
+
     if (args[i] && strcmp(args[i], "-r") == 0) {
         hash_clear();
         i++;
     }
+
     if (!args[i]) {
         hash_print();
         last_status = 0;
         return 1;
     }
-    for (; args[i]; i++) {
+
+    for (; args[i]; ) {
+        if (strcmp(args[i], "-p") == 0) {
+            if (!args[i+1] || !args[i+2]) {
+                fprintf(stderr, "usage: hash [-r] [-d name] [-p path name] [name...]\n");
+                last_status = 1;
+                return 1;
+            }
+            if (hash_add_path(args[i+2], args[i+1]) < 0) {
+                fprintf(stderr, "%s: not found\n", args[i+2]);
+                status = 1;
+            }
+            i += 3;
+            continue;
+        }
+        if (strcmp(args[i], "-d") == 0) {
+            if (!args[i+1]) {
+                fprintf(stderr, "usage: hash [-r] [-d name] [-p path name] [name...]\n");
+                last_status = 1;
+                return 1;
+            }
+            hash_remove(args[i+1]);
+            i += 2;
+            continue;
+        }
         if (hash_add(args[i]) < 0) {
             fprintf(stderr, "%s: not found\n", args[i]);
             status = 1;
         }
+        i++;
     }
+
     last_status = status;
     return 1;
 }
@@ -65,7 +93,7 @@ int builtin_help(char **args) {
     printf("  readonly [-p] NAME[=VALUE]  Mark variable as read-only or list them\n");
     printf("  unset [-f|-v] NAME  Remove functions with -f or variables with -v\n");
     printf("  history [-c|-d NUM]   Show or modify command history\n");
-    printf("  hash [-r] [name...]   Manage cached command paths\n");
+    printf("  hash [-r] [-d NAME] [-p PATH NAME] [NAME...]   Manage cached command paths\n");
     printf("  alias [-p] [NAME[=VALUE]]  Set or list aliases\n");
     printf("  unalias [-a] NAME   Remove alias(es)\n");
     printf("  read [-r] VAR...    Read a line into variables\n");

--- a/src/hash.h
+++ b/src/hash.h
@@ -10,6 +10,12 @@ const char *hash_lookup(const char *name, int *fd);
 /* Add NAME to the cache by searching PATH.  Returns 0 on success. */
 int hash_add(const char *name);
 
+/* Manually add NAME with PATH to the cache. Returns 0 on success. */
+int hash_add_path(const char *name, const char *path);
+
+/* Remove cached entry for NAME if it exists. */
+void hash_remove(const char *name);
+
 /* Remove all cached entries. */
 void hash_clear(void);
 

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -117,6 +117,8 @@ test_true_builtin.expect
 test_false_builtin.expect
 test_colon.expect
 test_hash.expect
+test_hash_p.expect
+test_hash_d.expect
 test_heredoc_dash.expect
 test_heredoc_tabs.expect
 test_heredoc_expand.expect

--- a/tests/test_hash_d.expect
+++ b/tests/test_hash_d.expect
@@ -1,0 +1,46 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [exec mktemp -d]
+set f [open "$dir/foo" "w"]
+puts $f "#!/bin/sh"
+puts $f "echo hashed1"
+close $f
+exec chmod +x "$dir/foo"
+set env(PATH) "$dir:/bin"
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "foo\r"
+expect {
+    -re "\[\r\n\]+hashed1\[\r\n\]+vush> " {}
+    timeout { send_user "first run failed\n"; exec rm -rf $dir; exit 1 }
+}
+send "hash foo\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+exec mv "$dir/foo" "$dir/foo2"
+send "foo\r"
+expect {
+    -re "\[\r\n\]+hashed1\[\r\n\]+vush> " {}
+    timeout { send_user "hash not used\n"; exec rm -rf $dir; exit 1 }
+}
+send "hash -d foo\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "foo\r"
+expect {
+    -re "\[\r\n\]+foo: command not found\[\r\n\]+vush> " {}
+    timeout { send_user "hash -d failed\n"; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir

--- a/tests/test_hash_p.expect
+++ b/tests/test_hash_p.expect
@@ -1,0 +1,30 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [exec mktemp -d]
+set f [open "$dir/bar" "w"]
+puts $f "#!/bin/sh"
+puts $f "echo manualhash"
+close $f
+exec chmod +x "$dir/bar"
+set env(PATH) "/bin"
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "hash -p $dir/bar foo\r"
+expect {
+    "vush> " {}
+    timeout { send_user "hash -p failed\n"; exec rm -rf $dir; exit 1 }
+}
+send "foo\r"
+expect {
+    -re "\[\r\n\]+manualhash\[\r\n\]+vush> " {}
+    timeout { send_user "manual entry failed\n"; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- extend `hash` builtin with `-p` and `-d`
- expose new helpers in hash table API
- document new options in the manual
- add tests for `hash -p` and `hash -d`

## Testing
- `make` *(passes)*
- `make test` *(fails: segmentation fault in `vush`)*

------
https://chatgpt.com/codex/tasks/task_e_68573c5cf6048324ab78aab0e9c3a85e