### PR TITLE
Improve job control documentation

### DIFF
--- a/src/builtins_jobs.c
+++ b/src/builtins_jobs.c
@@ -2,17 +2,12 @@
  * vush - a simple UNIX shell
  * Licensed under the BSD 2-Clause Simplified License.
  * Job control builtin commands.
- */
-
-/*
- * Job control builtins
  *
- * This file exposes the shell commands used to manipulate background
- * processes: `jobs`, `fg`, `bg` and `kill`.  These builtins are thin
- * wrappers around the helpers implemented in jobs.c, which maintains
- * the job list and performs the actual process management.  The
- * functions here simply parse command arguments and invoke those
- * helpers so the user can inspect, resume or signal running jobs.
+ * This module implements the shell commands used to manipulate
+ * background processes: `jobs`, `fg`, `bg`, `kill` and `wait`.  The
+ * builtins mainly parse their arguments and delegate the heavy lifting
+ * to the helpers in jobs.c which maintain the job list and perform the
+ * actual process management.
  */
 #define _GNU_SOURCE
 #include "builtins.h"
@@ -76,8 +71,14 @@ int builtin_jobs(char **args) {
     return 1;
 }
 
-/* builtin_fg - usage: fg ID
- * Bring the specified job to the foreground using wait_job and return 1. */
+/*
+ * builtin_fg - usage: fg ID
+ *
+ * Move the given background job to the foreground.  When no ID is
+ * supplied the most recently started job is used.  The shell waits for
+ * the process to finish via wait_job() before returning 1 to keep the
+ * interpreter running.
+ */
 int builtin_fg(char **args) {
     int id;
     if (!args[1]) {
@@ -97,8 +98,14 @@ int builtin_fg(char **args) {
     return 1;
 }
 
-/* builtin_bg - usage: bg ID
- * Resume a stopped job in the background via bg_job and return 1. */
+/*
+ * builtin_bg - usage: bg ID
+ *
+ * Resume a stopped job so it continues running in the background.
+ * If no ID is provided the last job is assumed.  After calling
+ * bg_job() the function briefly polls for completion so short-lived
+ * tasks still print a notification before control returns.
+ */
 int builtin_bg(char **args) {
     int id;
     if (!args[1]) {

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -2,21 +2,12 @@
  * vush - a simple UNIX shell
  * Licensed under the BSD 2-Clause Simplified License.
  * Job control helpers and process list.
- */
-
-/*
- * vush - a simple UNIX shell
- * Licensed under the BSD 2-Clause Simplified License.
  *
- * Job control helpers
- * -------------------
- *
- * Background processes started by the shell are stored in a simple
- * singly linked list.  Each list entry keeps the job's process ID,
- * a unique job number and the command line that was executed.  This
- * allows builtins such as `jobs`, `fg`, `bg` and `kill` to keep track
- * of active tasks and to notify the user when a background job
- * completes.
+ * Background processes launched with '&' are tracked in a simple
+ * singly linked list.  Each entry records the child PID, a unique job
+ * number, the command line and the current state.  Builtins such as
+ * `jobs`, `fg`, `bg` and `kill` operate on this list to manage running
+ * tasks and to notify the user when they complete.
  */
 #define _GNU_SOURCE
 #include "jobs.h"
@@ -190,6 +181,11 @@ int check_jobs_internal(int prefix) {
     return printed;
 }
 
+/*
+ * Reap finished background jobs and print a completion notice.
+ * The prefix is chosen based on whether the shell is at the prompt
+ * so messages appear on a new line if necessary.
+ */
 int check_jobs(void) {
     int prefix = jobs_at_prompt ? 2 : 1;
     return check_jobs_internal(prefix);

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -4,6 +4,13 @@
  * Background job tracking.
  */
 
+/*
+ * Jobs are stored in a singly linked list.  Each node keeps the
+ * process ID, an incremental job number and the command that was run.
+ * The helpers declared here manipulate this list so builtins like
+ * `jobs`, `fg` and `bg` can inspect and control active processes.
+ */
+
 #ifndef JOBS_H
 #define JOBS_H
 


### PR DESCRIPTION
## Summary
- clarify job tracking approach in `jobs.c` and `jobs.h`
- add header block in `builtins_jobs.c`
- document `check_jobs`, `builtin_fg` and `builtin_bg` functions

## Testing
- `make test` *(fails: "expect" errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b2b8ca8832485321e7ec91e42ec