### PR TITLE
Fix umask handling for redirects

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -153,7 +153,7 @@ int open_redirect(const char *path, int append, int force) {
     int flags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
     if (opt_noclobber && !append && !force)
         flags |= O_EXCL;
-    return open(path, flags, 0644);
+    return open(path, flags, 0666);
 }
 
 char *make_user_path(const char *env_var, const char *secondary,

--- a/tests/test_umask.expect
+++ b/tests/test_umask.expect
@@ -15,6 +15,26 @@ expect {
     -re "\r\nu=\[rwx\]*,g=\[rwx\]*,o=\[rwx\]*\r?\nvush> " {}
     timeout { send_user "umask -S output mismatch\n"; exit 1 }
 }
+send "umask 000\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo hi >umask.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "stat -c %a umask.tmp\r"
+expect {
+    -re "\r\n0666\r?\nvush> " {}
+    timeout { send_user "umask file mode mismatch (000)\n"; exit 1 }
+}
+send "rm umask.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
 send "umask 077\r"
 expect {
     "vush> " {}
@@ -24,6 +44,21 @@ send "umask -S 077\r"
 expect {
     -re "\r\nu=rwx,g=,o=\r?\nvush> " {}
     timeout { send_user "umask -S set failed\n"; exit 1 }
+}
+send "echo hi >umask.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "stat -c %a umask.tmp\r"
+expect {
+    -re "\r\n0600\r?\nvush> " {}
+    timeout { send_user "umask file mode mismatch (077)\n"; exit 1 }
+}
+send "rm umask.tmp\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
 }
 send "umask\r"
 expect {


### PR DESCRIPTION
## Summary
- respect the user's umask when creating redirection targets
- add tests verifying creation mode reflects current umask

## Testing
- `make` *(fails: Segmentation fault when running shell)*
- `make test` *(fails: Segmentation fault when running shell)*

------
https://chatgpt.com/codex/tasks/task_e_6858d88ebcb48324b3fe4da3ca212135