### PR TITLE
Add license header comments to all C files

### DIFF
--- a/src/alias_expand.c
+++ b/src/alias_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Alias expansion helpers for command tokens.
+ */
+
 #define _GNU_SOURCE
 #include "alias_expand.h"
 #include "builtins.h"

--- a/src/arith.c
+++ b/src/arith.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Arithmetic expression evaluator.
+ */
+
 #define _GNU_SOURCE
 /*
  * Simple arithmetic expression evaluator used by the shell.

--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Utilities for parsing variable assignments.
+ */
+
 #define _GNU_SOURCE
 #include <stdlib.h>
 #include <string.h>

--- a/src/brace_expand.c
+++ b/src/brace_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Brace pattern expansion.
+ */
+
 #define _GNU_SOURCE
 #include "brace_expand.h"
 #include "parser.h" /* for MAX_LINE and MAX_TOKENS */

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Builtin command table and dispatch helpers.
+ */
+
+/*
  * Builtin command table and dispatch helpers.
  *
  * The table below lists every builtin command by name along with the

--- a/src/builtins_alias.c
+++ b/src/builtins_alias.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Alias builtin commands and persistence.
+ */
+
+/*
  * Alias builtins and helpers.
  *
  * Aliases are stored in a simple list of `struct alias_entry`

--- a/src/builtins_core.c
+++ b/src/builtins_core.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Core builtin commands like exit.
+ */
+
+/*
  * Core builtin commands
  *
  * This file holds basic builtins such as exit, :, true and false.

--- a/src/builtins_exec.c
+++ b/src/builtins_exec.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Builtins that spawn or replace processes.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "history.h"

--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Directory and path related builtins.
+ */
+
+/*
  * Builtins that operate on the file system are implemented here.  This
  * includes commands such as cd, pushd, popd, dirs and pwd that change or
  * display the current working directory.  They are grouped together because

--- a/src/builtins_func.c
+++ b/src/builtins_func.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Shell function storage and loading.
+ */
+
+/*
  * Shell function support
  *
  * Function definitions are kept in a list of FuncEntry

--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Implementation of the getopts builtin.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "vars.h"

--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * History related builtin commands.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "history.h"

--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Job control builtin commands.
+ */
+
+/*
  * Job control builtins
  *
  * This file exposes the shell commands used to manipulate background

--- a/src/builtins_misc.c
+++ b/src/builtins_misc.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Miscellaneous builtin commands.
+ */
+
+/*
  * Miscellaneous builtin commands
  *
  * This file gathers builtins that don't fit the alias, variable,

--- a/src/builtins_print.c
+++ b/src/builtins_print.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Builtins for echo and printf.
+ */
+
+/*
  * Printing related builtin commands: echo and printf
  */
 #define _GNU_SOURCE

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Implementation of the read builtin.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "parser.h"

--- a/src/builtins_signals.c
+++ b/src/builtins_signals.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Signal handling builtins.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 #include "execute.h"

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * System setting builtins like ulimit.
+ */
+
+/*
  * System builtins
  *
  * This module implements builtins that modify process limits or file

--- a/src/builtins_test.c
+++ b/src/builtins_test.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Conditional evaluation builtins.
+ */
+
+/*
  * Test and conditional builtin commands
  *
  * This file implements the POSIX test/[ builtin and the [[ conditional

--- a/src/builtins_time.c
+++ b/src/builtins_time.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Timing builtin for commands.
+ */
+
 #define _GNU_SOURCE
 #include "builtins.h"
 

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Variable management builtins.
+ */
+
+/*
  * This module implements the builtins used to manipulate shell variables and
  * arrays.  A small linked list stores all shell variables so that both
  * builtins and expansion code share the same state.  Routines here are

--- a/src/cmd_subst.c
+++ b/src/cmd_subst.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Command substitution implementation.
+ */
+
 #define _GNU_SOURCE
 #include "cmd_subst.h"
 #include "parser.h" /* for MAX_LINE and parse_line */

--- a/src/completion.c
+++ b/src/completion.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Filename and command completion utilities.
+ */
+
+/*
  * Simple filename and command completion utilities.
  */
 #define _GNU_SOURCE

--- a/src/control.c
+++ b/src/control.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Execution helpers for loops and conditionals.
+ */
+
+/*
  * Control flow execution helpers.
  *
  * Implements loops, conditionals and other shell control structures.

--- a/src/dirstack.c
+++ b/src/dirstack.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Directory stack for pushd/popd.
+ */
+
+/*
  * Directory stack implementation for pushd/popd.
  *
  * The shell maintains a simple stack of directory paths so that the

--- a/src/execute.c
+++ b/src/execute.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Execution engine for parsed command lists.
+ */
+
+/*
  * Execution engine for running parsed command lists.
  *
  * This module drives pipelines, builtins, functions and handles all

--- a/src/field_split.c
+++ b/src/field_split.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Field splitting after expansions.
+ */
+
 #define _GNU_SOURCE
 #include "var_expand.h"
 #include "vars.h"

--- a/src/func_exec.c
+++ b/src/func_exec.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Helpers for executing shell functions.
+ */
+
+/*
  * Helpers for executing shell functions.
  *
  * Shell functions are stored as parsed command lists and are executed when

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Command path hashing cache.
+ */
+
+/*
  * Simple command hashing for faster lookups.
  */
 #define _GNU_SOURCE

--- a/src/history_expand.c
+++ b/src/history_expand.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * History reference expansion.
+ */
+
+/*
  * History expansion helper.
  *
  * Provides expand_history() used to replace leading '!'

--- a/src/history_file.c
+++ b/src/history_file.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Loading and saving the history file.
+ */
+
 #define _GNU_SOURCE
 #include "history.h"
 #include "parser.h" /* for MAX_LINE */

--- a/src/history_list.c
+++ b/src/history_list.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * In-memory command history list.
+ */
+
+/*
  * Command history management routines.
  *
  * History is kept in a list of ``HistEntry`` nodes.  New

--- a/src/history_search.c
+++ b/src/history_search.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Incremental history search routines.
+ */
+
+/*
  * Incremental history search used by the line editor.
  */
 #include "history_search.h"

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -1,6 +1,12 @@
 /*
  * vush - a simple UNIX shell
  * Licensed under the BSD 2-Clause Simplified License.
+ * Job control helpers and process list.
+ */
+
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
  *
  * Job control helpers
  * -------------------

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Main lexer entry points.
+ */
+
 /* Public lexer entry points are implemented in separate modules. */
 #include "lexer.h"
 #include "history.h"

--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Lexer expansion helpers.
+ */
+
 #define _GNU_SOURCE
 #include "lexer.h"
 #include "var_expand.h"

--- a/src/lexer_token.c
+++ b/src/lexer_token.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Tokenization routines.
+ */
+
 #define _GNU_SOURCE
 #include "lexer.h"
 #include "parser.h"

--- a/src/lineedit.c
+++ b/src/lineedit.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Interactive line editor.
+ */
+
+/*
  * Interactive line editor for the shell prompt.
  * Input is read in raw terminal mode so keypresses are delivered
  * immediately, allowing the editor to interpret arrow keys, history

--- a/src/mail.c
+++ b/src/mail.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Check for new mail between prompts.
+ */
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/param_expand.c
+++ b/src/param_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Parameter expansion logic.
+ */
+
 #define _GNU_SOURCE
 #include "var_expand.h"
 #include "lexer.h"

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * High-level parser driver.
+ */
+
+/*
  * Main parser entry points linking the helper modules.
  */
 #include "parser.h"

--- a/src/parser_brace_expand.c
+++ b/src/parser_brace_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Brace expansion support for parser tokens.
+ */
+
 #define _GNU_SOURCE
 #include "parser_brace_expand.h"
 #include "brace_expand.h"

--- a/src/parser_clauses.c
+++ b/src/parser_clauses.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Parsing of shell clauses.
+ */
+
+/*
  * Parsing of shell control clauses extracted from parser.c
  */
 #define _GNU_SOURCE

--- a/src/parser_here_doc.c
+++ b/src/parser_here_doc.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Here-document processing.
+ */
+
 #define _GNU_SOURCE
 #include "parser_here_doc.h"
 #include "lexer.h"

--- a/src/parser_pipeline.c
+++ b/src/parser_pipeline.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Parsing of pipelines.
+ */
+
+/*
  * Pipeline parsing routines extracted from parser.c
  */
 #define _GNU_SOURCE

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Parser utility helpers.
+ */
+
+/*
  * Parsing utility helpers extracted from parser.c
  */
 #define _GNU_SOURCE

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Low-level pipeline execution primitives.
+ */
+
+/*
  * Low-level pipeline execution primitives.
  *
  * Each pipeline is a linked list of PipelineSegment structures.  The

--- a/src/pipeline_exec.c
+++ b/src/pipeline_exec.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * High-level pipeline execution helpers.
+ */
+
+/*
  * High-level pipeline execution helpers.
  *
  * This module wraps the low level primitives from pipeline.c with

--- a/src/prompt_expand.c
+++ b/src/prompt_expand.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Expanding variables and escapes in prompts.
+ */
+
 #define _GNU_SOURCE
 #include "prompt_expand.h"
 #include "var_expand.h"

--- a/src/quote_utils.c
+++ b/src/quote_utils.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Utilities for quoting and unescaping.
+ */
+
 #define _GNU_SOURCE
 #include "var_expand.h"
 #include <stdlib.h>

--- a/src/redir.c
+++ b/src/redir.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Redirection helpers.
+ */
+
+/*
  * Redirection helpers for builtins and child processes.
  */
 #include <stdio.h>

--- a/src/repl.c
+++ b/src/repl.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Top-level REPL for the shell.
+ */
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/signal_utils.c
+++ b/src/signal_utils.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Portable signal helper functions.
+ */
+
 #include <unistd.h>
 #include <signal.h>
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Initialization routines and config loading.
+ */
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/state_paths.c
+++ b/src/state_paths.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Paths used for persistent shell state.
+ */
+
 #define _GNU_SOURCE
 #include "state_paths.h"
 #include "util.h"

--- a/src/strarray.c
+++ b/src/strarray.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Dynamic array of strings helpers.
+ */
+
 #include "strarray.h"
 #include <stdlib.h>
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Signal trap management.
+ */
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,10 @@
 /*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Miscellaneous utility functions.
+ */
+
+/*
  * Utility helpers for reading lines and printing messages.
  */
 #define _GNU_SOURCE

--- a/src/vars.c
+++ b/src/vars.c
@@ -1,3 +1,9 @@
+/*
+ * vush - a simple UNIX shell
+ * Licensed under the BSD 2-Clause Simplified License.
+ * Shell variable storage and lookup.
+ */
+
 #define _GNU_SOURCE
 #include "vars.h"
 #include "options.h"


### PR DESCRIPTION
## Summary
- add a consistent comment block to each C source file referencing the BSD 2-Clause license and summarizing the file

## Testing
- `./tests/run_tests.sh` *(fails: `../build/vush not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b22823160832495bb47bc6b3d3bb1