### PR TITLE
Fix duplicate interactive check

### DIFF
--- a/src/repl.c
+++ b/src/repl.c
@@ -49,8 +49,7 @@ void repl_loop(FILE *input)
             free(prompt);
             if (!line) {
                 if (any_pending_traps()) {
-                    if (interactive)
-                        printf("\n");
+                    printf("\n");
                     process_pending_traps();
                     continue;
                 }


### PR DESCRIPTION
## Summary
- remove redundant `if (interactive)` in `repl_loop`

## Testing
- `make`
- `cppcheck src/repl.c` *(fails: none)*
- `make test` *(fails: expect: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68587f02bb908324997cbd1d7a0dfd0e