### PR TITLE
Add documentation for startup and REPL functions

### DIFF
--- a/src/repl.c
+++ b/src/repl.c
@@ -26,6 +26,11 @@
 #include "vars.h"
 
 
+/*
+ * Main read-eval-print loop driving interactive and script execution.
+ * When INPUT is stdin the shell behaves interactively, otherwise it
+ * reads and executes commands from the given stream until EOF.
+ */
 void repl_loop(FILE *input)
 {
     char linebuf[MAX_LINE];

--- a/src/repl.h
+++ b/src/repl.h
@@ -7,5 +7,11 @@
 #ifndef REPL_H
 #define REPL_H
 #include <stdio.h>
+
+/*
+ * Start the shell's read-eval-print loop using INPUT as the source of
+ * commands.  When INPUT is stdin the shell runs interactively.
+ */
 void repl_loop(FILE *input);
+
 #endif /* REPL_H */

--- a/src/startup.h
+++ b/src/startup.h
@@ -7,7 +7,20 @@
 #ifndef STARTUP_H
 #define STARTUP_H
 #include <stdio.h>
+
+/*
+ * Source RC file located at PATH using INPUT for parse context.
+ * Returns non-zero if any commands were executed.
+ */
 int process_rc_file(const char *path, FILE *input);
+
+/*
+ * Locate and source the default startup file (~/.vushrc) if present.
+ */
 int process_startup_file(FILE *input);
+
+/*
+ * Execute CMD provided via the -c command line option.
+ */
 void run_command_string(const char *cmd);
 #endif /* STARTUP_H */


### PR DESCRIPTION
## Summary
- document the REPL loop implementation
- comment startup processing prototypes

## Testing
- `make test` *(fails: `make: *** [Makefile:55: test] Interrupt`)*

------
https://chatgpt.com/codex/tasks/task_e_685b396fb4288324895a5595d0af94cc