### PR TITLE
Fix array parsing count

### DIFF
--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -40,11 +40,13 @@ char **parse_array_values(const char *val, int *count) {
     }
     free(body);
 
+    int arr_count = arr.count;
     char **vals = strarray_finish(&arr);
     if (!vals)
         return NULL;
-    *count = arr.count ? arr.count - 1 : 0;
+    *count = arr_count;
     if (*count == 0) {
+        /* ensure caller sees an empty array terminator */
         vals[0] = NULL;
     }
     return vals;


### PR DESCRIPTION
## Summary
- fix array element count when assigning arrays

## Testing
- `build/vush -c 'nums=(one two); echo ${nums[1]}'`


------
https://chatgpt.com/codex/tasks/task_e_6859f9b70c0c832489d4bb0666a138c1