### PR TITLE
Add regression test for alias crash

### DIFF
--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -20,6 +20,7 @@ failed=0
 
 tests="
 test_alias.expect
+test_alias_crash.expect
 test_alias_flags.expect
 test_alias_update.expect
 test_alias_remove_dup.expect

--- a/tests/test_alias_crash.expect
+++ b/tests/test_alias_crash.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/env expect
+set dir [exec sh [file dirname [info script]]/mktempd.sh]
+set env(HOME) $dir
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias foo=bar\r"
+expect {
+    -re "foo=bar='bar'\r?\nvush> " {}
+    timeout { send_user "alias output missing\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}
+exec rm -rf $dir
+


### PR DESCRIPTION
## Summary
- add test alias_crash.expect covering `alias foo=bar`
- run alias tests script with the new test included

## Testing
- `make clean && make CFLAGS="-g -Wall"`
- `make test` *(fails: libnss_wrapper preload issue)*

------
https://chatgpt.com/codex/tasks/task_e_6859841cb7e88324a55394d1cada32e8