### PR TITLE
Improve pipeline docs

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -103,6 +103,11 @@ static int exec_funcdef(Command *cmd, const char *line) {
 }
 
 
+/*
+ * Expand CMD and spawn the resulting builtins, functions or external
+ * programs.  LINE is used when reporting jobs and trace output.  The exit
+ * status of the final command is returned.
+ */
 int run_pipeline(Command *cmd, const char *line) {
     if (!cmd)
         return 0;

--- a/src/execute.h
+++ b/src/execute.h
@@ -21,8 +21,8 @@
 
 #include "parser.h"
 
-/* Run the command or control structure CMD using LINE for job messages and
- * return the resulting exit status. */
+/* Expand CMD, spawn its commands and use LINE for job messages.
+ * Returns the resulting exit status. */
 int run_pipeline(Command *cmd, const char *line);
 
 /* Execute the linked list CMDS forwarding LINE for tracing and return the

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -36,7 +36,8 @@
 
 
 /*
- * Configure the child's standard input and output.
+ * Configure the child's standard input and output when spawning a pipeline
+ * segment.
  *
  * If 'in_fd' is valid it becomes the child's stdin.  When the segment has a
  * successor, 'pipefd' is the pipe whose write end should be connected to
@@ -57,11 +58,11 @@ void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]) {
 /*
  * Fork a child process for one pipeline segment.
  *
- * A pipe is created when the segment has a successor.  The child installs
- * the appropriate pipe ends using setup_child_pipes(), applies any I/O
- * redirections and exports temporary assignments before executing the
- * command.  The parent's copy of 'in_fd' is updated with the read end of the
- * pipe so the next segment can consume it.
+ * This spawns the command for SEG.  A pipe is created when the segment has a
+ * successor.  The child installs the appropriate pipe ends using
+ * setup_child_pipes(), applies any I/O redirections and exports temporary
+ * assignments before executing the command.  The parent's copy of 'in_fd' is
+ * updated with the read end of the pipe so the next segment can consume it.
  */
 pid_t fork_segment(PipelineSegment *seg, int *in_fd) {
     if (!seg->argv[0] || seg->argv[0][0] == '\0') {

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -14,10 +14,10 @@
 #include "parser.h"
 #include <sys/types.h>
 
-/* Configure the standard input/output of SEG's child using IN_FD and PIPEFD. */
+/* Prepare SEG's child to read from IN_FD and optionally write to PIPEFD. */
 void setup_child_pipes(PipelineSegment *seg, int in_fd, int pipefd[2]);
 
-/* Fork and execute SEG.  Updates IN_FD with the read end for the next segment. */
+/* Spawn SEG's command and update IN_FD with the read end for the next stage. */
 pid_t fork_segment(PipelineSegment *seg, int *in_fd);
 
 /* Wait for all COUNT processes in PIDS.  If BACKGROUND is non-zero the job


### PR DESCRIPTION
## Summary
- update comments for pipeline helper functions
- explain how run_pipeline spawns commands
- provide clearer pipeline.h comments

## Testing
- `make`
- `make test` *(fails: expect script errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b289a5e808324b757ca4efa531f68