### PR TITLE
Fix export status on failed setenv

### DIFF
--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -406,8 +406,10 @@ int builtin_export(char **args) {
                 *eq = '=';
                 continue;
             }
-            if (setenv(arg, valdup, 1) != 0)
+            if (setenv(arg, valdup, 1) != 0) {
                 perror("export");
+                status = 1;
+            }
             set_shell_var(arg, valdup);
             free(valdup);
             *eq = '=';
@@ -417,8 +419,10 @@ int builtin_export(char **args) {
                 val = "";
                 set_shell_var(arg, val);
             }
-            if (setenv(arg, val, 1) != 0)
+            if (setenv(arg, val, 1) != 0) {
                 perror("export");
+                status = 1;
+            }
         }
     }
     last_status = status;


### PR DESCRIPTION
## Summary
- ensure `setenv` failure propagates into export status

## Testing
- `make -j$(nproc)`
- `make test` *(fails: `test_alias_invalid.expect`, `test_export_quote.expect`, `test_export_n_unexport.expect`, `test_export_memfail.expect`)*

------
https://chatgpt.com/codex/tasks/task_e_686575d0e0a883249bc60160de81f874