### PR TITLE
Add descriptions for exported builtins

### DIFF
--- a/src/builtins_getopts.c
+++ b/src/builtins_getopts.c
@@ -138,6 +138,7 @@ static int getopts_next_option(const char *optstr, int silent, int *ind, char *o
     return OPT_OK;
 }
 
+/* Parse shell arguments according to OPTSTRING and store results in VAR. */
 int builtin_getopts(char **args) {
     int ind = read_optind();
     if (!args[1] || !args[2]) {

--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -278,6 +278,7 @@ static int fc_edit_commands(int start, int end, int step, const FcOptions *opts)
     return 1;
 }
 
+/* Replay or edit previous commands from the history list. */
 int builtin_fc(char **args)
 {
     FcOptions opts;

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -184,6 +184,7 @@ static int read_fd_line(int fd, char *buf, size_t size, int nchars,
 }
 
 
+/* Read a line from input and assign words to variables. */
 int builtin_read(char **args) {
     int raw = 0;
     int silent = 0;

--- a/src/builtins_sys.c
+++ b/src/builtins_sys.c
@@ -99,6 +99,7 @@ static int parse_symbolic_umask(const char *str, mode_t *out)
     return 0;
 }
 
+/* Display or set the process file mode creation mask. */
 int builtin_umask(char **args)
 {
     mode_t mask = umask(0);

--- a/src/builtins_time.c
+++ b/src/builtins_time.c
@@ -48,6 +48,7 @@ static int do_time(int posix, int (*func)(void *), void *data)
     return status;
 }
 
+/* Helper for timing an arbitrary function used by the time builtin. */
 int builtin_time_callback(int (*func)(void *), void *data, int posix)
 {
     return do_time(posix, func, data);

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -425,6 +425,7 @@ int builtin_export(char **args) {
     return 1;
 }
 
+/* Mark variables as read-only so they cannot be modified. */
 int builtin_readonly(char **args) {
     int pflag = 0;
     int i = 1;
@@ -466,6 +467,7 @@ int builtin_readonly(char **args) {
 }
 
 
+/* Declare local variables within a function scope. */
 int builtin_local(char **args) {
     if (!args[1])
         return 1;


### PR DESCRIPTION
## Summary
- document builtin function behavior with short comments

## Testing
- `make test` *(fails: expect errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b26c2c2cc832481421f72d127ba66