### PR TITLE
Fix segfault when running temp command with no argv

### DIFF
--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -374,6 +374,8 @@ static int run_temp_command(PipelineSegment *pipeline, int background,
         pipeline->out_fd != STDOUT_FILENO || pipeline->in_fd != STDIN_FILENO;
 
     int handled = 0;
+    if (!pipeline->argv[0])
+        return 0;
     int is_blt = is_builtin_command(pipeline->argv[0]);
     FuncEntry *fn = NULL;
     if (!is_blt)


### PR DESCRIPTION
## Summary
- guard against empty argv before checking builtins

## Testing
- `make`
- `make test` *(fails: Cannot fork / Expect errors)*

------
https://chatgpt.com/codex/tasks/task_e_685973340540832491f43b9f2b8fd36a