### PR TITLE
Fix command name lost by expansions

### DIFF
--- a/tests/test_null_command.expect
+++ b/tests/test_null_command.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "FOO=bar \$UNSET\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo \$FOO\r"
+expect {
+    -re "\r?\n+bar\r?\nvush> " {}
+    timeout { send_user "assignment lost\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- debug `expand_segment_no_assign` by logging argv
- ensure `run_temp_command` marks when the command vanishes after expansion
- permanently apply assignments when expansions remove the command
- add regression test for the null command case

## Testing
- `expect -f tests/test_null_command.expect`
- `make test` *(fails: object not open)*

------
https://chatgpt.com/codex/tasks/task_e_6859819d9cb48324be592f9308207155