### PR TITLE
Conditional noexecstack flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 CC ?= cc
-CFLAGS ?= -Wall -Wextra -std=c99 -Wa,--noexecstack
+CFLAGS ?= -Wall -Wextra -std=c99
+
+ifndef NOEXECSTACK_FLAG
+NOEXECSTACK_FLAG := $(shell printf 'int main(){}' | $(CC) -Wa,--noexecstack -c -x c -o /dev/null - >/dev/null 2>&1 && echo -Wa,--noexecstack)
+endif
+
+CFLAGS += $(NOEXECSTACK_FLAG)
 PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
 BUILDDIR := build

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ Use the provided `Makefile` to build the shell:
 make
 ```
 
-The default `CFLAGS` include `-Wa,--noexecstack` so the resulting objects
-contain a note marking the stack as non‑executable.
+The Makefile defines `NOEXECSTACK_FLAG` by probing the assembler for support of
+`--noexecstack`. When available, this variable expands to `-Wa,--noexecstack` so
+object files contain a note marking the stack as non‑executable. If your toolchain
+does not support the flag or you wish to disable it, invoke make with
+`NOEXECSTACK_FLAG=`.
 
 The resulting binary will be `build/vush`. Remove the directory with:
 


### PR DESCRIPTION
## Summary
- check assembler for `--noexecstack`
- only add that flag when supported
- document the `NOEXECSTACK_FLAG` variable in the build instructions

## Testing
- `make`
- `make test` *(fails: double free detected in tcache 2)*

------
https://chatgpt.com/codex/tasks/task_e_6858caa5a2748324b6ca6450ad2b607f