### PR TITLE
Handle quotes in export listing

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -350,10 +350,18 @@ static void list_exports(void)
     extern char **environ;
     for (char **e = environ; *e; e++) {
         char *eq = strchr(*e, '=');
-        if (eq)
-            printf("export %.*s='%s'\n", (int)(eq - *e), *e, eq + 1);
-        else
+        if (eq) {
+            printf("export %.*s='", (int)(eq - *e), *e);
+            for (const char *p = eq + 1; *p; p++) {
+                if (*p == '\'')
+                    fputs("'\\''", stdout);
+                else
+                    fputc(*p, stdout);
+            }
+            printf("'\n");
+        } else {
             printf("export %s\n", *e);
+        }
     }
 }
 

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -43,6 +43,7 @@ test_pid_params.expect
 test_export_p.expect
 test_export_n.expect
 test_export_p_listing.expect
+test_export_quote.expect
 test_export_n_unexport.expect
 test_readonly_p.expect
 test_set_list.expect

--- a/tests/test_export_quote.expect
+++ b/tests/test_export_quote.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "export FOO=bar'baz\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "export -p\r"
+expect {
+    -re "export FOO='bar'\\''baz'" {}
+    timeout { send_user "export -p quoting failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- escape single quotes when listing exported variables
- add regression test for `export -p` quoting

## Testing
- `make test` *(fails: `send: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_685792f6df9883248ab1147296ab19f3