### PR TITLE
Add env helpers for variable management

### DIFF
--- a/src/assignment_utils.c
+++ b/src/assignment_utils.c
@@ -179,14 +179,19 @@ void restore_assignments(PipelineSegment *pipeline, struct assign_backup *backs)
     for (int i = 0; i < pipeline->assign_count; i++) {
         if (!backs[i].name)
             continue;
-        if (backs[i].had_env)
-            setenv(backs[i].name, backs[i].env, 1);
-        else
-            unsetenv(backs[i].name);
-        if (backs[i].had_var)
-            set_shell_var(backs[i].name, backs[i].var);
-        else
-            unset_shell_var(backs[i].name);
+        if (backs[i].had_env && backs[i].had_var && backs[i].env && backs[i].var &&
+            strcmp(backs[i].env, backs[i].var) == 0) {
+            export_var(backs[i].name, backs[i].env);
+        } else {
+            if (backs[i].had_env)
+                setenv(backs[i].name, backs[i].env, 1);
+            else
+                unsetenv(backs[i].name);
+            if (backs[i].had_var)
+                set_shell_var(backs[i].name, backs[i].var);
+            else
+                unset_shell_var(backs[i].name);
+        }
         free(backs[i].name);
         free(backs[i].env);
         free(backs[i].var);

--- a/src/builtins_vars.c
+++ b/src/builtins_vars.c
@@ -338,8 +338,7 @@ int builtin_unset(char **args) {
                 *lb = '[';
             }
         } else {
-            unsetenv(name);
-            unset_shell_var(name);
+            unset_var(name);
         }
     }
     return 1;
@@ -384,7 +383,7 @@ int builtin_export(char **args) {
     }
 
     if (strcmp(args[1], "-n") == 0 && args[2] && !args[3]) {
-        unsetenv(args[2]);
+        unset_var(args[2]);
         return 1;
     }
 
@@ -393,19 +392,10 @@ int builtin_export(char **args) {
         char *eq = strchr(arg, '=');
         if (eq) {
             *eq = '\0';
-            char *valdup = strdup(eq + 1);
-            if (!valdup) {
-                perror("export");
-                status = 1;
-                *eq = '=';
-                continue;
-            }
-            if (setenv(arg, valdup, 1) != 0) {
+            if (export_var(arg, eq + 1) < 0) {
                 perror("export");
                 status = 1;
             }
-            set_shell_var(arg, valdup);
-            free(valdup);
             *eq = '=';
         } else {
             const char *val = get_shell_var(arg);
@@ -413,7 +403,7 @@ int builtin_export(char **args) {
                 val = "";
                 set_shell_var(arg, val);
             }
-            if (setenv(arg, val, 1) != 0) {
+            if (export_var(arg, val) < 0) {
                 perror("export");
                 status = 1;
             }

--- a/src/vars.c
+++ b/src/vars.c
@@ -415,3 +415,16 @@ void free_shell_vars(void) {
     readonly_vars = NULL;
 }
 
+int export_var(const char *name, const char *val) {
+    set_shell_var(name, val);
+    const char *v = get_shell_var(name);
+    if (setenv(name, v ? v : "", 1) != 0)
+        return -1;
+    return 0;
+}
+
+void unset_var(const char *name) {
+    unsetenv(name);
+    unset_shell_var(name);
+}
+

--- a/src/vars.h
+++ b/src/vars.h
@@ -29,5 +29,7 @@ void record_local_var(const char *name);
 void print_array(const char *prefix, char **arr, int len);
 void print_readonly_vars(void);
 void print_shell_vars(void);
+int export_var(const char *name, const char *val);
+void unset_var(const char *name);
 
 #endif /* VARS_H */


### PR DESCRIPTION
## Summary
- add `export_var` and `unset_var` helpers
- use helpers in `builtin_export` and `builtin_unset`
- adjust assignment restore logic to use `export_var`

## Testing
- `make`
- `make test` *(fails: `send: spawn id exp4 not open` and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d2b3d16808324ae26753b181398c1