### PR TITLE
Use O_CLOEXEC for hashed command descriptors

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -74,7 +74,7 @@ int hash_add(const char *name) {
         free(path);
         path = resolved;
     }
-    int fd = open(path, O_RDONLY);
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
     if (fd < 0) {
         free(path);
         return -1;
@@ -98,7 +98,12 @@ int hash_add(const char *name) {
         return -1;
     }
     e->path = path;
+#ifdef HAVE_FEXECVE
     e->fd = fd;
+#else
+    close(fd);
+    e->fd = -1;
+#endif
     e->next = hash_list;
     hash_list = e;
     return 0;
@@ -134,7 +139,7 @@ int hash_add_path(const char *name, const char *path) {
     char *p = real ? real : strdup(path);
     if (!p)
         return -1;
-    int fd = open(p, O_RDONLY);
+    int fd = open(p, O_RDONLY | O_CLOEXEC);
     if (fd < 0) {
         free(p);
         return -1;
@@ -155,7 +160,12 @@ int hash_add_path(const char *name, const char *path) {
         return -1;
     }
     e->path = p;
+#ifdef HAVE_FEXECVE
     e->fd = fd;
+#else
+    close(fd);
+    e->fd = -1;
+#endif
     e->next = hash_list;
     hash_list = e;
     return 0;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -93,8 +93,10 @@ pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
         if (hpath) {
 #ifdef HAVE_FEXECVE
             extern char **environ;
-            if (hfd >= 0)
+            if (hfd >= 0) {
+                fcntl(hfd, F_SETFD, 0);
                 fexecve(hfd, seg->argv, environ);
+            }
 #endif
             execv(hpath, seg->argv);
         }


### PR DESCRIPTION
## Summary
- use `O_CLOEXEC` when caching command paths
- only keep descriptors when `fexecve` is enabled
- sanitize descriptors before `fexecve`

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6859665428f08324b6fd58debcc987d1