### PR TITLE
Add FD_SETSIZE check to read

### DIFF
--- a/docs/vush.1
+++ b/docs/vush.1
@@ -104,7 +104,7 @@ Set or display aliases. With no arguments all aliases are listed. A single NAME 
 Remove aliases. With \-a all aliases are cleared.
 .TP
 .B "read [-r] VAR..."
-Read a line of input into variables using the first character of \$IFS to split fields.
+Read a line of input into variables using the first character of \$IFS to split fields. When a timeout is specified with \-t, the descriptor given to \-u must be less than FD_SETSIZE.
 .TP
 .B "return [status]"
 Return from a shell function with an optional status.

--- a/docs/vushdoc.md
+++ b/docs/vushdoc.md
@@ -353,7 +353,8 @@ hi
   read a line from input. `-a` stores fields in array `NAME`, `-p` displays a
   prompt, `-n` reads up to `nchars` characters, `-s` disables echo, `-t` sets a
   timeout in seconds, and `-u` reads from the specified file descriptor. The
-  input is split using the first character of `$IFS`.
+  input is split using the first character of `$IFS`. The command fails if
+  `fd` is greater than or equal to `FD_SETSIZE`.
 - `return [status]` - return from a shell function with an optional status.
 - `shift [N]` - drop the first `N` positional parameters (default 1).
 - `break [N]` - exit `N` levels of loops (default 1).

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -132,6 +132,12 @@ static int read_fd_line(int fd, char *buf, size_t size, int nchars,
     size_t pos = 0;
     while (pos < size - 1) {
         if (timeout >= 0) {
+            if (fd >= FD_SETSIZE) {
+                if (use_tty)
+                    tcsetattr(fd, TCSANOW, &orig);
+                errno = EINVAL;
+                return -1;
+            }
             fd_set set;
             FD_ZERO(&set);
             FD_SET(fd, &set);

--- a/tests/run_builtins_tests.sh
+++ b/tests/run_builtins_tests.sh
@@ -82,6 +82,7 @@ test_read_n.expect
 test_read_s.expect
 test_read_t.expect
 test_read_u.expect
+test_read_fdsize.expect
 test_case.expect
 test_case_posix.expect
 test_trap.expect

--- a/tests/test_read_fdsize.expect
+++ b/tests/test_read_fdsize.expect
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+set timeout 5
+spawn [file dirname [info script]]/../build/vush -c {read -t 1 -u 2048 var; echo $?}
+expect {
+    -re "1\r?\n" {}
+    timeout { send_user "fdsize check failed\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "eof timeout\n"; exit 1 }
+}


### PR DESCRIPTION
## Summary
- check that file descriptor is within `FD_SETSIZE` in `read_fd_line`
- document this restriction in `vushdoc.md` and the man page
- test the failure case

## Testing
- `make -j$(nproc)`
- `make test` *(fails: "expect: spawn id exp4 not open" during tests)*

------
https://chatgpt.com/codex/tasks/task_e_686577de07808324bb020ce74469b931