### PR TITLE
Fix fc mkstemp cleanup

### DIFF
--- a/src/builtins_history.c
+++ b/src/builtins_history.c
@@ -246,6 +246,8 @@ static int fc_edit_commands(int start, int end, int step, const FcOptions *opts)
     int fd = mkstemp(template);
     if (fd < 0) {
         perror("mkstemp");
+        free(template);
+        last_status = 1;
         return 1;
     }
     FILE *f = fdopen(fd, "w+");


### PR DESCRIPTION
## Summary
- free temporary file template if `mkstemp()` fails
- set `last_status` on `mkstemp()` failure

## Testing
- `make -j$(nproc)`
- `make test` *(fails: `mktempd.sh: 4: Cannot fork`)*

------
https://chatgpt.com/codex/tasks/task_e_6862d0e298b483249c2d3134186d148a