### PR TITLE
Use snprintf for tilde expansion

### DIFF
--- a/src/param_expand.c
+++ b/src/param_expand.c
@@ -111,15 +111,17 @@ static char *expand_tilde(const char *token) {
     }
     if (!home) home = getenv("HOME");
     if (!home) home = "";
-    char *ret = malloc(strlen(home) + strlen(rest) + 1);
+    size_t home_len = strlen(home);
+    size_t rest_len = strlen(rest);
+    size_t retlen = home_len + rest_len + 1;
+    char *ret = malloc(retlen);
     if (!ret) {
         perror("malloc");
         last_status = 1;
         free(home_alloc);
         return NULL;
     }
-    strcpy(ret, home);
-    strcat(ret, rest);
+    snprintf(ret, retlen, "%s%s", home, rest);
     free(home_alloc);
     return ret;
 }


### PR DESCRIPTION
## Summary
- prevent overflow in tilde expansion by sizing the buffer and using `snprintf`

## Testing
- `make test` *(fails: free(): double free detected in tcache 2)*

------
https://chatgpt.com/codex/tasks/task_e_68aad1c5d13883249c695c96f8415451