### PR TITLE
Improve expect dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ See [docs/vush.1](docs/vush.1) for the manual page.
 
 ## Tests
 
-The test suite relies on the `expect` command. If `expect` is not installed the
-`tests/run_tests.sh` driver will terminate with an error. Install the `expect`
-package to run the tests, then execute:
+The test suite relies on the `expect` command. **You must install the `expect`
+package** before running the tests. If `expect` is not installed the
+`tests/run_tests.sh` driver will terminate with an error. Once installed,
+execute:
 
 ```sh
 make test

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 if ! command -v expect >/dev/null; then
-    echo "Error: the 'expect' program is required to run the test suite." >&2
-    echo "Please install 'expect' and try again." >&2
+    echo "Error: the 'expect' command is not available." >&2
+    echo "Install the expect package (e.g. 'sudo apt-get install expect') and try again." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- clarify the need for the `expect` package in README
- emit clearer error when `expect` isn't installed in `run_tests.sh`

## Testing
- `make test` *(fails: mktempd.sh cannot fork)*

------
https://chatgpt.com/codex/tasks/task_e_68598d1323fc8324b1c739b04e553544