### PR TITLE
Add comments to editing and history search

### DIFF
--- a/src/completion.c
+++ b/src/completion.c
@@ -256,6 +256,12 @@ static void apply_completion(const char *match, char *buf, int *lenp, int *posp,
     }
 }
 
+/*
+ * Attempt to complete the word preceding the cursor.  Builtin commands and
+ * executable names found on $PATH are scanned for matches.  When a single
+ * completion exists it is inserted directly, otherwise all candidates are
+ * printed and the line is redrawn.
+ */
 void handle_completion(const char *prompt, char *buf, int *lenp, int *posp,
                        int *disp_lenp) {
     int start = *posp;

--- a/src/history_search.c
+++ b/src/history_search.c
@@ -31,6 +31,9 @@ static int redraw_search(const char *label, const char *search,
     return len;
 }
 
+/* Begin an incremental reverse search triggered by Ctrl-R.  The line buffer
+ * is updated as the user types and the search may be accepted or cancelled.
+ * Returns 1 when a match is accepted, 0 if cancelled, and -1 on error. */
 int reverse_search(const char *prompt, char *buf, int *lenp, int *posp,
                    int *disp_lenp) {
     char search[MAX_LINE];
@@ -95,6 +98,8 @@ int reverse_search(const char *prompt, char *buf, int *lenp, int *posp,
     }
 }
 
+/* Begin an incremental forward search triggered by Ctrl-S.  Behaviour and
+ * return codes mirror reverse_search above. */
 int forward_search(const char *prompt, char *buf, int *lenp, int *posp,
                    int *disp_lenp) {
     char search[MAX_LINE];
@@ -159,6 +164,12 @@ int forward_search(const char *prompt, char *buf, int *lenp, int *posp,
     }
 }
 
+/*
+ * Dispatch an incremental history search based on the received control
+ * character.  Ctrl-R triggers a reverse search while Ctrl-S performs a
+ * forward search.  The return value matches that of the invoked search
+ * routine or 0 when no search is started.
+ */
 int handle_history_search(char c, const char *prompt, char *buf,
                           int *lenp, int *posp, int *disp_lenp) {
     if (c == 0x12)

--- a/src/lineedit.c
+++ b/src/lineedit.c
@@ -321,6 +321,10 @@ static char *read_simple_line(const char *prompt) {
 }
 
 /* Read a line using the editor and return it as a new string. */
+/*
+ * Display PROMPT and read a line using the active editing mode.
+ * The returned string must be freed by the caller.
+ */
 char *line_edit(const char *prompt) {
     if (lineedit_mode == LINEEDIT_VI)
         return read_simple_line(prompt);


### PR DESCRIPTION
## Summary
- add short function comments for `line_edit`
- document history search helpers
- explain completion handler behavior

## Testing
- `make test` *(fails: `Cannot fork` and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b32ae608324b9a659aa2af7b193