### PR TITLE
Handle malloc failures

### DIFF
--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -7,6 +7,7 @@
 #include "vars.h"
 #include "util.h"
 #include "strarray.h"
+#include "shell_state.h"
 
 char **parse_array_values(const char *val, int *count) {
     *count = 0;
@@ -62,7 +63,12 @@ void apply_array_assignment(const char *name, const char *val, int export_env) {
         for (int j = 0; j < count; j++)
             joinlen += strlen(vals[j]) + 1;
         char *joined = malloc(joinlen + 1);
-        if (joined) {
+        if (!joined) {
+            /* Report allocation failure but still continue after setting
+             * last_status to indicate the error. */
+            perror("malloc");
+            last_status = 1;
+        } else {
             joined[0] = '\0';
             for (int j = 0; j < count; j++) {
                 strcat(joined, vals[j]);

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -109,7 +109,12 @@ void define_function(const char *name, Command *body, const char *text)
             char *new_name = strdup(name);
             char *new_text = strdup(text);
             if (!new_name || !new_text) {
+                /*
+                 * strdup failed.  Print an error, set last_status to 1 and
+                 * return without modifying the function list.
+                 */
                 perror("strdup");
+                last_status = 1;
                 free(new_name);
                 free(new_text);
                 free_commands(body);
@@ -127,14 +132,21 @@ void define_function(const char *name, Command *body, const char *text)
     }
     FuncEntry *fn = malloc(sizeof(FuncEntry));
     if (!fn) {
+        /*
+         * Allocation failure.  Report the error and set last_status so the
+         * caller can detect the failure.
+         */
         perror("malloc");
+        last_status = 1;
         free_commands(body);
         return;
     }
     char *name_copy = strdup(name);
     char *text_copy = strdup(text);
     if (!name_copy || !text_copy) {
+        /* strdup failed.  Clean up and signal failure. */
         perror("strdup");
+        last_status = 1;
         free(name_copy);
         free(text_copy);
         free(fn);

--- a/src/hash.c
+++ b/src/hash.c
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include "util.h"
+#include "shell_state.h"
 
 struct hash_entry {
     char *name;
@@ -80,12 +81,17 @@ int hash_add(const char *name) {
     }
     struct hash_entry *e = malloc(sizeof(struct hash_entry));
     if (!e) {
+        /* report failure when allocating the hash entry */
+        perror("malloc");
+        last_status = 1;
         free(path);
         close(fd);
         return -1;
     }
     e->name = strdup(name);
     if (!e->name) {
+        perror("strdup");
+        last_status = 1;
         free(path);
         close(fd);
         free(e);
@@ -141,6 +147,8 @@ int hash_add_path(const char *name, const char *path) {
     }
     e->name = strdup(name);
     if (!e->name) {
+        perror("strdup");
+        last_status = 1;
         free(p);
         close(fd);
         free(e);

--- a/src/history_expand.c
+++ b/src/history_expand.c
@@ -92,6 +92,12 @@ char *expand_history(const char *line) {
     size_t rest_len = strlen(rest);
     char *res = malloc(pre_len + exp_len + rest_len + 1);
     if (!res) {
+        /*
+         * Allocation failure constructing the expanded line.
+         * Report the error and set last_status before returning NULL.
+         */
+        perror("malloc");
+        last_status = 1;
         free(expansion);
         return NULL;
     }

--- a/src/repl.c
+++ b/src/repl.c
@@ -15,6 +15,7 @@
 #include "trap.h"
 #include "mail.h"
 #include "util.h"
+#include "shell_state.h"
 #include "options.h"
 #include "vars.h"
 
@@ -133,7 +134,9 @@ void repl_loop(FILE *input)
                 size_t len2 = strlen(more);
                 char *tmp = malloc(len1 + len2 + 2);
                 if (!tmp) {
+                    /* handle allocation failure when extending the line */
                     perror("malloc");
+                    last_status = 1;
                     free(cmdline);
                     free(more);
                     cmdline = NULL;


### PR DESCRIPTION
## Summary
- set `last_status=1` on failed allocations
- include `shell_state.h` where needed
- document allocation failure handling in code comments

## Testing
- `make test` *(fails: send: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6858b9b46b5883248445fa830a375a23