### PR TITLE
Handle strdup failure in export

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -372,6 +372,7 @@ static void list_exports(void)
  * value.  A usage message is printed on error and the function always returns 1.
  */
 int builtin_export(char **args) {
+    int status = 0;
     if (!args[1]) {
         fprintf(stderr, "usage: export [-p|-n NAME] NAME[=VALUE]...\n");
         return 1;
@@ -393,12 +394,16 @@ int builtin_export(char **args) {
         if (eq) {
             *eq = '\0';
             char *valdup = strdup(eq + 1);
-            if (valdup) {
-                if (setenv(arg, valdup, 1) != 0)
-                    perror("export");
-                set_shell_var(arg, valdup);
-                free(valdup);
+            if (!valdup) {
+                perror("export");
+                status = 1;
+                *eq = '=';
+                continue;
             }
+            if (setenv(arg, valdup, 1) != 0)
+                perror("export");
+            set_shell_var(arg, valdup);
+            free(valdup);
             *eq = '=';
         } else {
             const char *val = get_shell_var(arg);
@@ -410,6 +415,7 @@ int builtin_export(char **args) {
                 perror("export");
         }
     }
+    last_status = status;
     return 1;
 }
 

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -45,6 +45,7 @@ test_export_n.expect
 test_export_p_listing.expect
 test_export_quote.expect
 test_export_n_unexport.expect
+test_export_memfail.expect
 test_readonly_p.expect
 test_set_list.expect
 test_field_split_module.expect

--- a/tests/strdup_fail.c
+++ b/tests/strdup_fail.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+static char *(*real_strdup)(const char*) = NULL;
+static long count = 0;
+
+__attribute__((constructor))
+static void init(void) {
+    real_strdup = dlsym(RTLD_NEXT, "strdup");
+}
+
+char *strdup(const char *s) {
+    count++;
+    char *env = getenv("STRDUP_FAIL_AT");
+    if (env && atol(env) == count) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_strdup ? real_strdup(s) : NULL;
+}

--- a/tests/test_export_memfail.expect
+++ b/tests/test_export_memfail.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [file dirname [info script]]
+set src "$dir/strdup_fail.c"
+set lib "$dir/strdup_fail.so"
+exec cc -shared -fPIC $src -o $lib
+set env(LD_PRELOAD) $lib
+set env(STRDUP_FAIL_AT) 1
+spawn $dir/../build/vush -c {export FOO=bar}
+expect {
+    -re "export:.*Cannot allocate memory\r?\n" {}
+    timeout { send_user "missing strdup error\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+set code [lindex [wait] 3]
+if { $code == 0 } {
+    send_user "exit status mismatch\n"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- check strdup result in `builtin_export`
- note failure via `last_status`
- add failing strdup shim for tests
- run new test via var test script

## Testing
- `make`
- `./run_var_tests.sh` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6858791639a48324a3aa1bec1f9dd281