### PR TITLE
Improve for loop field splitting

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -50,12 +50,16 @@ void free_commands(Command *c) {
             for (int i = 0; i < c->word_count; i++)
                 free(c->words[i]);
             free(c->words);
+            free(c->word_expand);
+            free(c->word_quoted);
             free_commands(c->body);
         } else if (c->type == CMD_SELECT) {
             free(c->var);
             for (int i = 0; i < c->word_count; i++)
                 free(c->words[i]);
             free(c->words);
+            free(c->word_expand);
+            free(c->word_quoted);
             free_commands(c->body);
         } else if (c->type == CMD_FOR_ARITH) {
             free(c->arith_init);

--- a/src/parser.h
+++ b/src/parser.h
@@ -76,6 +76,8 @@ typedef struct Command {
     char *var;                /* for for loop variable */
     char **words;             /* for loop word list or [[ expression ]] */
     int word_count;
+    int *word_expand;         /* expansion flags for words */
+    int *word_quoted;         /* quoting flags for words */
     char *arith_init;         /* for arithmetic for loop */
     char *arith_cond;
     char *arith_update;


### PR DESCRIPTION
## Summary
- track quoting and expansion info for words parsed in `for`/`select`
- preserve and free these flags in `Command`
- use quoting info when iterating a `for` loop so unquoted variables
  undergo field splitting

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685a0809ffdc8324b8830e79a388dc37