### PR TITLE
Move job change notifications to main loop

### DIFF
--- a/src/jobs.h
+++ b/src/jobs.h
@@ -24,6 +24,7 @@ void jobs_sigchld_handler(int sig);
 
 /* True while the shell is waiting for input at the prompt */
 extern volatile sig_atomic_t jobs_at_prompt;
+extern volatile sig_atomic_t jobs_changed;
 
 /* PID of the most recently started background job */
 extern pid_t last_bg_pid;

--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,11 @@ int main(int argc, char **argv) {
     /* Ignore Ctrl-C in the shell itself */
     signal(SIGINT, SIG_IGN);
     /* Reap background jobs asynchronously */
-    signal(SIGCHLD, jobs_sigchld_handler);
+    struct sigaction sa_chld;
+    sigemptyset(&sa_chld.sa_mask);
+    sa_chld.sa_flags = 0;
+    sa_chld.sa_handler = jobs_sigchld_handler;
+    sigaction(SIGCHLD, &sa_chld, NULL);
     init_signal_handling();
 
     load_history();

--- a/src/repl.c
+++ b/src/repl.c
@@ -49,6 +49,19 @@ void repl_loop(FILE *input)
             jobs_at_prompt = 0;
             free(prompt);
             if (!line) {
+                if (jobs_changed) {
+                    jobs_at_prompt = 1;
+                    if (check_jobs_internal(1) && jobs_at_prompt) {
+                        const char *ps = getenv("PS1");
+                        printf("%s", ps ? ps : "vush> ");
+                        fflush(stdout);
+                        jobs_at_prompt = 0;
+                    } else {
+                        jobs_at_prompt = 0;
+                    }
+                    jobs_changed = 0;
+                    continue;
+                }
                 if (any_pending_traps()) {
                     printf("\n");
                     process_pending_traps();
@@ -108,6 +121,18 @@ void repl_loop(FILE *input)
                     jobs_at_prompt = 0;
                     free(p2);
                     if (!more) {
+                        if (jobs_changed) {
+                            jobs_at_prompt = 1;
+                            if (check_jobs_internal(1) && jobs_at_prompt) {
+                                const char *ps = getenv("PS1");
+                                printf("%s", ps ? ps : "vush> ");
+                                fflush(stdout);
+                                jobs_at_prompt = 0;
+                            } else {
+                                jobs_at_prompt = 0;
+                            }
+                            jobs_changed = 0;
+                        }
                         free(cmdline);
                         cmdline = NULL;
                         if (any_pending_traps()) {


### PR DESCRIPTION
## Summary
- flag job status changes in `jobs_sigchld_handler`
- install SIGCHLD handler with `sigaction`
- update the REPL to print job notifications when flagged

## Testing
- `make`
- `tests/run_tests.sh` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_6858d879f49883248b983f64980fd75c