### PR TITLE
Fix cd buffer lifetime

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -67,6 +67,7 @@ static void canonicalize_logical(const char *path, char *out)
  */
 int builtin_cd(char **args) {
     char prev[PATH_MAX];
+    char buf[PATH_MAX];
     if (!getcwd(prev, sizeof(prev))) {
         perror("getcwd");
         return 1;
@@ -87,7 +88,6 @@ int builtin_cd(char **args) {
     if (!args[idx]) {
         target = getenv("HOME");
     } else if (strcmp(args[idx], "-") == 0) {
-        char buf[PATH_MAX];
         target = getenv("OLDPWD");
         if (!target) {
             if (!getcwd(buf, sizeof(buf))) {


### PR DESCRIPTION
## Summary
- keep `buf` allocated for entire `cd` builtin to avoid lifetime issues

## Testing
- `make`
- `cppcheck --enable=warning,style src/builtins_fs.c`

------
https://chatgpt.com/codex/tasks/task_e_68587cef54ec83248a82c886cb6d196c