### PR TITLE
Implement xstrndup wrapper

### DIFF
--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -10,9 +10,7 @@
 
 char **parse_array_values(const char *val, int *count) {
     *count = 0;
-    char *body = strndup(val + 1, strlen(val) - 2);
-    if (!body)
-        return NULL;
+    char *body = xstrndup(val + 1, strlen(val) - 2);
 
     StrArray arr;
     strarray_init(&arr);
@@ -91,12 +89,7 @@ struct assign_backup *backup_assignments(PipelineSegment *pipeline) {
             backs[i].name = NULL;
             continue;
         }
-        backs[i].name = strndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
-        if (!backs[i].name) {
-            backs[i].env = backs[i].var = NULL;
-            backs[i].had_env = backs[i].had_var = 0;
-            continue;
-        }
+        backs[i].name = xstrndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
         const char *oe = getenv(backs[i].name);
         backs[i].had_env = oe != NULL;
         backs[i].env = oe ? strdup(oe) : NULL;

--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -223,12 +223,7 @@ int builtin_alias(char **args)
                 if (len >= 2 &&
                     ((newval[0] == '\'' && newval[len - 1] == '\'') ||
                      (newval[0] == '"' && newval[len - 1] == '"'))) {
-                    buf = strndup(newval + 1, len - 2);
-                    if (!buf) {
-                        *eq = '=';
-                        perror("strndup");
-                        return 1;
-                    }
+                    buf = xstrndup(newval + 1, len - 2);
                     newval = buf;
                 }
             }

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -452,7 +452,7 @@ int builtin_local(char **args) {
     for (int i = 1; args[i]; i++) {
         char *arg = args[i];
         char *eq = strchr(arg, '=');
-        char *name = eq ? strndup(arg, eq - arg) : strdup(arg);
+        char *name = eq ? xstrndup(arg, eq - arg) : strdup(arg);
         if (!name)
             continue;
         record_local_var(name);

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -180,7 +180,7 @@ char *expand_var(const char *token) {
         return ansi_unescape(inner);
     }
     if (tlen >= 2 && token[0] == '\'' && token[tlen - 1] == '\'') {
-        return strndup(token + 1, tlen - 2);
+        return xstrndup(token + 1, tlen - 2);
     }
     if (tlen >= 2 && token[0] == '"' && token[tlen - 1] == '"') {
         size_t innerlen = tlen - 2;

--- a/src/param_expand.c
+++ b/src/param_expand.c
@@ -40,7 +40,7 @@ static char *expand_tilde(const char *token) {
     } else {
         const char *slash = strchr(rest, '/');
         size_t len = slash ? (size_t)(slash - rest) : strlen(rest);
-        char *user = strndup(rest, len);
+        char *user = xstrndup(rest, len);
         if (user) {
             setpwent();
             struct passwd *pw = getpwnam(user);
@@ -74,8 +74,7 @@ static char *expand_arith(const char *token) {
     if (!(tlen > 4 && strncmp(token, "$((", 3) == 0 &&
           token[tlen-2] == ')' && token[tlen-1] == ')'))
         return NULL;
-    char *expr = strndup(token + 3, tlen - 5);
-    if (!expr) return strdup("");
+    char *expr = xstrndup(token + 3, tlen - 5);
     int err = 0;
     char *msg = NULL;
     long val = eval_arith(expr, &err, &msg);
@@ -231,9 +230,8 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
             if (!val) val = "";
             return strdup(val);
         }
-        char *pattern = strndup(pat, sep - pat);
+        char *pattern = xstrndup(pat, sep - pat);
         const char *repl = sep + 1;
-        if (!pattern) return strdup(val ? val : "");
         if (!val) val = "";
         size_t vlen = strlen(val);
         size_t rlen = strlen(repl);
@@ -291,8 +289,8 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
         if ((size_t)off > vlen) off = vlen;
         size_t avail = vlen - off;
         size_t count = (len < 0 || (size_t)len > avail) ? avail : (size_t)len;
-        char *res = strndup(val + off, count);
-        return res ? res : strdup("");
+        char *res = xstrndup(val + off, count);
+        return res;
     } else if (*p == '#' || *p == '%') {
         char op = *p;
         int longest = 0;
@@ -306,8 +304,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
         if (op == '#') {
             if (!longest) {
                 for (size_t i = 0; i <= vlen; i++) {
-                    char *pref = strndup(val, i);
-                    if (!pref) break;
+                    char *pref = xstrndup(val, i);
                     int m = fnmatch(pattern, pref, 0);
                     free(pref);
                     if (m == 0)
@@ -315,8 +312,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
                 }
             } else {
                 for (size_t i = vlen;; i--) {
-                    char *pref = strndup(val, i);
-                    if (!pref) break;
+                    char *pref = xstrndup(val, i);
                     int m = fnmatch(pattern, pref, 0);
                     free(pref);
                     if (m == 0)
@@ -334,8 +330,8 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
                     int m = fnmatch(pattern, suf, 0);
                     free(suf);
                     if (m == 0) {
-                        char *res = strndup(val, vlen - i);
-                        return res ? res : strdup("");
+                        char *res = xstrndup(val, vlen - i);
+                        return res;
                     }
                 }
             } else {
@@ -345,8 +341,8 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
                     int m = fnmatch(pattern, suf, 0);
                     free(suf);
                     if (m == 0) {
-                        char *res = strndup(val, vlen - i);
-                        return res ? res : strdup("");
+                        char *res = xstrndup(val, vlen - i);
+                        return res;
                     }
                     if (i == 0)
                         break;

--- a/src/parser_clauses.c
+++ b/src/parser_clauses.c
@@ -244,17 +244,8 @@ static char *parse_for_arith_exprs(char **p, char **init, char **cond, char **in
         return NULL;
     }
 
-    *init = strndup(exprs, s1 - exprs);
-    if (!*init) {
-        free(exprs);
-        return NULL;
-    }
-    *cond = strndup(s1 + 1, s2 - (s1 + 1));
-    if (!*cond) {
-        free(exprs);
-        free(*init);
-        return NULL;
-    }
+    *init = xstrndup(exprs, s1 - exprs);
+    *cond = xstrndup(s1 + 1, s2 - (s1 + 1));
     *incr = strdup(s2 + 1);
     if (!*incr) {
         free(exprs);

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -251,8 +251,9 @@ static int handle_assignment_or_alias(PipelineSegment *seg, int *argc, char **p,
             return -1;
         }
         if (eq) {
-            char *name = strndup(tok, eq - tok);
-            if (name) { set_temp_var(name, eq + 1); free(name); }
+            char *name = xstrndup(tok, eq - tok);
+            set_temp_var(name, eq + 1);
+            free(name);
         }
         *tok_ptr = NULL;
         return 1;

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -6,6 +6,7 @@
 #include "lexer.h"
 #include "execute.h"
 #include "shell_state.h"
+#include "util.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -192,7 +193,7 @@ char *gather_braced(char **p) {
                 depth--;
                 if (depth == 0) {
                     size_t len = (size_t)(*p - start);
-                    char *res = strndup(start, len);
+                    char *res = xstrndup(start, len);
                     (*p)++; /* skip closing brace */
                     return res;
                 }
@@ -226,7 +227,7 @@ char *gather_parens(char **p) {
                 depth--;
                 if (depth == 0) {
                     size_t len = (size_t)(*p - start);
-                    char *res = strndup(start, len);
+                    char *res = xstrndup(start, len);
                     (*p)++; /* skip closing paren */
                     return res;
                 }
@@ -241,7 +242,7 @@ char *trim_ws(const char *s) {
     while (*s && isspace((unsigned char)*s)) s++;
     const char *end = s + strlen(s);
     while (end > s && isspace((unsigned char)*(end-1))) end--;
-    return strndup(s, end - s);
+    return xstrndup(s, end - s);
 }
 
 char *gather_dbl_parens(char **p) {
@@ -266,7 +267,7 @@ char *gather_dbl_parens(char **p) {
                 depth++;
             } else if (c == ')') {
                 if (depth == 0 && *(*p + 1) == ')') {
-                    char *res = strndup(start, *p - start);
+                    char *res = xstrndup(start, *p - start);
                     *p += 2;
                     return res;
                 }

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -24,6 +24,7 @@
 #include "pipeline.h"
 #include "jobs.h"
 #include "options.h"
+#include "util.h"
 #include "hash.h"
 #include "redir.h"
 #include "error.h"
@@ -78,11 +79,9 @@ pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
             char *eq = strchr(seg->assigns[ai], '=');
             if (eq) {
                 size_t len = (size_t)(eq - seg->assigns[ai]);
-                char *name = strndup(seg->assigns[ai], len);
-                if (name) {
-                    setenv(name, eq + 1, 1);
-                    free(name);
-                }
+                char *name = xstrndup(seg->assigns[ai], len);
+                setenv(name, eq + 1, 1);
+                free(name);
             }
         }
 

--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -64,14 +64,14 @@ static void expand_temp_assignments(PipelineSegment *seg) {
     for (int i = 0; i < seg->assign_count; i++) {
         char *eq = strchr(seg->assigns[i], '=');
         if (eq) {
-            char *name = strndup(seg->assigns[i], eq - seg->assigns[i]);
+            char *name = xstrndup(seg->assigns[i], eq - seg->assigns[i]);
             char *val = expand_var(eq + 1);
             if (val) {
                 size_t len = strlen(val);
                 if (len >= 2 && ((val[0] == '\'' && val[len - 1] == '\'') ||
                                  (val[0] == '"' && val[len - 1] == '"'))) {
-                    char *trim = strndup(val + 1, len - 2);
-                    if (trim) { free(val); val = trim; }
+                    char *trim = xstrndup(val + 1, len - 2);
+                    free(val); val = trim;
                 }
             }
             char *tmp = NULL;
@@ -184,14 +184,14 @@ static void expand_segment(PipelineSegment *seg) {
     for (int i = 0; i < seg->assign_count; i++) {
         char *eq = strchr(seg->assigns[i], '=');
         if (eq) {
-            char *name = strndup(seg->assigns[i], eq - seg->assigns[i]);
+            char *name = xstrndup(seg->assigns[i], eq - seg->assigns[i]);
             char *val = expand_var(eq + 1);
             if (val) {
                 size_t len = strlen(val);
                 if (len >= 2 && ((val[0] == '\'' && val[len - 1] == '\'') ||
                                  (val[0] == '"' && val[len - 1] == '"'))) {
-                    char *trim = strndup(val + 1, len - 2);
-                    if (trim) { free(val); val = trim; }
+                    char *trim = xstrndup(val + 1, len - 2);
+                    free(val); val = trim;
                 }
             }
             char *tmp = NULL;
@@ -321,9 +321,7 @@ static struct assign_backup *set_temp_environment(PipelineSegment *pipeline) {
             char *eq = strchr(pipeline->assigns[i], '=');
             if (!eq)
                 continue;
-            char *name = strndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
-            if (!name)
-                continue;
+            char *name = xstrndup(pipeline->assigns[i], eq - pipeline->assigns[i]);
             char *val = eq + 1;
             size_t vlen = strlen(val);
             if (vlen > 1 && val[0] == '(' && val[vlen - 1] == ')') {

--- a/src/util.c
+++ b/src/util.c
@@ -39,6 +39,27 @@ char *xstrdup(const char *s) {
     }
     return ptr;
 }
+
+/* Duplicate up to N bytes of S, exiting on allocation failure. */
+char *xstrndup(const char *s, size_t n) {
+#if defined(__GLIBC__) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L)
+    char *ptr = strndup(s, n);
+#else
+    size_t len = 0;
+    while (len < n && s[len])
+        len++;
+    char *ptr = malloc(len + 1);
+    if (ptr) {
+        memcpy(ptr, s, len);
+        ptr[len] = '\0';
+    }
+#endif
+    if (!ptr) {
+        perror("strndup");
+        exit(1);
+    }
+    return ptr;
+}
 /*
  * Read a line continuing backslash escapes across multiple physical lines.
  */

--- a/src/util.h
+++ b/src/util.h
@@ -26,4 +26,5 @@ int parse_positive_int(const char *s, int *out);
 void *xcalloc(size_t nmemb, size_t size);
 void *xmalloc(size_t size);
 char *xstrdup(const char *s);
+char *xstrndup(const char *s, size_t n);
 #endif /* VUSH_UTIL_H */


### PR DESCRIPTION
## Summary
- add `xstrndup` helper with feature guard for `strndup`
- use `xstrndup` instead of `strndup`
- include `util.h` where needed

## Testing
- `make`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6857967561d48324be465171c67f95b1