### PR TITLE
Fix builtin check for NULL and new dash-c test

### DIFF
--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -34,6 +34,8 @@ static int spawn_pipeline_segments(PipelineSegment *pipeline, int background,
 
 /* Determine if a command name corresponds to a builtin. */
 static int is_builtin_command(const char *name) {
+    if (!name)
+        return 0;
     for (int i = 0; i < BI_COUNT; i++) {
         if (strcmp(name, builtin_table[i].name) == 0)
             return 1;

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -61,6 +61,7 @@ test_type.expect
 test_type_t.expect
 test_dash_c.expect
 test_dash_c_quotes.expect
+test_dash_c_echo.expect
 test_echo_options.expect
 test_heredoc.expect
 test_herestring.expect

--- a/tests/test_dash_c_echo.expect
+++ b/tests/test_dash_c_echo.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush -c {echo hi}
+expect {
+    -re "hi\r?\n" {}
+    timeout { send_user "-c echo output mismatch\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- handle NULL command names in `is_builtin_command`
- add expect test verifying `vush -c {echo hi}` runs without crash
- register new test in builtins test suite

## Testing
- `make`
- `make test` *(fails: FAILED: test_alias_crash.expect, test_for_shellvar.expect)*

------
https://chatgpt.com/codex/tasks/task_e_685988dcb58c8324bcdd34da3193629c