### PR TITLE
Handle quoting with explicit length

### DIFF
--- a/src/lexer_expand.c
+++ b/src/lexer_expand.c
@@ -198,14 +198,14 @@ char *expand_var(const char *token) {
         char *res = expand_var(inner);
         if (!res)
             return NULL;
-        char *quoted = malloc(strlen(res) + 3);
+        size_t rlen = strlen(res);
+        char *quoted = malloc(rlen + 3);
         if (!quoted) {
             free(res);
             return NULL;
         }
         quoted[0] = '"';
-        strcpy(quoted + 1, res);
-        size_t rlen = strlen(res);
+        memcpy(quoted + 1, res, rlen + 1);
         quoted[rlen + 1] = '"';
         quoted[rlen + 2] = '\0';
         free(res);


### PR DESCRIPTION
## Summary
- Allocate quoted expansion using computed length
- Copy string including null terminator with `memcpy`

## Testing
- `make test` *(fails: spawn id exp4 not open / double free detected)*

------
https://chatgpt.com/codex/tasks/task_e_68ac054d81548324a3e874a7787382e8