### PR TITLE
Add cleanup helpers and apply to parsing routines

### DIFF
--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -13,16 +13,17 @@
 #include "vars.h"
 #include "util.h"
 #include "strarray.h"
+#include "cleanup.h"
 #include "shell_state.h"
 #include "var_expand.h"
 
 char **parse_array_values(const char *val, int *count) {
     *count = 0;
-    char *body = strndup(val + 1, strlen(val) - 2);
+    CLEANUP_FREE char *body = strndup(val + 1, strlen(val) - 2);
     if (!body)
         return NULL;
 
-    StrArray arr;
+    CLEANUP_STRARRAY StrArray arr;
     strarray_init(&arr);
     char *p = body;
     while (*p) {
@@ -39,15 +40,12 @@ char **parse_array_values(const char *val, int *count) {
         char *dup = strdup(start);
         if (!dup || strarray_push(&arr, dup) == -1) {
             free(dup);
-            free(body);
             *count = arr.count;
             if (*count > 0)
                 last_status = 1;
-            strarray_release(&arr);
             return NULL;
         }
     }
-    free(body);
 
     int arr_count = arr.count;
     char **vals = strarray_finish(&arr);

--- a/src/builtins_read.c
+++ b/src/builtins_read.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include "shell_state.h"
 #include "strarray.h"
+#include "cleanup.h"
 #include <unistd.h>
 #include <errno.h>
 #include <termios.h>
@@ -66,7 +67,7 @@ static int parse_read_options(char **args, int *raw, const char **array_name,
 }
 
 static char **split_array_values(char *line, int *count, char sep) {
-    StrArray arr;
+    CLEANUP_STRARRAY StrArray arr;
     strarray_init(&arr);
     *count = 0;
     char *p = line;
@@ -83,7 +84,6 @@ static char **split_array_values(char *line, int *count, char sep) {
         char *dup = strdup(start);
         if (!dup || strarray_push(&arr, dup) == -1) {
             free(dup);
-            strarray_release(&arr);
             *count = 0;
             return NULL;
         }

--- a/src/cleanup.h
+++ b/src/cleanup.h
@@ -1,0 +1,18 @@
+#ifndef VUSH_CLEANUP_H
+#define VUSH_CLEANUP_H
+
+#include <stdlib.h>
+#include "strarray.h"
+
+static inline void cleanup_freep(void *p) {
+    free(*(void **)p);
+}
+
+static inline void cleanup_strarrayp(void *p) {
+    strarray_release((StrArray *)p);
+}
+
+#define CLEANUP_FREE __attribute__((cleanup(cleanup_freep)))
+#define CLEANUP_STRARRAY __attribute__((cleanup(cleanup_strarrayp)))
+
+#endif /* VUSH_CLEANUP_H */

--- a/src/field_split.c
+++ b/src/field_split.c
@@ -8,6 +8,7 @@
 #include "var_expand.h"
 #include "vars.h"
 #include "strarray.h"
+#include "cleanup.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -46,12 +47,12 @@ char **split_fields(const char *text, int *count_out) {
             other_tab[c] = 1;
     }
 
-    char *dup = strdup(text);
+    CLEANUP_FREE char *dup = strdup(text);
     if (!dup)
         return NULL;
     char *p = dup;
     char *field_start = dup;
-    StrArray arr;
+    CLEANUP_STRARRAY StrArray arr;
     strarray_init(&arr);
     int last_nonspace = 0;
 
@@ -110,9 +111,7 @@ char **split_fields(const char *text, int *count_out) {
     return res;
 
 fail:
-    free(dup);
 fail_alloc:
-    strarray_release(&arr);
     if (count_out)
         *count_out = 0;
     return NULL;


### PR DESCRIPTION
## Summary
- add `cleanup.h` providing `CLEANUP_FREE` and `CLEANUP_STRARRAY`
- use the cleanup helpers in parsing code
- simplify memory cleanup paths

## Testing
- `make -j$(nproc)`
- `make test` *(fails: spawn id exp4 not open)*

------
https://chatgpt.com/codex/tasks/task_e_686d25458754832498daaf42b640b8de