### PR TITLE
Set last_status when cd path has too many components

### DIFF
--- a/src/builtins_fs.c
+++ b/src/builtins_fs.c
@@ -49,6 +49,7 @@ static void canonicalize_logical(const char *path, char *out, size_t out_size)
             if ((size_t)sp >= max_parts) {
                 fprintf(stderr,
                         "cd: path has too many components\n");
+                last_status = 1;
                 break;
             }
             parts[sp++] = t;


### PR DESCRIPTION
## Summary
- allow callers to detect canonicalize_logical failure

## Testing
- `make test` *(fails: `expect: spawn id exp4 not open`)*

------
https://chatgpt.com/codex/tasks/task_e_6865a2a11b348324abcb270a097ecc59