### PR TITLE
Fix strarray_finish cleanup on realloc failure

### DIFF
--- a/src/strarray.c
+++ b/src/strarray.c
@@ -21,8 +21,10 @@ int strarray_push(StrArray *arr, char *str) {
 }
 
 char **strarray_finish(StrArray *arr) {
-    if (strarray_push(arr, NULL) == -1)
+    if (strarray_push(arr, NULL) == -1) {
+        strarray_release(arr);
         return NULL;
+    }
     char **res = arr->items;
     arr->items = NULL;
     arr->count = 0;

--- a/tests/realloc_fail.c
+++ b/tests/realloc_fail.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+static void *(*real_realloc)(void *, size_t) = NULL;
+static long count = 0;
+
+void *realloc(void *ptr, size_t size) {
+    if (!real_realloc)
+        real_realloc = dlsym(RTLD_NEXT, "realloc");
+    count++;
+    char *env = getenv("REALLOC_FAIL_AT");
+    if (env && atol(env) == count) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_realloc(ptr, size);
+}

--- a/tests/run_var_tests.sh
+++ b/tests/run_var_tests.sh
@@ -52,6 +52,7 @@ test_field_split_module.expect
 test_param_expand_module.expect
 test_quote_utils_module.expect
 test_param_at_q.expect
+test_strarray_finish_memfail.expect
 "
 for test in $tests; do
     echo "Running $test"

--- a/tests/test_strarray_finish.c
+++ b/tests/test_strarray_finish.c
@@ -1,0 +1,36 @@
+#define _GNU_SOURCE
+#include "strarray.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+int main(void) {
+    StrArray arr;
+    strarray_init(&arr);
+    for (int i = 0; i < 4; i++) {
+        char *s = strdup("x");
+        if (!s || strarray_push(&arr, s) == -1) {
+            perror("alloc");
+            free(s);
+            strarray_release(&arr);
+            return 1;
+        }
+    }
+
+    char **res = strarray_finish(&arr);
+    if (res) {
+        fprintf(stderr, "unexpected success\n");
+        strarray_free(res);
+        return 1;
+    }
+
+    if (arr.items || arr.count != 0 || arr.capacity != 0) {
+        fprintf(stderr, "array not released\n");
+        strarray_release(&arr);
+        return 1;
+    }
+
+    perror("realloc");
+    return 0;
+}

--- a/tests/test_strarray_finish_memfail.expect
+++ b/tests/test_strarray_finish_memfail.expect
@@ -1,0 +1,28 @@
+#!/usr/bin/env expect
+set timeout 5
+set dir [file dirname [info script]]
+set src "$dir/realloc_fail.c"
+set lib "$dir/realloc_fail.so"
+set testsrc "$dir/test_strarray_finish.c"
+set testbin "$dir/test_strarray_finish"
+# compile failing realloc library
+exec cc -shared -fPIC $src -o $lib
+# compile test program
+exec cc -std=c99 -Wall -Wextra -I$dir/../src $testsrc $dir/../src/strarray.c -o $testbin
+set env(LD_PRELOAD) $lib
+set env(REALLOC_FAIL_AT) 2
+spawn $testbin
+expect {
+    -re "realloc: Cannot allocate memory\r?\n" {}
+    timeout { send_user "missing realloc error\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+set code [lindex [wait] 3]
+if { $code != 0 } {
+    send_user "exit status mismatch\n"
+    exit 1
+}
+exec rm -f $lib $testbin


### PR DESCRIPTION
## Summary
- clean up array if sentinel push fails in strarray_finish
- add failing realloc test for strarray_finish
- run this new test with other variable tests

## Testing
- `make clean && make`
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6858c42e4e188324ab066215e1d7622a