### PR TITLE
Use POSIX mktemp for temp dirs

### DIFF
--- a/tests/mktempd.sh
+++ b/tests/mktempd.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# POSIX-compatible mktemp -d replacement
+set -e
+tmp=$(mktemp)
+rm -f "$tmp"
+mkdir "$tmp"
+printf '%s\n' "$tmp"

--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -11,7 +11,7 @@ if [ ! -x ../build/vush ]; then
     exit 1
 fi
 
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(./mktempd.sh)
 export HOME="$TMP_HOME"
 export VUSH_FUNCFILE=/dev/null
 trap 'rm -rf "$TMP_HOME"' EXIT
@@ -30,7 +30,7 @@ test_custom_aliasfile.expect
 for test in $tests; do
     echo "Running $test"
     if [ "$test" = "test_glob.expect" ]; then
-        tmpdir=$(mktemp -d)
+        tmpdir=$(./mktempd.sh)
         curdir=$(pwd)
         cd "$tmpdir"
         if [ -x "$curdir/$test" ]; then

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -11,7 +11,7 @@ if [ ! -x ../build/vush ]; then
     exit 1
 fi
 
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(./mktempd.sh)
 export HOME="$TMP_HOME"
 export VUSH_FUNCFILE=/dev/null
 trap 'rm -rf "$TMP_HOME"' EXIT
@@ -172,7 +172,7 @@ test_set_o.expect
 for test in $tests; do
     echo "Running $test"
     if [ "$test" = "test_glob.expect" ]; then
-        tmpdir=$(mktemp -d)
+        tmpdir=$(./mktempd.sh)
         curdir=$(pwd)
         cd "$tmpdir"
         if [ -x "$curdir/$test" ]; then

--- a/tests/run_history_tests.sh
+++ b/tests/run_history_tests.sh
@@ -11,7 +11,7 @@ if [ ! -x ../build/vush ]; then
     exit 1
 fi
 
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(./mktempd.sh)
 export HOME="$TMP_HOME"
 export VUSH_FUNCFILE=/dev/null
 trap 'rm -rf "$TMP_HOME"' EXIT
@@ -33,7 +33,7 @@ test_bang_words.expect
 for test in $tests; do
     echo "Running $test"
     if [ "$test" = "test_glob.expect" ]; then
-        tmpdir=$(mktemp -d)
+        tmpdir=$(./mktempd.sh)
         curdir=$(pwd)
         cd "$tmpdir"
         if [ -x "$curdir/$test" ]; then

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -11,7 +11,7 @@ if [ ! -x ../build/vush ]; then
     exit 1
 fi
 
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(./mktempd.sh)
 export HOME="$TMP_HOME"
 export VUSH_FUNCFILE=/dev/null
 trap 'rm -rf "$TMP_HOME"' EXIT
@@ -54,7 +54,7 @@ test_param_at_q.expect
 for test in $tests; do
     echo "Running $test"
     if [ "$test" = "test_glob.expect" ]; then
-        tmpdir=$(mktemp -d)
+        tmpdir=$(./mktempd.sh)
         curdir=$(pwd)
         cd "$tmpdir"
         if [ -x "$curdir/$test" ]; then

--- a/tests/test_alias.expect
+++ b/tests/test_alias.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_alias_flags.expect
+++ b/tests/test_alias_flags.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_alias_persist.expect
+++ b/tests/test_alias_persist.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 spawn [file dirname [info script]]/../build/vush
 expect {

--- a/tests/test_alias_quoted_query.expect
+++ b/tests/test_alias_quoted_query.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_alias_remove_dup.expect
+++ b/tests/test_alias_remove_dup.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_alias_update.expect
+++ b/tests/test_alias_update.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_cd_P.expect
+++ b/tests/test_cd_P.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 file mkdir "$dir/real"
 file link -symbolic "$dir/link" "$dir/real"
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_cd_P_dangle.expect
+++ b/tests/test_cd_P_dangle.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 file mkdir "$dir/real"
 exec ln -s "$dir/real" "$dir/link"
 exec ln -s "$dir/missing" "$dir/real/bad"

--- a/tests/test_cdpath.expect
+++ b/tests/test_cdpath.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 file mkdir "$dir/a"
 set env(CDPATH) $dir
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_command.expect
+++ b/tests/test_command.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_command_V.expect
+++ b/tests/test_command_V.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_command_v.expect
+++ b/tests/test_command_v.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_command_v_path_long.expect
+++ b/tests/test_command_v_path_long.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set base [exec mktemp -d]
+set base [exec sh [file dirname [info script]]/mktempd.sh]
 set long $base
 for {set i 0} {$i < 350} {incr i} {
     append long "/abcdefghij"

--- a/tests/test_completion.expect
+++ b/tests/test_completion.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set tmp [exec mktemp -d]
+set tmp [exec sh [file dirname [info script]]/mktempd.sh]
 set env(PATH) $tmp
 spawn [file dirname [info script]]/../build/vush
 expect {

--- a/tests/test_completion_path.expect
+++ b/tests/test_completion_path.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/foo" "w"]
 puts $f "#!/bin/sh"
 puts $f "echo pathcomplete"

--- a/tests/test_custom_aliasfile.expect
+++ b/tests/test_custom_aliasfile.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set env(VUSH_ALIASFILE) "$dir/aliases"
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_custom_histfile.expect
+++ b/tests/test_custom_histfile.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set env(VUSH_HISTFILE) "$dir/histfile"
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_envfile.expect
+++ b/tests/test_envfile.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/envfile" "w"]
 puts $f "echo envstart"
 close $f

--- a/tests/test_fc_fork_fail.expect
+++ b/tests/test_fc_fork_fail.expect
@@ -7,7 +7,7 @@ set lib "$dir/fork_fail.so"
 exec cc -shared -fPIC $src -o $lib
 set env(LD_PRELOAD) $lib
 set env(FORK_FAIL_AT) 1
-set tmpdir [exec mktemp -d]
+set tmpdir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(TMPDIR) $tmpdir
 spawn $dir/../build/vush
 expect {

--- a/tests/test_hash.expect
+++ b/tests/test_hash.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/foo" "w"]
 puts $f "#!/bin/sh"
 puts $f "echo hashed1"

--- a/tests/test_hash_d.expect
+++ b/tests/test_hash_d.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/foo" "w"]
 puts $f "#!/bin/sh"
 puts $f "echo hashed1"

--- a/tests/test_hash_p.expect
+++ b/tests/test_hash_p.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/bar" "w"]
 puts $f "#!/bin/sh"
 puts $f "echo manualhash"

--- a/tests/test_history_limit.expect
+++ b/tests/test_history_limit.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set env(VUSH_HISTSIZE) 3
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_path_blank.expect
+++ b/tests/test_path_blank.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set scriptdir [file normalize [file dirname [info script]]]
 set f [open "$dir/foo" "w"]
 puts $f "#!/bin/sh"

--- a/tests/test_path_long.expect
+++ b/tests/test_path_long.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set base [exec mktemp -d]
+set base [exec sh [file dirname [info script]]/mktempd.sh]
 set long $base
 for {set i 0} {$i < 350} {incr i} {
     append long "/abcdefghij"

--- a/tests/test_pwd_options.expect
+++ b/tests/test_pwd_options.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 file mkdir "$dir/real"
 file link -symbolic "$dir/link" "$dir/real"
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_test.expect
+++ b/tests/test_test.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set file "$dir/file"
 exec touch $file
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -1,7 +1,7 @@
 #!/usr/bin/env expect
 set timeout 5
 set user "tempuser"
-set home [exec mktemp -d]
+set home [exec sh [file dirname [info script]]/mktempd.sh]
 exec sh -c "echo \"$user:x:12345:12345::$home:/bin/false\" >> /etc/passwd"
 spawn [file dirname [info script]]/../build/vush
 expect {

--- a/tests/test_type.expect
+++ b/tests/test_type.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_type_t.expect
+++ b/tests/test_type_t.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_unalias_a.expect
+++ b/tests/test_unalias_a.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/env expect
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set env(HOME) $dir
 set timeout 5
 spawn [file dirname [info script]]/../build/vush

--- a/tests/test_vushrc.expect
+++ b/tests/test_vushrc.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 5
-set dir [exec mktemp -d]
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
 set f [open "$dir/.vushrc" "w"]
 puts $f "echo rcstart"
 close $f


### PR DESCRIPTION
## Summary
- add `mktempd.sh` helper that uses `mktemp` and `mkdir`
- adjust test runner scripts to call the new helper
- replace direct `mktemp -d` calls in expect scripts

## Testing
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68579742855883248a5dc98d9ee51976