### PR TITLE
Ensure portability when WCONTINUED is missing

### DIFF
--- a/src/jobs.c
+++ b/src/jobs.c
@@ -97,7 +97,11 @@ int check_jobs_internal(int prefix) {
     int printed = 0;
     int status;
     pid_t pid;
+#ifdef WCONTINUED
     while ((pid = waitpid(-1, &status, WNOHANG | WUNTRACED | WCONTINUED)) > 0) {
+#else
+    while ((pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) > 0) {
+#endif
         Job *curr = jobs;
         while (curr && curr->pid != pid)
             curr = curr->next;


### PR DESCRIPTION
## Summary
- fix waitpid flag usage to compile on systems without `WCONTINUED`

## Testing
- `make -j$(nproc)`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6858d06908ec83248c570751c6440130