### PR TITLE
Add portable asprintf wrapper

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <fcntl.h>
+#include "util.h"
 
 struct hash_entry {
     char *name;
@@ -33,7 +34,7 @@ static char *search_path(const char *name) {
     while (dir) {
         const char *d = *dir ? dir : ".";
         char *full = NULL;
-        if (asprintf(&full, "%s/%s", d, name) < 0) {
+        if (xasprintf(&full, "%s/%s", d, name) < 0) {
             result = NULL;
             break;
         }

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -352,7 +352,7 @@ static int parse_pipeline_segment(char **p, PipelineSegment **seg_ptr, int *argc
                 char *op = read_token(p, &q2, &de2);
                 if (!op) { free(tok); return -1; }
                 char *nt = NULL;
-                int ret = asprintf(&nt, "%s%s", tok, op);
+                int ret = xasprintf(&nt, "%s%s", tok, op);
                 if (ret < 0 || !nt) {
                     free(op);
                     free(tok);

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -16,6 +16,7 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <signal.h>
+#include "util.h"
 
 
 /* Temporary variable tracking for process substitutions */
@@ -98,7 +99,7 @@ char *gather_until(char **p, const char **stops, int nstops, int *idx) {
         }
         if (res) {
             char *tmp;
-            int ret = asprintf(&tmp, "%s %s", res, tok);
+            int ret = xasprintf(&tmp, "%s %s", res, tok);
             if (ret == -1 || tmp == NULL) {
                 free(res);
                 free(tok);
@@ -150,7 +151,7 @@ char *gather_until_done(char **p) {
         }
         if (res) {
             char *tmp;
-            if (asprintf(&tmp, "%s %s", res, tok) == -1 || !tmp) {
+            if (xasprintf(&tmp, "%s %s", res, tok) == -1 || !tmp) {
                 free(res);
                 free(tok);
                 return NULL;

--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -76,7 +76,7 @@ static void expand_temp_assignments(PipelineSegment *seg) {
             }
             char *tmp = NULL;
             if (name && val)
-                asprintf(&tmp, "%s=%s", name, val);
+                xasprintf(&tmp, "%s=%s", name, val);
             if (tmp) {
                 free(seg->assigns[i]);
                 seg->assigns[i] = tmp;
@@ -196,7 +196,7 @@ static void expand_segment(PipelineSegment *seg) {
             }
             char *tmp = NULL;
             if (name && val)
-                asprintf(&tmp, "%s=%s", name, val);
+                xasprintf(&tmp, "%s=%s", name, val);
             if (tmp) {
                 free(seg->assigns[i]);
                 seg->assigns[i] = tmp;

--- a/src/util.h
+++ b/src/util.h
@@ -26,4 +26,6 @@ int parse_positive_int(const char *s, int *out);
 void *xcalloc(size_t nmemb, size_t size);
 void *xmalloc(size_t size);
 char *xstrdup(const char *s);
+/* asprintf wrapper using system implementation when available */
+int xasprintf(char **strp, const char *fmt, ...);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- implement `xasprintf` fallback when `asprintf` is unavailable
- use new helper across the codebase

## Testing
- `make`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_685795c30c188324a9a7c1ec644ec02e