### PR TITLE
Ensure last_status remains 1 on indirect expansion errors

### DIFF
--- a/src/param_expand.c
+++ b/src/param_expand.c
@@ -367,6 +367,7 @@ static char *apply_modifier(const char *name, const char *val, const char *p) {
             if (opt_nounset) {
                 fprintf(stderr, "%s: unbound variable\n", name);
                 last_status = 1;
+                param_error = 1;
             }
             val = "";
         }
@@ -440,6 +441,7 @@ static char *expand_braced(const char *inner) {
             if (opt_nounset) {
                 fprintf(stderr, "%s: unbound variable\n", name);
                 last_status = 1;
+                param_error = 1;
             }
             val = "";
         }


### PR DESCRIPTION
## Summary
- propagate `param_error` for `${!VAR}` when the referenced variable is unset
- mark indirect expansion path so that `run_pipeline_internal` keeps `last_status=1`

## Testing
- `expect -f tests/test_param_indirect.expect`


------
https://chatgpt.com/codex/tasks/task_e_6859a7f7bbd4832497bf8529fa79cf61