### PR TITLE
Fix expansion logic when no variables present

### DIFF
--- a/tests/run_alias_tests.sh
+++ b/tests/run_alias_tests.sh
@@ -20,6 +20,7 @@ failed=0
 
 tests="
 test_alias.expect
+test_alias_argv0.expect
 test_alias_crash.expect
 test_alias_flags.expect
 test_alias_update.expect

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -20,6 +20,7 @@ failed=0
 
 tests="
 test_basic_cmd.expect
+test_basic_cmd_regress.expect
 test_env.expect
 test_ps1.expect
 test_ps1_cmdsub.expect

--- a/tests/test_alias_argv0.expect
+++ b/tests/test_alias_argv0.expect
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "alias hi=echo\r"
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "hi world\r"
+expect {
+    -re "\[\r\n\]+world\[\r\n\]+vush> " {}
+    timeout { send_user "alias argv0 failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}

--- a/tests/test_basic_cmd_regress.expect
+++ b/tests/test_basic_cmd_regress.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush
+expect {
+    "vush> " {}
+    timeout { send_user "prompt timeout\n"; exit 1 }
+}
+send "echo hello\r"
+expect {
+    -re "\[\r\n\]+hello\[\r\n\]+vush> " {}
+    timeout { send_user "basic cmd regression failed\n"; exit 1 }
+}
+send "exit\r"
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- preserve argv pointers when no expansion occurs
- test expansion with simple commands and alias usage

## Testing
- `make`
- `make test` *(fails: `expect: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_68598a5124d483249a8dafd747b978c8