### PR TITLE
Use memcpy for quoting single quotes safely

### DIFF
--- a/src/param_expand.c
+++ b/src/param_expand.c
@@ -197,21 +197,38 @@ static char *quote_value(const char *val) {
     if (!val)
         val = "";
     size_t len = strlen(val);
-    char *res = malloc(len * 4 + 3);
+    size_t alloc = len * 4 + 3;
+    char *res = malloc(alloc);
     if (!res)
         return NULL;
+
     char *p = res;
+    size_t remaining = alloc;
+
     *p++ = '\'';
+    remaining--;
+
     for (const char *s = val; *s; s++) {
         if (*s == '\'') {
-            strcpy(p, "'\\''");
+            if (remaining < 6)
+                break;
+            memcpy(p, "'\\''", 4);
             p += 4;
+            remaining -= 4;
         } else {
+            if (remaining < 3)
+                break;
             *p++ = *s;
+            remaining--;
         }
     }
-    *p++ = '\'';
-    *p = '\0';
+
+    if (remaining >= 2) {
+        *p++ = '\'';
+        *p = '\0';
+    } else if (alloc > 0) {
+        res[alloc - 1] = '\0';
+    }
     return res;
 }
 


### PR DESCRIPTION
## Summary
- replace strcpy with memcpy in `quote_value`
- check and guard remaining buffer space when emitting `'\''` sequences

## Testing
- `make`
- `make test` *(fails: free(): double free detected in tcache 2)*

------
https://chatgpt.com/codex/tasks/task_e_68aad2a4cf408324ab1efba3486dbc93