### PR TITLE
Gracefully handle missing expect in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ See [docs/vush.1](docs/vush.1) for the manual page.
 
 ## Tests
 
-The test suite relies on the `expect` command. Install the `expect` package
-before running the tests, then execute:
+The test suite relies on the `expect` command. If `expect` is not installed the
+scripts will print a warning and skip the tests. Install the `expect` package to
+run them, then execute:
 
 ```sh
 make test

--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Expect is not installed. Please install Expect to run tests." >&2
-    exit 1
+    echo "Expect is not installed; skipping alias tests." >&2
+    exit 0
 fi
 
 if [ ! -x ../build/vush ]; then

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Expect is not installed. Please install Expect to run tests." >&2
-    exit 1
+    echo "Expect is not installed; skipping built-in command tests." >&2
+    exit 0
 fi
 
 if [ ! -x ../build/vush ]; then

--- a/tests/run_history_tests.sh
+++ b/tests/run_history_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Expect is not installed. Please install Expect to run tests." >&2
-    exit 1
+    echo "Expect is not installed; skipping history tests." >&2
+    exit 0
 fi
 
 if [ ! -x ../build/vush ]; then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Error: 'expect' is required to run the test suite." >&2
-    exit 1
+    echo "'expect' not found; skipping tests." >&2
+    exit 0
 fi
 
 failed=0

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Expect is not installed. Please install Expect to run tests." >&2
-    exit 1
+    echo "Expect is not installed; skipping variable tests." >&2
+    exit 0
 fi
 
 if [ ! -x ../build/vush ]; then


### PR DESCRIPTION
## Summary
- skip tests when `expect` is missing
- update docs about the new behaviour

## Testing
- `make test` *(fails: `test_alias.expect` and others fail with `spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_6858c1f56d688324b61d6c456cecd5cd