### PR TITLE
Fix empty command expansion handling

### DIFF
--- a/src/field_split.c
+++ b/src/field_split.c
@@ -95,11 +95,12 @@ char **split_fields(const char *text, int *count_out) {
 
     free(dup);
 
+    int cnt = arr.count;
     char **res = strarray_finish(&arr);
     if (!res)
         goto fail_alloc;
     if (count_out)
-        *count_out = arr.count ? arr.count - 1 : 0;
+        *count_out = cnt;
     return res;
 
 fail:

--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -364,6 +364,8 @@ static struct assign_backup *set_temp_environment(PipelineSegment *pipeline) {
 static int run_temp_command(PipelineSegment *pipeline, int background,
                             const char *line) {
     expand_segment_no_assign(pipeline);
+    if (!pipeline->argv[0])
+        return 0;        /* nothing to execute after expansion */
 
     int has_redir =
         pipeline->in_file || pipeline->out_file || pipeline->err_file ||

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -46,6 +46,7 @@ test_glob.expect
 test_status.expect
 test_badcmd.expect
 test_badcmd_noninteractive.expect
+test_empty_cmd.expect
 test_cmdsub.expect
 test_cmdsub_regress.expect
 test_completion.expect

--- a/tests/test_empty_cmd.expect
+++ b/tests/test_empty_cmd.expect
@@ -1,0 +1,31 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "UNSET=\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "\"\$UNSET\"\r"
+expect {
+    -re "syntax error: missing command" {}
+    timeout { send_user "missing syntax error message\n"; exit 1 }
+}
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$?\r"
+expect {
+    -re "\[\r\n\]+1\[\r\n\]+vush> " {}
+    timeout { send_user "status code mismatch\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- avoid executing when expansion removes command
- fix field splitting count
- add regression test for empty command

## Testing
- `make clean`
- `make`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_68596eaf849c832487ce63dc77a0c797