### PR TITLE
Fix alias invalid value handling

### DIFF
--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -92,6 +92,10 @@ const char *get_alias(const char *name)
 /* Create or update an alias. */
 static int set_alias(const char *name, const char *value)
 {
+    if (strchr(value, '\n') || strchr(value, '=')) {
+        fprintf(stderr, "alias: invalid value for %s\n", name);
+        return -1;
+    }
     /* If an alias with this NAME already exists make sure it is fully
      * removed so the new definition completely replaces it.  This avoids
      * duplicate entries which could cause the old value to be printed when

--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -24,6 +24,7 @@ test_alias_flags.expect
 test_alias_update.expect
 test_alias_remove_dup.expect
 test_alias_persist.expect
+test_alias_invalid.expect
 test_unalias_a.expect
 test_custom_aliasfile.expect
 "

--- a/tests/test_alias_invalid.expect
+++ b/tests/test_alias_invalid.expect
@@ -1,0 +1,59 @@
+#!/usr/bin/env expect
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
+set env(HOME) $dir
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias good='echo ok'\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias bad='bad=value'\r"
+expect {
+    -re "alias: invalid value" {}
+    timeout { send_user "missing invalid error\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+set f [open "$dir/.vush_aliases" r]
+set data [read $f]
+close $f
+if {![string match {*good=echo ok*} $data]} {
+    send_user "valid alias missing in file\n"
+    exec rm -rf $dir
+    exit 1
+}
+if {[string match {*bad=*} $data]} {
+    send_user "invalid alias saved\n"
+    exec rm -rf $dir
+    exit 1
+}
+spawn [file dirname [info script]]/../build/vush
+set env(HOME) $dir
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "good test\r"
+expect {
+    -re "\r\nok test\r\nvush> " {}
+    timeout { send_user "valid alias not loaded\n"; exec rm -rf $dir; exit 1 }
+}
+send "alias bad\r"
+expect {
+    -re "alias: bad: not found\r\nvush> " {}
+    timeout { send_user "invalid alias persisted\n"; exec rm -rf $dir; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir


### PR DESCRIPTION
## Summary
- validate alias values to reject newlines or '=' characters
- expand alias test suite with invalid value checks
- run alias tests including the new one

## Testing
- `make test` *(fails: `spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_685876d8ee2c8324a0610d9e455f796a