### PR TITLE
Add passwd fallback for tilde expansion

### DIFF
--- a/tests/test_tilde_user.expect
+++ b/tests/test_tilde_user.expect
@@ -12,7 +12,6 @@ puts $g "tempgroup:x:12345:"
 close $g
 set env(NSS_WRAPPER_PASSWD) $passfile
 set env(NSS_WRAPPER_GROUP) $groupfile
-set env(LD_PRELOAD) "/usr/lib/x86_64-linux-gnu/libnss_wrapper.so"
 spawn [file dirname [info script]]/../build/vush
 expect {
     "vush> " {}


### PR DESCRIPTION
## Summary
- support reading `$NSS_WRAPPER_PASSWD` or `/etc/passwd` when `getpwnam` fails
- adjust tilde user test to avoid requiring `libnss_wrapper`

## Testing
- `make test` *(fails: expect script errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859af0aa74c83248004e88da1fa00d2